### PR TITLE
[release-3.0] 3.0.1 backports for node reset, SBOM, and unified network config

### DIFF
--- a/asciidoc/components/networking.adoc
+++ b/asciidoc/components/networking.adoc
@@ -62,7 +62,7 @@ The EIB container image is publicly available and can be downloaded from the SUS
 
 [,shell]
 ----
-podman pull registry.suse.com/edge/edge-image-builder:1.0.1
+podman pull registry.suse.com/edge/edge-image-builder:1.0.2
 ----
 
 === Creating the image configuration directory [[config_dir_creation]]
@@ -357,7 +357,7 @@ Now that all the necessary configurations are in place, we can build the image b
 
 [,shell]
 ----
-podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/edge-image-builder:1.0.1 build --definition-file definition.yaml
+podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/edge-image-builder:1.0.2 build --definition-file definition.yaml
 ----
 
 The output should be similar to the following:
@@ -700,10 +700,157 @@ NAME              UUID                                  TYPE      DEVICE  FILENA
 Wired Connection  300ed658-08d4-4281-9f8c-d1b8882d29b9  ethernet  eth0    /var/run/NetworkManager/system-connections/default_connection.nmconnection
 ----
 
+=== Unified node configurations
+
+There are occasions where relying on known MAC addresses is not an option. In these cases we can opt for the so-called _unified configuration_
+which allows us to specify settings in an `_all.yaml` file which will then be applied across all provisioned nodes.
+
+We will build and provision an edge node using different configuration structure. Follow all steps starting from <<config_dir_creation>> up until <<default_network_definition>>.
+
+In this example we define a desired state of two Ethernet interfaces (eth0 and eth1) - one using DHCP, and one assigned a static IP address.
+
+[,shell]
+----
+mkdir -p $CONFIG_DIR/network
+
+cat <<- EOF > $CONFIG_DIR/network/_all.yaml
+interfaces:
+- name: eth0
+  type: ethernet
+  state: up
+  ipv4:
+    dhcp: true
+    enabled: true
+  ipv6:
+    enabled: false
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: 10.0.0.1
+      prefix-length: 24
+    enabled: true
+    dhcp: false
+  ipv6:
+    enabled: false
+EOF
+----
+
+Let's build the image:
+
+[,shell]
+----
+podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/edge-image-builder:1.0.2 build --definition-file definition.yaml
+----
+
+Once the image is successfully built, let's create a virtual machine using it:
+
+[,shell]
+----
+virt-install --name node1 --ram 10000 --vcpus 6 --disk path=$CONFIG_DIR/modified-image.raw,format=raw --osinfo detect=on,name=sle-unknown --graphics none --console pty,target_type=serial --network default --network default --virt-type kvm --import
+----
+
+The provisioning process might take a few minutes. Once it's finished, log in to the system with the provided credentials.
+
+Verify that the routing is properly configured:
+
+[,shell]
+----
+localhost:~ # ip r
+default via 192.168.122.1 dev eth0 proto dhcp src 192.168.122.100 metric 100
+10.0.0.0/24 dev eth1 proto kernel scope link src 10.0.0.1 metric 101
+192.168.122.0/24 dev eth0 proto kernel scope link src 192.168.122.100 metric 100
+----
+
+Verify that Internet connection is available:
+
+[,shell]
+----
+localhost:~ # ping google.com
+PING google.com (142.250.72.46) 56(84) bytes of data.
+64 bytes from den16s08-in-f14.1e100.net (142.250.72.46): icmp_seq=1 ttl=56 time=14.3 ms
+64 bytes from den16s08-in-f14.1e100.net (142.250.72.46): icmp_seq=2 ttl=56 time=14.2 ms
+^C
+--- google.com ping statistics ---
+2 packets transmitted, 2 received, 0% packet loss, time 1001ms
+rtt min/avg/max/mdev = 14.196/14.260/14.324/0.064 ms
+----
+
+Verify that the Ethernet interfaces are configured and active:
+
+[,shell]
+----
+localhost:~ # ip a
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+    link/ether 52:54:00:26:44:7a brd ff:ff:ff:ff:ff:ff
+    altname enp1s0
+    inet 192.168.122.100/24 brd 192.168.122.255 scope global dynamic noprefixroute eth0
+       valid_lft 3505sec preferred_lft 3505sec
+3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+    link/ether 52:54:00:ec:57:9e brd ff:ff:ff:ff:ff:ff
+    altname enp7s0
+    inet 10.0.0.1/24 brd 10.0.0.255 scope global noprefixroute eth1
+       valid_lft forever preferred_lft forever
+
+localhost:~ # nmcli -f NAME,UUID,TYPE,DEVICE,FILENAME con show
+NAME  UUID                                  TYPE      DEVICE  FILENAME
+eth0  dfd202f5-562f-5f07-8f2a-a7717756fb70  ethernet  eth0    /etc/NetworkManager/system-connections/eth0.nmconnection
+eth1  0523c0a1-5f5e-5603-bcf2-68155d5d322e  ethernet  eth1    /etc/NetworkManager/system-connections/eth1.nmconnection
+
+localhost:~ # cat /etc/NetworkManager/system-connections/eth0.nmconnection
+[connection]
+autoconnect=true
+autoconnect-slaves=-1
+id=eth0
+interface-name=eth0
+type=802-3-ethernet
+uuid=dfd202f5-562f-5f07-8f2a-a7717756fb70
+
+[ipv4]
+dhcp-client-id=mac
+dhcp-send-hostname=true
+dhcp-timeout=2147483647
+ignore-auto-dns=false
+ignore-auto-routes=false
+method=auto
+never-default=false
+
+[ipv6]
+addr-gen-mode=0
+dhcp-timeout=2147483647
+method=disabled
+
+localhost:~ # cat /etc/NetworkManager/system-connections/eth1.nmconnection
+[connection]
+autoconnect=true
+autoconnect-slaves=-1
+id=eth1
+interface-name=eth1
+type=802-3-ethernet
+uuid=0523c0a1-5f5e-5603-bcf2-68155d5d322e
+
+[ipv4]
+address0=10.0.0.1/24
+dhcp-timeout=2147483647
+method=manual
+
+[ipv6]
+addr-gen-mode=0
+dhcp-timeout=2147483647
+method=disabled
+----
+
 === Custom network configurations
 
 We have already covered the default network configuration for Edge Image Builder which relies on the NetworkManager Configurator.
-However, there is also the option to modify it via a custom script. Whilst this option is very flexible and is not MAC address dependant,
+However, there is also the option to modify it via a custom script. Whilst this option is very flexible and is also not MAC address dependant,
 its limitation stems from the fact that using it is much less convenient when bootstrapping multiple nodes with a single image.
 
 > NOTE: It is recommended to use the default network configuration via files describing the desired network states under the `/network` directory.
@@ -718,9 +865,9 @@ Let's start by storing the connection file in the `/custom/files` directory:
 
 [,shell]
 ----
-mkdir -p custom/files
+mkdir -p $CONFIG_DIR/custom/files
 
-cat << EOF > custom/files/eth0.nmconnection
+cat << EOF > $CONFIG_DIR/custom/files/eth0.nmconnection
 [connection]
 autoconnect=true
 autoconnect-slaves=-1
@@ -746,9 +893,9 @@ Now that the static configuration is created, we will also create our custom net
 
 [,shell]
 ----
-mkdir -p network
+mkdir -p $CONFIG_DIR/network
 
-cat << EOF > network/configure-network.sh
+cat << EOF > $CONFIG_DIR/network/configure-network.sh
 #!/bin/bash
 set -eux
 
@@ -763,7 +910,7 @@ cp eth0.nmconnection /etc/NetworkManager/system-connections/
 chmod 600 /etc/NetworkManager/system-connections/*.nmconnection
 EOF
 
-chmod a+x network/configure-network.sh
+chmod a+x $CONFIG_DIR/network/configure-network.sh
 ----
 
 > NOTE: The nmc binary will still be included by default, so it can also be used in the `configure-network.sh` script if necessary.
@@ -779,6 +926,9 @@ The configuration directory at this point should look like the following:
 [,console]
 ----
 ├── definition.yaml
+├── custom/
+│   └── files/
+│       └── eth0.nmconnection
 ├── network/
 │   └── configure-network.sh
 └── base-images/
@@ -789,7 +939,7 @@ Let's build the image:
 
 [,shell]
 ----
-podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/edge-image-builder:1.0.1 build --definition-file definition.yaml
+podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/edge-image-builder:1.0.2 build --definition-file definition.yaml
 ----
 
 Once the image is successfully built, let's create a virtual machine using it:

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -152,6 +152,13 @@ The following checks were performed on each of these signatures:
   - The signatures were verified against the specified public key
 ----
 
+It is also possible to extract SBOM data as described at https://www.suse.com/support/security/sbom/
+
+[,bash]
+----
+> cosign verify-attestation --type spdxjson --key key.pem registry.suse.com/edge/baremetal-operator@sha256:13e8b2c59aeb503f8adaac095495007071559c9d6d8ef5a7cb1ce6fd1430c782 | jq '.payload | @base64d | fromjson | .predicate'
+----
+
 === Upgrade Steps
 
 * Not Applicable - this is the first release shipped in 3.0.z, and is a new architecture introduced for the first time.

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -437,6 +437,41 @@ elemental-register --label "network=$INET" \
 ----
 ====
 
+== Node Reset
+
+SUSE Rancher Elemental supports the ability to perform a "node reset" which can optionally trigger when either a whole cluster is deleted from Rancher, a single node is deleted from a cluster, or a node is manually deleted from the machine inventory. This is useful when you want to reset and clean-up any orphaned resources and want to automatically bring the cleaned node back into the machine inventory so it can be reused. This is not enabled by default, and thus any system that is removed, will not be cleaned up (i.e. data will not be removed, and any Kubernetes cluster resources will continue to operate on the downstream clusters) and it will require manual intervention to wipe data and re-register the machine to Rancher via Elemental.
+
+If you wish for this functionality to be enabled by default, you need to make sure that your `MachineRegistration` explicitly enables this by adding `config.elemental.reset.enabled: true`, for example:
+
+[,yaml]
+----
+config:
+  elemental:
+    registration:
+      auth: tpm
+    reset:
+      enabled: true
+----
+
+Then, all systems registered with this `MachineRegistration` will automatically receive the `elemental.cattle.io/resettable: 'true'` annotation in their configuration. If you wish to do this manually on individual nodes, e.g. because you've got an existing `MachineInventory` that doesn't have this annotation, or you have already deployed nodes, you can modify the `MachineInventory` and add the `resettable` configuration, for example:
+
+[,yaml]
+----
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventory
+metadata:
+  annotations:
+    elemental.cattle.io/os.unmanaged: 'true'
+    elemental.cattle.io/resettable: 'true'
+----
+
+In SUSE Edge 3.0, the Elemental Operator puts down a marker on the operating system that will trigger the cleanup process automatically; it will stop all Kubernetes services, remove all persistent data, uninstall all Kubernetes services, cleanup any remaining Kubernetes/Rancher directories, and force a re-registration to Rancher via the original Elemental `MachineRegistration` configuration. This happens automaticaly, there is no need for any manual intervention. The script that gets called can be found in `/opt/edge/elemental_node_cleanup.sh` and is triggered via `systemd.path` upon the placement of the marker, so its execution is immediate.
+
+[WARNING]
+====
+Using the `resettable` functionality assumes that the desired behavior when removing a node/cluster from Rancher is to wipe data and force a re-registration. Data loss is guaranteed in this situation, so only use this if you're sure that you want automatic reset to be performed.
+====
+
 == Next steps
 
 Here are some recommended resources to research after using this guide:


### PR DESCRIPTION
Backport of #272, #282, and #283.

* Added documentation for Elemental node reset
* Add unified configuration section for nm-configurator
* Added example of extracting SBOM data

 (cherry picked from commits f300d944643a3ae4d8e171f21db0d7ee39e111dd, e2543622e79720bb383b26d605e712ab7a7bb990, dbe39d9ba6e5da6ffd5be6907351660c94e47463)