### PR TITLE
ATIP docs align direct network provisioning naming

### DIFF
--- a/asciidoc/product/atip-architecture.adoc
+++ b/asciidoc/product/atip-architecture.adoc
@@ -45,9 +45,10 @@ There are two different blocks, the management stack and the runtime stack:
 === Example deployment flows
 
 The following are high-level examples of workflows to understand the relationship between the management and the runtime components.
-`ZTP` (Zero Touch Provisioning) is the workflow that enables the deployment of a new downstream cluster with all the components preconfigured and ready to run workloads with no manual intervention.
 
-* Example 1: Deploying a new management cluster with all components installed
+Direct network provisioning is the workflow that enables the deployment of a new downstream cluster with all the components preconfigured and ready to run workloads with no manual intervention.
+
+==== Example 1: Deploying a new management cluster with all components installed
 
 Using the <<components-eib,Edge Image Builder>> to create a new `ISO` image with the management stack included. You can then use this `ISO` image to install a new management cluster on VMs or bare metal.
 
@@ -58,9 +59,9 @@ NOTE: For more information about how to deploy a new management cluster, see the
 NOTE: For more information about how to use the Edge Image Builder, see the <<quickstart-eib,Edge Image Builder guide>>.
 
 
-* Example 2: Deploying a single-node downstream cluster with Telco profiles to enable it to run Telco workloads
+==== Example 2: Deploying a single-node downstream cluster with Telco profiles to enable it to run Telco workloads
 
-Once we have the management cluster up and running, we can use it to deploy a single-node downstream cluster with all Telco capabilities enabled and configured using the `ZTP` workflow.
+Once we have the management cluster up and running, we can use it to deploy a single-node downstream cluster with all Telco capabilities enabled and configured using the direct network provisioning workflow.
 
 The following diagram shows the high-level workflow to deploy it:
 
@@ -70,9 +71,9 @@ NOTE: For more information about how to deploy a downstream cluster, see the <<a
 
 NOTE: For more information about Telco features, see the <<atip-features,ATIP Telco Features guide.>>
 
-* Example 3: Deploying a high availability downstream cluster using MetalLB as a Load Balancer
+==== Example 3: Deploying a high availability downstream cluster using MetalLB as a Load Balancer
 
-Once we have the management cluster up and running, we can use it to deploy a high availability downstream cluster with `MetalLB` as a load balancer using the `ZTP` workflow.
+Once we have the management cluster up and running, we can use it to deploy a high availability downstream cluster with `MetalLB` as a load balancer using the direct network provisioning workflow.
 
 The following diagram shows the high-level workflow to deploy it:
 

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1,5 +1,5 @@
 [#atip-automated-provisioning]
-== Automated provisioning with ZTP
+== Automated provisioning with Direct network provisioning
 
 ifdef::env-github[]
 :imagesdir: ../images/
@@ -12,8 +12,9 @@ endif::[]
 
 === Introduction
 
-The downstream cluster provisioning with `ZTP` (Zero Touch Provisioning) is a feature that allows you to automate the provisioning of downstream clusters. This feature is useful when you have many downstream clusters to provision, and you want to automate the process.
-From a technical point of view, the management cluster contains the following components:
+Direct network provisioning is a feature that allows you to automate the provisioning of downstream clusters. This feature is useful when you have many downstream clusters to provision, and you want to automate the process.
+
+The management cluster contains the following components:
 
 * `SUSE Linux Enterprise Micro RT` as the OS. Depending on the use case, configurations like networking, storage, users and kernel arguments can be customized.
 * `RKE2` as the Kubernetes cluster. The default `CNI` plug-in is `Cilium`. Depending on the use case, certain `CNI` plug-ins can be used, such as `Cilium+Multus`.
@@ -36,22 +37,22 @@ For more information about `NeuVector`, see <<components-neuvector>>
 
 ====
 
-The `ZTP` workflow allows to automate the provisioning of the downstream clusters. The following sections describe the different `ZTP` workflows and some additional features that can be added to the provisioning process:
+The following sections describe the different direct network provisioning workflows and some additional features that can be added to the provisioning process:
 
-* xref:ztp-eib-edge-image[]
+* xref:eib-edge-image[]
 
-* xref:ztp-single-node[]
+* xref:single-node[]
 
-* xref:ztp-multi-node[]
+* xref:multi-node[]
 
-* xref:ztp-add-advanced-network[]
+* xref:advanced-network-configuration[]
 
-* xref:ztp-add-telco[]
+* xref:add-telco[]
 
-* xref:ztp-private-registry[]
+* xref:atip-private-registry[]
 
 
-[#ztp-eib-edge-image]
+[#eib-edge-image]
 === Generating the downstream image using EIB
 
 Using `Edge Image Builder` to create the image to be used in the downstream clusters, a lot of configurations can be customized. But in this guide, we cover the minimal configurations necessary to set up the downstream cluster.
@@ -118,7 +119,7 @@ openssl passwd -6 PASSWORD
 
 For the production environment, the recommendation is to use the SSH keys that can be added to the users block replacing the `$\{USERKEY1\}` with the real SSH keys.
 
-[#ztp-add-telco-feature-eib]
+[#add-telco-feature-eib]
 * If you need to configure Telco features like `dpdk`, `sr-iov` or `FEC`, the following file includes the packages required to enable these features:
 
 [,yaml]
@@ -157,13 +158,13 @@ operatingSystem:
 Where `$\{SCC_REGISTRATION_CODE\}` is the registration code for the SUSE Customer Center, and the package list contains the minimum packages to be used for the Telco profiles.
 To use the `pf-bb-config` package (to enable the `FEC` feature and binding with drivers), the `additionalRepos` block must be included to add the `SUSE Edge Telco` repository.
 
-[#ztp-add-advanced-network-eib]
+[#advanced-network-configuration-eib]
 
-[#ztp-add-network-eib]
+[#add-network-eib]
 * If you need to configure the networking for a DHCP-less or more networking advanced scenarios, the following folder and file should be included with the networking configuration.
 
 In the `network` folder, the `configure-network.sh` file contains the networking configuration for the downstream cluster.
-The following script tries to statically configure a NIC when the bare-metal object has been created with a secret containing the static network configuration covered in the xref:ztp-add-advanced-network[Additional Features with ZTP - DHCP-less] section.
+The following script tries to statically configure a NIC when the bare-metal object has been created with a secret containing the static network configuration covered in the xref:advanced-network-configuration[advanced network configuration] section.
 Also, it uses the networking information to generate the network configuration for the downstream cluster using the `nmc` https://github.com/suse-edge/nm-configurator[tool].
 
 [,shell]
@@ -201,7 +202,7 @@ umount /mnt
 ./nmc apply --config-dir /tmp/nmc/generated
 ----
 
-[#ztp-add-custom-script-growfs]
+[#add-custom-script-growfs]
 * There is a custom script (`custom/scripts/growfs.sh`) which is required to grow the file system to the disk size once it is installed during the process. The `growfs.sh` script contains the following information:
 
 [,shell]
@@ -244,25 +245,24 @@ podman run --rm --privileged -it -v $PWD:/eib \
 This creates the output ISO image file named `eibimage-slemicro55rt-telco.raw`, based on the definition described above.
 
 
+[#single-node]
+=== Downstream cluster provisioning with Direct network provisioning (single-node)
 
-[#ztp-single-node]
-=== Downstream cluster provisioning with ZTP (single-node)
-
-This section describes the workflow used to automate the provisioning of a single-node downstream cluster using `ZTP`.
+This section describes the workflow used to automate the provisioning of a single-node downstream cluster using direct network provisioning.
 This is the simplest way to automate the provisioning of a downstream cluster.
 
 *Requirements*
 
-- The image generated using `EIB`, as described in the xref:ztp-eib-edge-image[previous section], with the minimal configuration to set up the downstream cluster has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
+- The image generated using `EIB`, as described in the xref:eib-edge-image[previous section], with the minimal configuration to set up the downstream cluster has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
 - The management server created and available to be used on the following sections. For more information, refer to the Management Cluster section <<atip-management-cluster>>.
 
 *Workflow*
 
-The following diagram shows the workflow used to automate the provisioning of a single-node downstream cluster using `ZTP`:
+The following diagram shows the workflow used to automate the provisioning of a single-node downstream cluster using direct network provisioning:
 
 image::atip-automated-singlenode1.png[]
 
-There are two different steps to automate the provisioning of a single-node downstream cluster using `ZTP`:
+There are two different steps to automate the provisioning of a single-node downstream cluster using direct network provisioning:
 
 1. Enroll the bare-metal host to make it available for the provisioning process.
 2. Provision the bare-metal host to install and configure the operating system and the Kubernetes cluster.
@@ -325,7 +325,7 @@ $ kubectl get bmh
 The `BaremetalHost` object is in the `registering` state until the `BMC` credentials are validated. Once the credentials are validated, the `BaremetalHost` object changes its state to `inspecting`, and this step could take some time depending on the hardware (up to 20 minutes). During the inspecting phase, the hardware information is retrieved and the Kubernetes object is updated. Check the information using the following command: `kubectl get bmh -o yaml`.
 ====
 
-[#ztp-single-node-provision]
+[#single-node-provision]
 *Provision step*
 
 Once the bare-metal host is enrolled and available, the next step is to provision the bare-metal host to install and configure the operating system and the Kubernetes cluster.
@@ -435,7 +435,7 @@ The `Metal3MachineTemplate` object specifies the following information:
 
 - The `dataTemplate` to be used as a reference to the template.
 - The `hostSelector` to be used matching with the label created during the enrollment process.
-- The `image` to be used as a reference to the image generated using `EIB` on the previous xref:ztp-eib-edge-image[section], and the `checksum` and `checksumType` to be used to validate the image.
+- The `image` to be used as a reference to the image generated using `EIB` on the previous xref:eib-edge-image[section], and the `checksum` and `checksumType` to be used to validate the image.
 
 [,yaml]
 ----
@@ -488,22 +488,22 @@ $ kubectl apply -f capi-provisioning-example.yaml
 ----
 
 
-[#ztp-multi-node]
-=== Downstream cluster provisioning with ZTP (multi-node)
+[#multi-node]
+=== Downstream cluster provisioning with Direct network provisioning (multi-node)
 
-This section describes the workflow used to automate the provisioning of a multi-node downstream cluster using `ZTP` and `MetalLB` as a load-balancer strategy.
-This is the simplest way to automate the provisioning of a downstream cluster. The following diagram shows the workflow used to automate the provisioning of a multi-node downstream cluster using `ZTP` and `MetalLB`.
+This section describes the workflow used to automate the provisioning of a multi-node downstream cluster using direct network provisioning and `MetalLB` as a load-balancer strategy.
+This is the simplest way to automate the provisioning of a downstream cluster. The following diagram shows the workflow used to automate the provisioning of a multi-node downstream cluster using direct network provisioning and `MetalLB`.
 
 
 
 *Requirements*
 
-- The image generated using `EIB`, as described in the xref:ztp-eib-edge-image[previous section], with the minimal configuration to set up the downstream cluster has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
+- The image generated using `EIB`, as described in the xref:eib-edge-image[previous section], with the minimal configuration to set up the downstream cluster has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
 - The management server created and available to be used on the following sections. For more information, refer to the Management Cluster section: <<atip-management-cluster>>.
 
 *Workflow*
 
-The following diagram shows the workflow used to automate the provisioning of a multi-node downstream cluster using `ZTP`:
+The following diagram shows the workflow used to automate the provisioning of a multi-node downstream cluster using direct network provisioning:
 
 image::atip-automate-multinode1.png[]
 
@@ -779,7 +779,7 @@ The `Metal3MachineTemplate` object specifies the following information:
 
 - The `dataTemplate` to be used as a reference to the template.
 - The `hostSelector` to be used matching with the label created during the enrollment process.
-- The `image` to be used as a reference to the image generated using `EIB` on the previous xref:ztp-eib-edge-image[section], and `checksum` and `checksumType` to be used to validate the image.
+- The `image` to be used as a reference to the image generated using `EIB` on the previous xref:eib-edge-image[section], and `checksum` and `checksumType` to be used to validate the image.
 
 [,yaml]
 ----
@@ -832,23 +832,23 @@ $ kubectl apply -f capi-provisioning-example.yaml
 ----
 
 
-[#ztp-add-advanced-network]
-=== Additional features with ZTP — advanced network configuration
+[#advanced-network-configuration]
+=== Advanced network configuration
 
-The `ZTP` workflow allows to automate the provisioning of the downstream clusters using advanced network configurations like DHCP-less, bond+vlans. The following sections describe the differences that can be used to automate the provisioning of the downstream clusters using advanced network configuration.
+The direct network provisioning workflow allows to automate the provisioning of the downstream clusters using advanced network configurations like DHCP-less, bond+vlans. The following sections describe the differences that can be used to automate the provisioning of the downstream clusters using advanced network configuration.
 
 *Requirements*
 
-- The image generated using `EIB` has to include the network folder and the script following xref:ztp-add-network-eib[this section].
-- The image generated using `EIB`, as described in the xref:ztp-eib-edge-image[previous section], has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
+- The image generated using `EIB` has to include the network folder and the script following xref:add-network-eib[this section].
+- The image generated using `EIB`, as described in the xref:eib-edge-image[previous section], has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
 - The management server created and available to be used on the following sections. For more information, refer to the Management Cluster section: <<atip-management-cluster>>.
 
 *Configuration*
 
 Use the following two sections as the base to enroll and provision the hosts:
 
-* xref:ztp-single-node[Downstream cluster provisioning with ZTP (single-node)]
-* xref:ztp-multi-node[Downstream cluster provisioning with ZTP (multi-node)]
+* xref:single-node[Downstream cluster provisioning with Direct network provisioning (single-node)]
+* xref:multi-node[Downstream cluster provisioning with Direct network provisioning (multi-node)]
 
 The changes required to enable the advanced network configuration are the following:
 
@@ -965,23 +965,23 @@ spec:
 The `Metal3DataTemplate`, `networkData` and `Metal3 IPAM` are currently not supported; only the configuration via static secrets is fully supported.
 ====
 
-[#ztp-add-telco]
-=== Additional features with ZTP — Telco features (DPDK, SR-IOV, CPU isolation, huge pages, NUMA, etc.)
+[#add-telco]
+===  Telco features (DPDK, SR-IOV, CPU isolation, huge pages, NUMA, etc.)
 
-The `ZTP` workflow allows to automate the Telco features to be used in the downstream clusters to run Telco workloads on top of those servers.
+The direct network provisioning workflow allows to automate the Telco features to be used in the downstream clusters to run Telco workloads on top of those servers.
 
 *Requirements*
 
-- The image generated using `EIB` has to include the specific Telco packages following xref:ztp-add-telco-feature-eib[this section].
-- The image generated using `EIB`, as described in the xref:ztp-eib-edge-image[previous section],  has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
+- The image generated using `EIB` has to include the specific Telco packages following xref:add-telco-feature-eib[this section].
+- The image generated using `EIB`, as described in the xref:eib-edge-image[previous section],  has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
 - The management server created and available to be used on the following sections. For more information, refer to the Management Cluster section: <<atip-management-cluster>>.
 
 *Configuration*
 
 Use the following two sections as the base to enroll and provision the hosts:
 
-* xref:ztp-single-node[Downstream cluster provisioning with ZTP (single-node)]
-* xref:ztp-multi-node[Downstream cluster provisioning with ZTP (multi-node)]
+* xref:single-node[Downstream cluster provisioning with Direct network provisioning (single-node)]
+* xref:multi-node[Downstream cluster provisioning with Direct network provisioning (multi-node)]
 
 The Telco features covered in this section are the following:
 
@@ -996,7 +996,7 @@ The Telco features covered in this section are the following:
 For more information about the Telco features, see <<atip-features>>.
 ====
 
-The changes required to enable the Telco features shown above are all inside the `RKE2ControlPlane` block in the provision file `capi-provisioning-example.yaml`. The rest of the information inside the file `capi-provisioning-example.yaml` is the same as the information provided in the xref:ztp-single-node-provision[provisioning section].
+The changes required to enable the Telco features shown above are all inside the `RKE2ControlPlane` block in the provision file `capi-provisioning-example.yaml`. The rest of the information inside the file `capi-provisioning-example.yaml` is the same as the information provided in the xref:single-node-provision[provisioning section].
 
 To make the process clear, the changes required on that block (`RKE2ControlPlane`) to enable the Telco features are the following:
 
@@ -1250,12 +1250,12 @@ Once the file is created by joining the previous blocks, the following command m
 $ kubectl apply -f capi-provisioning-example.yaml
 ----
 
-[#ztp-private-registry]
-=== Additional features with ZTP — private registry
+[#atip-private-registry]
+===  private registry
 
-The `ZTP` workflow allows to automate the provision of the downstream clusters and configure the private registry as a mirror to enable the images to be used by the workloads.
+It is possible to configure a private registry as a mirror for images used by workloads.
 
-The first step to enable the private registry is to create the secret containing the information about the private registry to be used by the downstream cluster.
+To do this we create the secret containing the information about the private registry to be used by the downstream cluster.
 
 [,yaml]
 ----

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 This section documents and explains the configuration of Telco-specific features on ATIP-deployed clusters.
 
-The configuration and the provision based on a `Zero Touch Provisioning` (ZTP) process are described in the <<atip-automated-provisioning,ATIP Automated Provision>> section.
+The direct network provisioning deployment method is used, as described in the <<atip-automated-provisioning,ATIP Automated Provision>> section.
 
 The following topics are covered in this section:
 

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -21,7 +21,7 @@ From a technical point of view, the management cluster contains the following co
 * `Metal^3^` as the component to manage the lifecycle of the bare metal nodes.
 * `CAPI` as the component to manage the lifecycle of the Kubernetes clusters (downstream clusters). With ATIP, also the `RKE2 CAPI Provider` is used to manage the lifecycle of the RKE2 clusters (downstream clusters).
 
-With all components mentioned above, the management cluster can manage the lifecycle of the runtime stacks, using a declarative approach and the `Zero Touch Provisioning` to manage the infrastructure and the applications.
+With all components mentioned above, the management cluster can manage the lifecycle of downstream clusters, using a declarative approach to manage the infrastructure and applications.
 
 [NOTE]
 ====

--- a/asciidoc/product/atip-requirements.adoc
+++ b/asciidoc/product/atip-requirements.adoc
@@ -55,7 +55,7 @@ The network architecture is based on the following components:
 
 [NOTE]
 ====
-To use the `ATIP ZTP workflow`, the `controlplane network` and the `management network` should be connected to provision the ATIP nodes using `metal^3^`. The management cluster will provide the image to be provisioned through the `BMC` so the communication between the management cluster and the `BMC` is required.
+To use the direct network provisioning workflow, the management cluster must have network connectivity to the downstream cluster server Baseboard Management Controller (BMC) so that host preparation and provisioning can be automated.
 ====
 
 === Services (DHCP, DNS, etc.)
@@ -63,8 +63,8 @@ To use the `ATIP ZTP workflow`, the `controlplane network` and the `management n
 Some external services like `DHCP`, `DNS`, etc. could be required depending on the kind of environment where they are deployed:
 
 * **Connected environment**: In this case, the ATIP nodes will be connected to the Internet (via routing L3 protocols) and the external services will be provided by the customer.
-* **Disconnected / air-gap environment**: In this case, the ATIP nodes will not have Internet IP connectivity (via routing L3 protocols) and the configuration for static IPs will be configured during the bootstrap process on the ATIP ZTP workflow.
-* **File server**: A file server is used to store the ISO images to be provisioned on the ATIP nodes during the ZTP workflow. `metal^3^` Helm chart can deploy a media server to store the ISO images — check the following xref:metal3-media-server[section], but it is also possible to use an existing customer file server.
+* **Disconnected / air-gap environment**: In this case, the ATIP nodes will not have Internet IP connectivity and additional services will be required to locally mirror content required by the ATIP direct network provisioning workflow.
+* **File server**: A file server is used to store the ISO images to be provisioned on the ATIP nodes during the direct network provisioning workflow. The `metal^3^` Helm chart can deploy a media server to store the ISO images — check the following xref:metal3-media-server[section], but it is also possible to use an existing local webserver.
 
 === Disabling rebootmgr
 
@@ -104,5 +104,5 @@ rebootmgrctl strategy off
 
 [NOTE]
 ====
-This configuration to set the `rebootmgr` strategy can be automated using the `ATIP ZTP workflow`. For more information, check the <<atip-automated-provisioning,ATIP Automated Provision document>>.
+This configuration to set the `rebootmgr` strategy can be automated using the direct network provisioning workflow. For more information, check the <<atip-automated-provisioning,ATIP Automated Provisioning documentation>>.
 ====


### PR DESCRIPTION
Elsewhere we use the term "direct network provisioning" so align here for consistency and fix a few wording and format issues.