### PR TITLE
Elemental quickstart fix broken link

### DIFF
--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -289,7 +289,7 @@ While the current version of Elemental (at time of writing) does have a way to b
 
 [TIP]
 ====
-For more details on the Edge Image Builder, you can check out the <<quickstart-eib,Getting Started Guide for it>>. Or, for a more full discussion on it's capabilities there is a [full page documenting it].
+For more details on the Edge Image Builder, you can check out the <<quickstart-eib,Getting Started Guide for it>> and also the <<components-eib,Component Documentation>>.
 ====
 
 From a linux system with Podman installed, run


### PR DESCRIPTION
I think this is meant to link to the component documentation?