### PR TITLE
blog: 2023-07-28-flexran: Avoid wording of next

### DIFF
--- a/blog/2023-07-28-flexran.md
+++ b/blog/2023-07-28-flexran.md
@@ -233,12 +233,12 @@ uname -r
 
 >If you want to download the SLE Micro RT 5.4 ISO, you can use the following link paying special attention to the `-RT` in the image name, once you've logged in with your SUSE credentials: [Download SLE Micro RT from Suse Customer Center](https://www.suse.com/download/sle-micro/)
 
-> For more information about how to install the operating system SLE Micro RT, see the next [link](https://suse-edge.github.io/docs/product/atip/management-cluster#os-install)
+> For more information about how to install the operating system SLE Micro RT, see the following [link](https://suse-edge.github.io/docs/product/atip/management-cluster#os-install)
 
 
 ### OS Configuration and Tuning
 
-Once you have the Operating System installed, you can proceed with the Operating System configuration. For this article, we will configure the Operating System using the next steps:
+Once you have the Operating System installed, you can proceed with the Operating System configuration. For this article, we will configure the Operating System using the following steps:
 
 1. CPU Tuned Configuration
 
@@ -277,7 +277,7 @@ The following options have to be customized:
 | hugepages | 40    | Number of hugepages defined before                                                                   |
 | default_hugepagesz| 1G | Default value to enable huge pages                                                                   |
 
-> For mor information about theses parameters, please refer to the next [link](https://suse-edge.github.io/docs/product/atip/features)
+> For mor information about theses parameters, please refer to the following [link](https://suse-edge.github.io/docs/product/atip/features)
 
 With the values showed above, we are isolating 60 cores, and we are using 4 cores for the OS.
 
@@ -756,7 +756,7 @@ To deploy workloads with SR-IOV VF, Auxiliary network devices or PCI PF, this pl
 
 1. Prepare the config map for the device plugin:
 
-You could get the information to fill the config map from the `lspci` command. In our case we will have the next 3 types of devices:
+You could get the information to fill the config map from the `lspci` command. In our case we will have the following 3 types of devices:
 - FEC acceleartor card VF: `0d5d`. 
 This is the first VF created on the ACC100 card and should match with the first VF created on the previous section.
 
@@ -940,7 +940,7 @@ Basically, FlexRan will request some resources available in the host to be used 
 
 ### References
 
-For this article, we will use the next references to deploy the Intel FlexRan reference implementation on top of the ATIP edge cluster:
+For this article, we will use the following references to deploy the Intel FlexRan reference implementation on top of the ATIP edge cluster:
 
 - We will use the pre-defined containers from Intel: [FlexRan pre-defined containers](https://hub.docker.com/r/intel/flexran_vdu)
 - You will also need to download the FlexRan-22.07 tarball from Intel to run the tests and mount the downloaded `tests` folder into the pre-defined containers because it's not included into the pre-defined containers. 
@@ -990,7 +990,7 @@ The modifications done in this file will be:
 
 - `export INTEL_COM_INTEL_CPULIST=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)` to get the CPU list of the host machine.
 
-Also, we need to change the CPU cores as well as the MAC addresses into the RU section because there isn't any substitution in the entrypoint script. We need to change the next lines:
+Also, we need to change the CPU cores as well as the MAC addresses into the RU section because there isn't any substitution in the entrypoint script. We need to change the following lines:
 
 ```shell
     sed -i "s/ioCore=2/ioCore=62/g" config_file_o_ru.dat
@@ -1035,7 +1035,7 @@ The test case is a setup for one peak cell and two average cells. 8 cores with H
 
 ![img.png](2023-07-29-flexran-images/timer3.png)
 
-To deploy the Test Timer Mode, we will use the next yaml file:
+To deploy the Test Timer Mode, we will use the following yaml file:
 
 ```yaml
 cat <<EOF | kubectl apply -f - 
@@ -1132,7 +1132,7 @@ spec:
 EOF
 ```
 
-The next resources are required:
+The following resources are required:
 
 - `intel.com/intel_fec_5g: '1'` to request the FEC ACC100 resource.
 - `hugepages-1Gi: 16Gi` to request the hugepages resource for the first container.
@@ -1170,7 +1170,7 @@ Using `htop` we could see the CPU usage of the containers as well as the pinned 
 ![img_1.png](2023-07-29-flexran-images/clitimer.png)
 
 Using the Rancher UI, you can check the status of the pods and the logs of the containers.
-Also, you could get the next metrics using prometheus and grafana to check the CPU usage , CPU cores isolated used, and the Memory usage of the containers:
+Also, you could get the following metrics using prometheus and grafana to check the CPU usage, CPU cores isolated used, and the Memory usage of the containers:
 
 ![img_6.png](2023-07-29-flexran-images/graftimer.png)
 
@@ -1184,7 +1184,7 @@ The test case is a setup for six average cells with O-RAN lower layer split opti
 
 ![img.png](2023-07-29-flexran-images/xran1.png)
 
-To deploy the XRAN Mode, we will use the next yaml file:
+To deploy the XRAN Mode, we will use the following yaml file:
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -1326,7 +1326,7 @@ spec:
 EOF  
 ```
 
-The next resources are required:
+The following resources are required:
 
 - `intel.com/intel_fec_5g: '1'` to request the FEC ACC100 resource.
 - `intel.com/intel_sriov_odu: '4'` to request the 4 VFs for the ODU interface.
@@ -1335,7 +1335,7 @@ The next resources are required:
 - `hugepages-1Gi: 16Gi` to request the hugepages resource for the second container.
 - `/home/tmp_flexran/tests` folder mounted to `/home/flexran/tests` in order to have the tests available for the containers.
 
-Once the pods are deployed, you need to launch the tests manually. You can do that using the next commands:
+Once the pods are deployed, you need to launch the tests manually. You can do that using the following commands:
 
 1. Open a terminal in the `flexran-vdu` pod and run the following commands:
 
@@ -1370,7 +1370,7 @@ Using `htop` we could see the CPU usage of the containers as well as the pinned 
 ![img_2.png](2023-07-29-flexran-images/xran2.png)
 
 Using the Rancher UI, you can check the status of the pods and the logs of the containers.
-Also, you could get the next metrics using prometheus and grafana to check the CPU usage , CPU cores isolated used, and the Memory usage of the containers:
+Also, you could get the following metrics using prometheus and grafana to check the CPU usage, CPU cores isolated used, and the Memory usage of the containers:
 
 ![img_3.png](2023-07-29-flexran-images/xran3.png)
 


### PR DESCRIPTION
Refer to "following" link/requirements/references/etc. in the text.
Otherwise it needs to be clear next after what.