### PR TITLE
Reinstate deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+# https://github.com/peaceiris/actions-gh-pages/issues/852
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run the docs build in a container
+        uses: addnab/docker-run-action@v3
+        with:
+            image: registry.opensuse.org/home/atgracey/cnbp/containers/builder:latest
+            options: -v ${{ github.workspace }}:/docs
+            run: |
+                cd /docs/asciidoc
+                daps -d DC-edge html
+
+      # Popular action to deploy to GitHub Pages:
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./asciidoc/build/edge/html/edge
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,29 @@
+name: Test deployment
+
+# https://github.com/peaceiris/actions-gh-pages/issues/852
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+
+jobs:
+  test-deploy:
+    name: Test deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run the docs build in a container
+        uses: addnab/docker-run-action@v3
+        with:
+            image: registry.opensuse.org/home/atgracey/cnbp/containers/builder:latest
+            options: -v ${{ github.workspace }}:/docs
+            run: |
+                cd /docs/asciidoc
+                daps -d DC-edge html


### PR DESCRIPTION
These were removed in #109 so revert that here and adjust to build the asciidoc format

Based on the steps described in #132 