### PR TITLE
Fix missing images in elemental quickstart

### DIFF
--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -241,7 +241,7 @@ REGISURL=$(kubectl get machineregistration ele-quickstart-nodes -n fleet-default
 ----
 
 Alternatively, this can also be done from the UI.
-+
+
 UI Extension::
 +
 . From the OS Management Extension, click "Create Registration Endpoint":
@@ -256,7 +256,6 @@ image::create-registration-name.png[Add Name]
 ====
 You can ignore the Cloud Configuration field as the data here is overridden by the following steps with Edge Image Builder
 ====
-+
 . Next you can scroll down a bit and click "Add Label" for each label you want to be on the resource that gets created when a machine registers. This is useful for tracking which machine is which.
 +
 image::create-registration-labels.png[Add Labels]


### PR DESCRIPTION
A few images are not included on the generated webpages due to issuse with list markers.
This commit fixes the issue by correcting list markers.