### PR TITLE
rephrased metal3 quick start reference to eib

### DIFF
--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -60,7 +60,7 @@ The basic steps to install a management cluster and use Metal^3^ are:
 . Register BareMetalHost CRs to define the bare-metal inventory
 . Create a downstream cluster by defining CAPI resources
 
-This guide assumes an existing RKE2 cluster and Rancher (including cert-manager) has been installed, for example by following the <<quickstart-eib, Edge Image Builder quick start guide>>.
+This guide assumes an existing RKE2 cluster and Rancher (including cert-manager) has been installed, for example by using <<components-eib, Edge Image Builder>>.
 
 TIP: The steps here can also be fully automated as described in the <<atip-management-cluster, ATIP management cluster documentation>>.
 


### PR DESCRIPTION
The EIB quickstart doesn't talk about Rancher or cert-manager, so to avoid confusion I rephrased it so the user doesn't expect to find that.