### PR TITLE
ATIP management cluster fix hostname script issue

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -271,7 +271,7 @@ until [ -f /etc/rancher/rke2/rke2.yaml ]; do sleep 2; done
 # export the kubeconfig using the right kubeconfig path depending on the cluster (k3s or rke2)
 export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
 # Wait for the node to be available, meaning the K8s API is available
-while ! ${KUBECTL} wait --for condition=ready node $(cat /etc/hostname | tr '[:upper:]' '[:lower:]') ; do sleep 2 ; done
+while ! ${KUBECTL} wait --for condition=ready node $(hostname | tr '[:upper:]' '[:lower:]') ; do sleep 2 ; done
 
 ## Add Helm repos
 helm repo add rancher-prime https://charts.rancher.com/server-charts/prime


### PR DESCRIPTION
/etc/hostname is only populated when the hostname is statically configured, if the hostname is provided via DHCP this won't work so we can use `hostname` instead