### PR TITLE
quickstart: add registration code info

### DIFF
--- a/docs/quickstart/slemicro-utm-aarch64.md
+++ b/docs/quickstart/slemicro-utm-aarch64.md
@@ -171,6 +171,7 @@ In this scenario, Ignition runs before Combustion.
   download the file.
 
 - Access to <https://scc.suse.com/> to generate a registration code
+  - Search for `SUSE Linux Enterprise Micro` via the `Products` menu, select the arch/version then copy and manually activate the registration code
 
 - Butane, qemu and cdrtools installed (using brew for example)
   ```

--- a/docs/quickstart/slemicro-virt-install-x86_64.md
+++ b/docs/quickstart/slemicro-virt-install-x86_64.md
@@ -33,6 +33,8 @@ Basically we will use the following documents as reference to create the image c
 If you are trying to download to a remote server, you can use scp to copy that file to the server.
 
 - Access to <https://scc.suse.com/> to generate a registration code
+    - Search for `SUSE Linux Enterprise Micro` via the `Products` menu, select the arch/version then copy and manually activate the registration code
+
 - Butane, qemu-img and cdrtools installed (using zypper for example)
  
  ```bash


### PR DESCRIPTION
As a new user of scc.suse.com it's not entirely clear where to find the registration code initially, so add a hint here that it's found via searching for the product name then activating.