### PR TITLE
x64 SLE Micro instruction tweaks

### DIFF
--- a/docs/quickstart/slemicro-virt-install-x86_64.md
+++ b/docs/quickstart/slemicro-virt-install-x86_64.md
@@ -32,23 +32,10 @@ Basically we will use the following documents as reference to create the image c
 
 If you are trying to download to a remote server, you can use scp to copy that file to the server.
 
-<details>
-  <summary>Click here for instructions to get the raw file to remote server</summary>
-  
-**NOTES:** 
- - Be sure **NOT** to unzip the file before transfering it to your server  
- - Make sure to replace the paths as necessary
-  
-### Transfering file to server:
-```
- scp -rp ~/PATH-TO-FILE/SLE-Micro.x86_64-5.4.0-Default-GM.raw.xz user@ip:~/PATH-TO-STORE-IN
-```
-</details>
-
 - Access to <https://scc.suse.com/> to generate a registration code
 - Butane, qemu-img and cdrtools installed (using zypper for example)
  ```bash
-  sudo zypper install butane qemu-tools xz
+  sudo zypper install butane qemu-tools xz mkisofs
  ```
 - Unzip the file
 
@@ -142,8 +129,7 @@ Combustion as explained before:
   parameter)
 
   ```
-  mkisofs -full-iso9660-filenames -o ignition-and-combustion.iso -V
-  ignition ${TMPDIR}
+  mkisofs -full-iso9660-filenames -o ignition-and-combustion.iso -V ignition ${TMPDIR}
   ```
 
 - **Optional:** Remove the temporary folder

--- a/docs/quickstart/slemicro-virt-install-x86_64.md
+++ b/docs/quickstart/slemicro-virt-install-x86_64.md
@@ -157,7 +157,7 @@ Combustion as explained before:
 virt-install --name MyVM --memory 4096 --vcpus 4 --disk ./slemicro --import --cdrom ./ignition-and-combustion.iso --network default --osinfo detect=on,name=sle-unknown
 ```
 **NOTES:** 
- - Pass the -noautoconsole flag in case your console hangs on the installation, this will allow you to run other commands without CTRL-C interrupt
+ - Pass the `-noautoconsole` flag in case your console hangs on the installation, this will allow you to run other commands without CTRL-C interrupt
  - Pass the `--debug` flag if you run into issues
  - If you run into an issue and you need to restart, or if you get an error saying that MyVM is already running, run this command:
 

--- a/docs/quickstart/slemicro-virt-install-x86_64.md
+++ b/docs/quickstart/slemicro-virt-install-x86_64.md
@@ -157,7 +157,7 @@ Combustion as explained before:
 virt-install --name MyVM --memory 4096 --vcpus 4 --disk ./slemicro --import --cdrom ./ignition-and-combustion.iso --network default --osinfo detect=on,name=sle-unknown
 ```
 **NOTES:** 
- - Pass the -noautoconsole flag in case your console hangs on the installation, this will allow you to run other commands without CTRL-C intterupt
+ - Pass the -noautoconsole flag in case your console hangs on the installation, this will allow you to run other commands without CTRL-C interrupt
  - Pass the --debug flag if you run into issues
  - If you run into an issue and you need to restart, or if you get an error saying that MyVM is already running, run this command:
 

--- a/docs/quickstart/slemicro-virt-install-x86_64.md
+++ b/docs/quickstart/slemicro-virt-install-x86_64.md
@@ -35,8 +35,8 @@ Basically we will use the following documents as reference to create the image c
 <details>
   <summary>Click here for instructions to get the raw file to remote server</summary>
   
-**Note:** Be sure **NOT** to unzip the file before transfering it to your server  
- - After downloading, run this command to get your raw file to the server
+**NOTES:** 
+ - Be sure **NOT** to unzip the file before transfering it to your server  
  - Make sure to replace the paths as necessary
   
 ### Transfering file to server:
@@ -50,11 +50,16 @@ Basically we will use the following documents as reference to create the image c
  ```bash
   sudo zypper install butane qemu-tools xz
  ```
+- Unzip the file
+
+```bash
+  xz -d SLE-Micro.x86_64-5.4.0-Default-GM.raw.xz 
+```
 
 - Resize the image file. In this example, to 30G
 
 ```bash
- qemu-img resize -f raw ~/PATH-TO-FILE/SLE-Micro.x86_64-5.4.0-Default-GM.raw30G > /dev/null
+ qemu-img resize -f raw ~/PATH-TO-FILE/SLE-Micro.x86_64-5.4.0-Default-GM.raw 30G > /dev/null
 ```
  
 ## Convert the raw image to qcow2

--- a/docs/quickstart/slemicro-virt-install-x86_64.md
+++ b/docs/quickstart/slemicro-virt-install-x86_64.md
@@ -30,7 +30,7 @@ Basically we will use the following documents as reference to create the image c
  
 **NOTE:** You need to have a valid user on the SUSE site to be able to download the file.
 
-**If you are trying to download to a remote server, open this section for instructions:**
+If you are trying to download to a remote server, you can use scp to copy that file to the server.
 
 <details>
   <summary>Click here for instructions to get the raw file to remote server</summary>
@@ -158,7 +158,7 @@ virt-install --name MyVM --memory 4096 --vcpus 4 --disk ./slemicro --import --cd
 ```
 **NOTES:** 
  - Pass the -noautoconsole flag in case your console hangs on the installation, this will allow you to run other commands without CTRL-C interrupt
- - Pass the --debug flag if you run into issues
+ - Pass the `--debug` flag if you run into issues
  - If you run into an issue and you need to restart, or if you get an error saying that MyVM is already running, run this command:
 
 ```


### PR DESCRIPTION
To make the process for installing SLE Micro on linux (specifically openSUSE) a bit smoother, I added to the guide and also added parts from the ARM64 section so that you don't have to go back and forth between the pages during the installation.