### PR TITLE
Pin the link to EIB upstream to the 1.0 release

### DIFF
--- a/asciidoc/components/edge-image-builder.adoc
+++ b/asciidoc/components/edge-image-builder.adoc
@@ -40,7 +40,7 @@ SUSE Edge uses EIB for the simplified and quick configuration of customized SLE 
 
 === Getting started
 
-Comprehensive documentation for the usage and testing of Edge Image Builder can be found https://github.com/suse-edge/edge-image-builder/blob/main/docs[here].
+Comprehensive documentation for the usage and testing of Edge Image Builder can be found https://github.com/suse-edge/edge-image-builder/tree/release-1.0/docs[here].
 
 Additionally, here is a <<quickstart-eib,quick-start guide>> for Edge Image Builder covering a basic deployment scenario.
 


### PR DESCRIPTION
Our release docs should point into a release branch so that when main changes, users aren't shown things that don't exist in the 1.0 release.