### PR TITLE
3.0.2 documentation updates

### DIFF
--- a/asciidoc/components/longhorn.adoc
+++ b/asciidoc/components/longhorn.adoc
@@ -263,7 +263,7 @@ image:
   arch: x86_64
   outputImageName: eib-image.iso
 kubernetes:
-  version: v1.28.9+rke2r1
+  version: v1.28.10+rke2r1
   helm:
     charts:
       - name: longhorn

--- a/asciidoc/components/networking.adoc
+++ b/asciidoc/components/networking.adoc
@@ -700,6 +700,7 @@ NAME              UUID                                  TYPE      DEVICE  FILENA
 Wired Connection  300ed658-08d4-4281-9f8c-d1b8882d29b9  ethernet  eth0    /var/run/NetworkManager/system-connections/default_connection.nmconnection
 ----
 
+[#networking-unified]
 === Unified node configurations
 
 There are occasions where relying on known MAC addresses is not an option. In these cases we can opt for the so-called _unified configuration_

--- a/asciidoc/components/virtualization.adoc
+++ b/asciidoc/components/virtualization.adoc
@@ -66,9 +66,9 @@ This should show something similar to the following:
 [,shell]
 ----
 NAME                   STATUS   ROLES                       AGE     VERSION
-node1.edge.rdo.wales   Ready    control-plane,etcd,master   4h20m   v1.28.9+rke2r1
-node2.edge.rdo.wales   Ready    control-plane,etcd,master   4h15m   v1.28.9+rke2r1
-node3.edge.rdo.wales   Ready    control-plane,etcd,master   4h15m   v1.28.9+rke2r1
+node1.edge.rdo.wales   Ready    control-plane,etcd,master   4h20m   v1.28.10+rke2r1
+node2.edge.rdo.wales   Ready    control-plane,etcd,master   4h15m   v1.28.10+rke2r1
+node3.edge.rdo.wales   Ready    control-plane,etcd,master   4h15m   v1.28.10+rke2r1
 ----
 
 Now you can proceed to install the *KubeVirt* and *Containerized Data Importer (CDI)* Helm charts:

--- a/asciidoc/day2/downstream-cluster-helm.adoc
+++ b/asciidoc/day2/downstream-cluster-helm.adoc
@@ -525,7 +525,7 @@ kubernetes:
   # - hostname: agent2rke2.example.com
   #   type: agent
   # version depending on the distribution
-  version: v1.28.9+k3s1/v1.28.9+rke2r1
+  version: v1.28.10+k3s1/v1.28.10+rke2r1
   helm:
     charts:
     - name: longhorn

--- a/asciidoc/day2/mgmt-cluster.adoc
+++ b/asciidoc/day2/mgmt-cluster.adoc
@@ -228,7 +228,7 @@ This section offer examples on how to upgrade a:
 To ensure disaster recovery, we advise to do a Rancher backup. For information on how to do this, check link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher[here].
 ====
 
-This example shows how to upgrade Rancher to the `2.8.4` version.
+This example shows how to upgrade Rancher to the `2.8.5` version.
 
 . Add the `Rancher Prime` Helm repository:
 +
@@ -241,14 +241,14 @@ helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
 +
 [source,bash]
 ----
-helm pull rancher-prime/rancher --version=2.8.4
+helm pull rancher-prime/rancher --version=2.8.5
 ----
 
 . Encode `.tgz` archive so that it can be passed to a `HelmChart` CR config:
 +
 [source,bash]
 ----
-base64 -w 0 rancher-2.8.4.tgz  > rancher-2.8.4-encoded.txt
+base64 -w 0 rancher-2.8.5.tgz  > rancher-2.8.5-encoded.txt
 ----
 
 . Make a copy of the `rancher.yaml` file that we will edit:
@@ -262,7 +262,7 @@ cp /var/lib/rancher/rke2/server/manifests/rancher.yaml ./rancher.yaml
 +
 [source,bash]
 ----
-sed -i -e "s|chartContent:.*|chartContent: $(<rancher-2.8.4-encoded.txt)|" -e "s|version:.*|version: 2.8.4|" rancher.yaml
+sed -i -e "s|chartContent:.*|chartContent: $(<rancher-2.8.5-encoded.txt)|" -e "s|version:.*|version: 2.8.5|" rancher.yaml
 ----
 +
 [NOTE]
@@ -326,26 +326,26 @@ kubectl get settings.management.cattle.io server-version
 
 # Example output
 NAME             VALUE
-server-version   v2.8.4
+server-version   v2.8.5
 ----
 
 [#day2-mgmt-cluster-eib-helm-chart-upgrade-examples-metal3]
 ===== Metal^3^ upgrade
 
-This example shows how to upgrade Metal^3^ to the `0.7.1` version.
+This example shows how to upgrade Metal^3^ to the `0.7.3` version.
 
 . Pull the latest `Metal^3^` helm chart version:
 +
 [source,bash]
 ----
-helm pull oci://registry.suse.com/edge/metal3-chart --version 0.7.1
+helm pull oci://registry.suse.com/edge/metal3-chart --version 0.7.3
 ----
 
 . Encode `.tgz` archive so that it can be passed to a `HelmChart` CR config:
 +
 [source,bash]
 ----
-base64 -w 0 metal3-chart-0.7.1.tgz  > metal3-chart-0.7.1-encoded.txt
+base64 -w 0 metal3-chart-0.7.3.tgz  > metal3-chart-0.7.3-encoded.txt
 ----
 
 . Make a copy of the `Metal^3^` manifest file that we will edit:
@@ -359,7 +359,7 @@ cp /var/lib/rancher/rke2/server/manifests/metal3.yaml ./metal3.yaml
 +
 [source,bash]
 ----
-sed -i -e "s|chartContent:.*|chartContent: $(<metal3-chart-0.7.1-encoded.txt)|" -e "s|version:.*|version: 0.7.1|" metal3.yaml
+sed -i -e "s|chartContent:.*|chartContent: $(<metal3-chart-0.7.3-encoded.txt)|" -e "s|version:.*|version: 0.7.3|" metal3.yaml
 ----
 +
 [NOTE]
@@ -418,7 +418,7 @@ kubectl get helmchart metal3 -n default
 
 # Example output
 NAME     JOB                   CHART   TARGETNAMESPACE   VERSION   REPO   HELMVERSION   BOOTSTRAP
-metal3   helm-install-metal3           metal3-system     0.7.1                          
+metal3   helm-install-metal3           metal3-system     0.7.3
 ----
 
 [#day2-mgmt-cluster-helm-chart-upgrade]
@@ -467,7 +467,7 @@ This section offer examples on how to upgrade a:
 To ensure disaster recovery, we advise to do a Rancher backup. For information on how to do this, check link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher[here].
 ====
 
-This example shows how to upgrade Rancher to the `2.8.4` version.
+This example shows how to upgrade Rancher to the `2.8.5` version.
 
 . Get the values for the current Rancher release and print them to a `rancher-values.yaml` file:
 +
@@ -483,7 +483,7 @@ helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
 helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   -f rancher-values.yaml \
-  --version=2.8.4
+  --version=2.8.5
 ----
 
 . Verify `Rancher` version upgrade:
@@ -494,7 +494,7 @@ kubectl get settings.management.cattle.io server-version
 
 # Example output
 NAME             VALUE
-server-version   v2.8.4
+server-version   v2.8.5
 ----
 
 _For additional information on the Rancher helm chart upgrade, check link:https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades[here]._
@@ -503,7 +503,7 @@ _For additional information on the Rancher helm chart upgrade, check link:https:
 [#day2-mgmt-cluster-helm-chart-upgrade-examples-metal3]
 ===== Metal^3^
 
-This example shows how to upgrade Metal^3^ to the `0.7.1` version.
+This example shows how to upgrade Metal^3^ to the `0.7.3` version.
 
 . Get the values for the current Rancher release and print them to a `rancher-values.yaml` file:
 +
@@ -519,7 +519,7 @@ helm get values metal3 -n metal3-system -o yaml > metal3-values.yaml
 helm upgrade metal3 oci://registry.suse.com/edge/metal3-chart \
   --namespace metal3-system \
   -f metal3-values.yaml \
-  --version=0.7.1
+  --version=0.7.3
 ----
 
 . Verify `Metal^3^` pods are running:
@@ -542,6 +542,6 @@ metal3-metal3-mariadb-55fd44b648-7fmvk                   1/1     Running   0    
 helm ls -n metal3-system
 
 # Expected output
-NAME  	NAMESPACE    	REVISION	UPDATED                                	STATUS  	CHART       	APP VERSION
-metal3	metal3-system	2       	2024-06-17 12:43:06.774802846 +0000 UTC	deployed	metal3-0.7.1	1.16.0   
+NAME    NAMESPACE      REVISION  UPDATED                                  STATUS    CHART         APP VERSION
+metal3  metal3-system  2         2024-06-17 12:43:06.774802846 +0000 UTC  deployed  metal3-0.7.3  1.16.0
 ----

--- a/asciidoc/day2/mgmt-cluster.adoc
+++ b/asciidoc/day2/mgmt-cluster.adoc
@@ -545,3 +545,21 @@ helm ls -n metal3-system
 NAME    NAMESPACE      REVISION  UPDATED                                  STATUS    CHART         APP VERSION
 metal3  metal3-system  2         2024-06-17 12:43:06.774802846 +0000 UTC  deployed  metal3-0.7.3  1.16.0
 ----
+
+== Cluster API upgrade
+
+The Cluster API (CAPI) controllers on a Metal^3^ management cluster are not currently managed via Helm, this section describes the upgrade process.
+
+[NOTE]
+====
+This section assumes you have installed `clusterctl` and configured on your system as described in the <<quickstart-metal3, Metal^3^ quickstart>>
+====
+
+When upgrading to Edge 3.0.2 from any previous version it will be necessary to upgrade the RKE2 providers:
+
+[,bash]
+----
+clusterctl upgrade apply --bootstrap "rke2:v0.4.1" --control-plane "rke2:v0.4.1"
+----
+
+WARNING: Please ensure the versions selected align with those described in the <<id-release-notes, Release Notes>>, usage of other upstream releases is not supported.

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -68,10 +68,10 @@ registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
 registry.suse.com/rancher/mirrored-neuvector-updater:latest
 | Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-controller:1.6.2 +
 registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
-registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.2.6
+registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.2.6 +
+registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.2.6
 | Metal^3^ | 1.16.0 | 0.6.5 | registry.suse.com/edge/metal3-chart:0.6.5 +
 registry.suse.com/edge/baremetal-operator:0.5.1 +
-registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.2.6 +
 registry.suse.com/edge/ip-address-manager:1.6.0 +
 registry.suse.com/edge/ironic:23.0.1.2 +
 registry.suse.com/edge/ironic-ipa-downloader:1.3.1 +
@@ -166,10 +166,10 @@ registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
 registry.suse.com/rancher/mirrored-neuvector-updater:latest
 | Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-controller:1.6.2 +
 registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
-registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.2.6
+registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.2.6 +
+registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.2.6
 s| Metal^3^ s| 1.16.0 s| 0.7.1 | registry.suse.com/edge/metal3-chart:0.7.1 +
 registry.suse.com/edge/baremetal-operator:0.5.1 +
-registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.2.6 +
 registry.suse.com/edge/ip-address-manager:1.6.0 +
 registry.suse.com/edge/ironic:23.0.2.1 +
 registry.suse.com/edge/ironic-ipa-downloader:1.3.2 +
@@ -213,6 +213,100 @@ registry.suse.com/edge/akri-opcua-discovery-handler:v0.12.20 +
 registry.suse.com/edge/akri-udev-discovery-handler:v0.12.20 +
 registry.suse.com/edge/akri-webhook-configuration:v0.12.20
 s| SR-IOV Network Operator s| 1.2.2 s| 1.2.2+up0.1.0 | registry.suse.com/edge/sriov-network-operator-chart:1.2.2 +
+registry.suse.com/edge/sriov-crd-chart:1.2.2
+|======
+
+= Release 3.0.2
+
+Availability Date: TBC
+
+Summary: SUSE Edge 3.0.2 is the second z-stream release in the SUSE Edge 3.0 portfolio.
+
+== New Features
+
+* The Metal^3^ chart now supports static network configuration without any `mac-address`: https://github.com/suse-edge/charts/pull/134[SUSE Edge issue #134]
+
+== Bug & Security Fixes
+
+* The Metal^3^ chart fixes an issue where host reprovisioning may use stale static static network configuration: https://github.com/suse-edge/charts/pull/133[SUSE Edge issue #133]
+* The RKE2 Cluster API provider fixes an issue when specifying TLS configuration for a local registry: https://github.com/rancher/cluster-api-provider-rke2/pull/357[RKE2 Provider issue #357]
+* The RKE2 Cluster API provider fixes an issue causing rke2-install to error after system reboot: https://github.com/rancher/cluster-api-provider-rke2/pull/346[RKE2 Provider issue #346]
+
+== Components Versions
+
+The following table describes the individual components that make up the 3.0.2 release, including the version, the Helm chart version (if applicable), and from where the released artifact can be pulled in the binary format. Please follow the associated documentation for usage and deployment examples.
+
+|======
+| Name | Version | Helm Chart Version | Artifact Location (URL/Image)
+| SLE Micro | 5.5 (latest) | N/A | https://www.suse.com/download/sle-micro/[SLE Micro Download Page] +
+SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso (sha256 4f672a4a0f8ec421e7c25797def05598037c56b7f306283566a9f921bdce904a) +
+SLE-Micro.x86_64-5.5.0-Default-RT-SelfInstall-GM2.install.iso (sha256 527a5a7cdbf11e3e6238e386533755257676ad8b4c80be3b159d0904cb637678) +
+SLE-Micro.x86_64-5.5.0-Default-GM.raw.xz (sha256 13243a737ca219bad6a7aa41fa747c06e8b825fef10a756cf4d575f4493ed68b) +
+SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw.xz (sha256 6c2af94e7ac785c8f6a276032c8e6a4b493c294e6cd72809c75089522f01bc93)
+| SUSE Manager | 4.3.11 | N/A | https://www.suse.com/download/suse-manager/[SUSE Manager Download Page]
+s| K3s s| 1.28.10 | N/A | https://github.com/k3s-io/k3s/releases/tag/v1.28.10%2Bk3s1[Upstream K3s Release]
+s| RKE2 s| 1.28.10 | N/A | https://github.com/rancher/rke2/releases/tag/v1.28.10%2Brke2r1[Upstream RKE2 Release]
+s| Rancher Prime s| 2.8.5 s| 2.8.5 | https://github.com/rancher/rancher/releases/download/v2.8.5/rancher-images.txt[Rancher 2.8.5 Images] +
+ https://charts.rancher.com/server-charts/prime[Rancher Prime Helm Repo]
+| Longhorn | 1.6.1 | 103.3.0 | https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn-images.txt[Longhorn 1.6.1 Images] +
+https://charts.longhorn.io[Longhorn Helm Repo]
+| NM Configurator | 0.3.0 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.0[NMConfigurator Upstream Release]
+| NeuVector| 5.3.0 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.0 +
+registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.0 +
+registry.suse.com/rancher/mirrored-neuvector-manager:5.3.0 +
+registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.0 +
+registry.suse.com/rancher mirrored-neuvector-registry-adapter:0.1.1-s1 +
+registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
+registry.suse.com/rancher/mirrored-neuvector-updater:latest
+s| Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-controller:1.6.2 +
+registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
+*registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.4.1* +
+*registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.4.1*
+s| Metal^3^ s| 1.16.0 s| 0.7.3 | registry.suse.com/edge/metal3-chart:0.7.3 +
+registry.suse.com/edge/baremetal-operator:0.5.1 +
+registry.suse.com/edge/ip-address-manager:1.6.0 +
+registry.suse.com/edge/ironic:23.0.2.1 +
+*registry.suse.com/edge/ironic-ipa-downloader:1.3.4* +
+registry.suse.com/edge/kube-rbac-proxy:v0.14.2 +.1
+registry.suse.com/edge/mariadb:10.6.15.1
+| MetalLB | 0.14.3 | 0.14.3 | registry.suse.com/edge/metallb-chart:0.14.3 +
+registry.suse.com/edge/metallb-controller:v0.14.3 +
+registry.suse.com/edge/metallb-speaker:v0.14.3 +
+registry.suse.com/edge/frr:8.4 +
+registry.suse.com/edge/frr-k8s:v0.0.8
+| Elemental | 1.4.4 | 103.1.0 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
+registry.suse.com/rancher/elemental-operator-crds-chart:1.4.4 +
+registry.suse.com/rancher/elemental-operator:1.4.4
+| Edge Image Builder | 1.0.2 | N/A | registry.suse.com/edge/edge-image-builder:1.0.2
+| KubeVirt | 1.1.1 | 0.2.4 | registry.suse.com/edge/kubevirt-chart:0.2.4 +
+registry.suse.com/suse/sles/15.5/virt-operator:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-api:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-controller:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-exportproxy:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-exportserver:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-handler:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-launcher:1.1.1
+| KubeVirt Dashboard Extension | 1.0.0 | 1.0.0 | registry.suse.com/edge/kubevirt-dashboard-extension-chart:1.0.0
+| Containerized Data Importer | 1.58.0 | 0.2.3 | registry.suse.com/edge/cdi-chart:0.2.3 +
+registry.suse.com/suse/sles/15.5/cdi-operator:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-controller:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-importer:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-cloner:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-apiserver:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadserver:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadproxy:1.58.0
+| Endpoint Copier Operator | 0.2.0 | 0.2.0 | registry.suse.com/edge/endpoint-copier-operator:v0.2.0 +
+registry.suse.com/edge/endpoint-copier-operator-chart:0.2.0
+| Akri (Tech Preview) | 0.12.20 | 0.12.20 | registry.suse.com/edge/akri-chart:0.12.20 +
+registry.suse.com/edge/akri-dashboard-extension-chart:1.0.0 +
+registry.suse.com/edge/akri-agent:v0.12.20 +
+registry.suse.com/edge/akri-controller:v0.12.20 +
+registry.suse.com/edge/akri-debug-echo-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-onvif-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-opcua-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-udev-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-webhook-configuration:v0.12.20
+| SR-IOV Network Operator | 1.2.2 | 1.2.2+up0.1.0 | registry.suse.com/edge/sriov-network-operator-chart:1.2.2 +
 registry.suse.com/edge/sriov-crd-chart:1.2.2
 |======
 

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -225,6 +225,7 @@ Summary: SUSE Edge 3.0.2 is the second z-stream release in the SUSE Edge 3.0 por
 == New Features
 
 * The Metal^3^ chart now supports static network configuration without any `mac-address`: https://github.com/suse-edge/charts/pull/134[SUSE Edge issue #134]
+* Kubevirt is updated from `1.1.1` to `1.2.2` for details of new features refer to the: https://github.com/kubevirt/kubevirt/releases[Upstream Release Notes]
 
 == Bug & Security Fixes
 

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -82,7 +82,7 @@ registry.suse.com/edge/metallb-controller:v0.14.3 +
 registry.suse.com/edge/metallb-speaker:v0.14.3 +
 registry.suse.com/edge/frr:8.4 +
 registry.suse.com/edge/frr-k8s:v0.0.8
-| Elemental | 1.4.3 | 103.1.0 | registry.suse.com/rancher/elemental-operator-chart:1.4.3 +
+| Elemental | 1.4.3 | 1.4.3 | registry.suse.com/rancher/elemental-operator-chart:1.4.3 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.4.3 +
 registry.suse.com/rancher/elemental-operator:1.4.3
 | Edge Image Builder | 1.0.1 | N/A | registry.suse.com/edge/edge-image-builder:1.0.1
@@ -180,7 +180,7 @@ registry.suse.com/edge/metallb-controller:v0.14.3 +
 registry.suse.com/edge/metallb-speaker:v0.14.3 +
 registry.suse.com/edge/frr:8.4 +
 registry.suse.com/edge/frr-k8s:v0.0.8
-s| Elemental s| 1.4.4 s| 103.1.0 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
+s| Elemental s| 1.4.4 s| 1.4.4 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.4.4 +
 registry.suse.com/rancher/elemental-operator:1.4.4
 s| Edge Image Builder s| 1.0.2 | N/A | registry.suse.com/edge/edge-image-builder:1.0.2
@@ -218,7 +218,7 @@ registry.suse.com/edge/sriov-crd-chart:1.2.2
 
 = Release 3.0.2
 
-Availability Date: TBC
+Availability Date: 16th August 2024
 
 Summary: SUSE Edge 3.0.2 is the second z-stream release in the SUSE Edge 3.0 portfolio.
 
@@ -231,6 +231,7 @@ Summary: SUSE Edge 3.0.2 is the second z-stream release in the SUSE Edge 3.0 por
 * The Metal^3^ chart fixes an issue where host reprovisioning may use stale static static network configuration: https://github.com/suse-edge/charts/pull/133[SUSE Edge issue #133]
 * The RKE2 Cluster API provider fixes an issue when specifying TLS configuration for a local registry: https://github.com/rancher/cluster-api-provider-rke2/pull/357[RKE2 Provider issue #357]
 * The RKE2 Cluster API provider fixes an issue causing rke2-install to error after system reboot: https://github.com/rancher/cluster-api-provider-rke2/pull/346[RKE2 Provider issue #346]
+* Kubevirt is updated to include several security fixes: https://www.suse.com/support/update/announcement/2024/suse-su-20242669-1[Kubevirt Update]
 
 == Components Versions
 
@@ -274,27 +275,27 @@ registry.suse.com/edge/metallb-controller:v0.14.3 +
 registry.suse.com/edge/metallb-speaker:v0.14.3 +
 registry.suse.com/edge/frr:8.4 +
 registry.suse.com/edge/frr-k8s:v0.0.8
-| Elemental | 1.4.4 | 103.1.0 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
+| Elemental | 1.4.4 | 1.4.4 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.4.4 +
 registry.suse.com/rancher/elemental-operator:1.4.4
 | Edge Image Builder | 1.0.2 | N/A | registry.suse.com/edge/edge-image-builder:1.0.2
-| KubeVirt | 1.1.1 | 0.2.4 | registry.suse.com/edge/kubevirt-chart:0.2.4 +
-registry.suse.com/suse/sles/15.5/virt-operator:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-api:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-controller:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-exportproxy:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-exportserver:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-handler:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-launcher:1.1.1
+s| KubeVirt s| 1.2.2 s| 0.3.0 s| registry.suse.com/edge/kubevirt-chart:0.3.0 +
+registry.suse.com/suse/sles/15.5/virt-operator:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-api:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-controller:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-exportproxy:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-exportserver:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-handler:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-launcher:1.2.2
 | KubeVirt Dashboard Extension | 1.0.0 | 1.0.0 | registry.suse.com/edge/kubevirt-dashboard-extension-chart:1.0.0
-| Containerized Data Importer | 1.58.0 | 0.2.3 | registry.suse.com/edge/cdi-chart:0.2.3 +
-registry.suse.com/suse/sles/15.5/cdi-operator:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-controller:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-importer:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-cloner:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-apiserver:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-uploadserver:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-uploadproxy:1.58.0
+s| Containerized Data Importer s| 1.59.0 s| 0.3.0 s| registry.suse.com/edge/cdi-chart:0.3.0 +
+registry.suse.com/suse/sles/15.5/cdi-operator:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-controller:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-importer:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-cloner:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-apiserver:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadserver:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadproxy:1.59.0
 | Endpoint Copier Operator | 0.2.0 | 0.2.0 | registry.suse.com/edge/endpoint-copier-operator:v0.2.0 +
 registry.suse.com/edge/endpoint-copier-operator-chart:0.2.0
 | Akri (Tech Preview) | 0.12.20 | 0.12.20 | registry.suse.com/edge/akri-chart:0.12.20 +

--- a/asciidoc/edge-book/version-matrix.adoc
+++ b/asciidoc/edge-book/version-matrix.adoc
@@ -17,11 +17,11 @@ endif::[]
 |======
 | Name | Version | Chart Version
 | SLE Micro | 5.5 | N/A
-| Rancher Prime | 2.8.4 | 2.8.4
+| Rancher Prime | 2.8.5 | 2.8.5
 | Fleet | 0.9.2 | 0.9.2
-| K3s | 1.28.9 | N/A
-| RKE2 | 1.28.9 | N/A
-| Metal^3^ | 1.16.0 | 0.7.1
+| K3s | 1.28.10 | N/A
+| RKE2 | 1.28.10 | N/A
+| Metal^3^ | 1.16.0 | 0.7.3
 | MetalLB | 0.14.3 | 0.14.3
 | Elemental | 1.4.4 | 103.1.0
 | Edge Image Builder | 1.0.2 | N/A

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -250,9 +250,9 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/coreos-prometheus-config-reloader:v0.38.1
     - name: registry.rancher.com/rancher/coreos-prometheus-operator:v0.38.1
     - name: registry.rancher.com/rancher/flannel-cni:v0.3.0-rancher9
-    - name: registry.rancher.com/rancher/fleet-agent:v0.9.4
-    - name: registry.rancher.com/rancher/fleet:v0.9.4
-    - name: registry.rancher.com/rancher/gitjob:v0.9.7
+    - name: registry.rancher.com/rancher/fleet-agent:v0.9.5
+    - name: registry.rancher.com/rancher/fleet:v0.9.5
+    - name: registry.rancher.com/rancher/gitjob:v0.9.8
     - name: registry.rancher.com/rancher/grafana-grafana:7.1.5
     - name: registry.rancher.com/rancher/hardened-addon-resizer:1.8.20-build20240410
     - name: registry.rancher.com/rancher/hardened-calico:v3.27.3-build20240423
@@ -263,7 +263,7 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/hardened-etcd:v3.5.9-k3s1-build20240418
     - name: registry.rancher.com/rancher/hardened-flannel:v0.25.1-build20240423
     - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
-    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.10-rke2r1-build20240416
+    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.10-rke2r1-build20240514
     - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240208
     - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.14.1-build20230926
     - name: registry.rancher.com/rancher/hardened-whereabouts:v0.6.3-build20240208
@@ -286,26 +286,27 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/prom-prometheus:v2.18.2
     - name: registry.rancher.com/rancher/prometheus-auth:v0.2.2
     - name: registry.rancher.com/rancher/prometheus-federator:v0.3.4
-    - name: registry.rancher.com/rancher/pushprox-client:v0.1.0-rancher2-client
-    - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.0-rancher2-proxy
+    - name: registry.rancher.com/rancher/pushprox-client:v0.1.3-rancher2-client
+    - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.3-rancher2-proxy
     - name: registry.rancher.com/rancher/rancher-agent:v2.8.5
     - name: registry.rancher.com/rancher/rancher-csp-adapter:v3.0.1
-    - name: registry.rancher.com/rancher/rancher-webhook:v0.4.5
+    - name: registry.rancher.com/rancher/rancher-webhook:v0.4.7
     - name: registry.rancher.com/rancher/rancher:v2.8.5
     - name: registry.rancher.com/rancher/rke-tools:v0.1.96
     - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
     - name: registry.rancher.com/rancher/rke2-runtime:v1.28.10-rke2r1
     - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.10-rke2r1
     - name: registry.rancher.com/rancher/security-scan:v0.2.15
-    - name: registry.rancher.com/rancher/shell:v0.1.24
+    - name: registry.rancher.com/rancher/shell:v0.1.25
     - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.10-k3s1
     - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.10-rke2r1
     - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
     - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
-    - name: registry.rancher.com/rancher/ui-plugin-catalog:1.3.0
+    - name: registry.rancher.com/rancher/ui-plugin-catalog:1.4.0
     - name: registry.rancher.com/rancher/ui-plugin-operator:v0.1.1
     - name: registry.rancher.com/rancher/webhook-receiver:v0.2.5
     - name: registry.rancher.com/rancher/kubectl:v1.20.2
+    - name: registry.rancher.com/rancher/shell:v0.1.24
 ----
 
 As compared to the full list of 602 container images, this slimmed down version only contains 62 which makes the new CRB image only about 7GB.

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -174,7 +174,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.9+rke2r1
+  version: v1.28.10+rke2r1
 embeddedArtifactRegistry:
   images:
     - ...
@@ -184,8 +184,8 @@ The `image` section is required, and it specifies the input image, its architect
 
 The `operatingSystem` section is optional, and contains configuration to enable login on the provisioned systems with the `root/eib` username/password.
 
-The `kubernetes` section is optional, and it defines the Kubernetes type and version. We are going to use Kubernetes 1.28.9 and RKE2 by default.
-Use `kubernetes.version: v1.28.9+k3s1` if K3s is desired instead. Unless explicitly configured via the `kubernetes.nodes` field, all clusters we bootstrap in this guide will be single-node ones.
+The `kubernetes` section is optional, and it defines the Kubernetes type and version. We are going to use Kubernetes 1.28.10 and RKE2 by default.
+Use `kubernetes.version: v1.28.10+k3s1` if K3s is desired instead. Unless explicitly configured via the `kubernetes.nodes` field, all clusters we bootstrap in this guide will be single-node ones.
 
 The `embeddedArtifactRegistry` section will include all images which are only referenced and pulled at runtime for the specific component.
 
@@ -196,7 +196,7 @@ The `embeddedArtifactRegistry` section will include all images which are only re
 The <<components-rancher,Rancher>> deployment that will be demonstrated will be highly slimmed down for demonstration purposes. For your actual deployments, additional artifacts may be necessary depending on your configuration.
 ====
 
-The https://github.com/rancher/rancher/releases/tag/v2.8.4[Rancher v2.8.4] release assets contain a `rancher-images.txt` file which lists all the images required for an air-gapped installation.
+The https://github.com/rancher/rancher/releases/tag/v2.8.5[Rancher v2.8.5] release assets contain a `rancher-images.txt` file which lists all the images required for an air-gapped installation.
 
 There are about 602 container images in total which means that the resulting CRB image would be roughly 28GB+. For our Rancher installation, we will strip down that list to the smallest working configuration. From there, you can add back any images you may need for your deployments.
 
@@ -215,7 +215,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.9+rke2r1
+  version: v1.28.10+rke2r1
   network:
     apiVIP: 192.168.100.151
   manifests:
@@ -224,7 +224,7 @@ kubernetes:
   helm:
     charts:
       - name: rancher
-        version: 2.8.4
+        version: 2.8.5
         repositoryName: rancher-prime
         valuesFile: rancher-values.yaml
         targetNamespace: cattle-system
@@ -263,14 +263,14 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/hardened-etcd:v3.5.9-k3s1-build20240418
     - name: registry.rancher.com/rancher/hardened-flannel:v0.25.1-build20240423
     - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
-    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.9-rke2r1-build20240416
+    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.10-rke2r1-build20240416
     - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240208
     - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.14.1-build20230926
     - name: registry.rancher.com/rancher/hardened-whereabouts:v0.6.3-build20240208
     - name: registry.rancher.com/rancher/helm-project-operator:v0.2.1
     - name: registry.rancher.com/rancher/istio-kubectl:1.5.10
     - name: registry.rancher.com/rancher/jimmidyson-configmap-reload:v0.3.0
-    - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.9-k3s1
+    - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.10-k3s1
     - name: registry.rancher.com/rancher/klipper-helm:v0.8.3-build20240228
     - name: registry.rancher.com/rancher/klipper-lb:v0.4.7
     - name: registry.rancher.com/rancher/kube-api-auth:v0.2.1
@@ -288,18 +288,18 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/prometheus-federator:v0.3.4
     - name: registry.rancher.com/rancher/pushprox-client:v0.1.0-rancher2-client
     - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.0-rancher2-proxy
-    - name: registry.rancher.com/rancher/rancher-agent:v2.8.4
+    - name: registry.rancher.com/rancher/rancher-agent:v2.8.5
     - name: registry.rancher.com/rancher/rancher-csp-adapter:v3.0.1
     - name: registry.rancher.com/rancher/rancher-webhook:v0.4.5
-    - name: registry.rancher.com/rancher/rancher:v2.8.4
+    - name: registry.rancher.com/rancher/rancher:v2.8.5
     - name: registry.rancher.com/rancher/rke-tools:v0.1.96
     - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
-    - name: registry.rancher.com/rancher/rke2-runtime:v1.28.9-rke2r1
-    - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.9-rke2r1
+    - name: registry.rancher.com/rancher/rke2-runtime:v1.28.10-rke2r1
+    - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.10-rke2r1
     - name: registry.rancher.com/rancher/security-scan:v0.2.15
     - name: registry.rancher.com/rancher/shell:v0.1.24
-    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.9-k3s1
-    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.9-rke2r1
+    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.10-k3s1
+    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.10-rke2r1
     - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
     - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
     - name: registry.rancher.com/rancher/ui-plugin-catalog:1.3.0
@@ -536,7 +536,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.9+rke2r1
+  version: v1.28.10+rke2r1
   helm:
     charts:
       - name: neuvector-crd
@@ -662,7 +662,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.9+rke2r1
+  version: v1.28.10+rke2r1
   helm:
     charts:
       - name: longhorn
@@ -812,7 +812,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.9+rke2r1
+  version: v1.28.10+rke2r1
   helm:
     charts:
       - name: kubevirt-chart

--- a/asciidoc/integrations/nvidia-slemicro.adoc
+++ b/asciidoc/integrations/nvidia-slemicro.adoc
@@ -272,7 +272,7 @@ This should show something similar to the following:
 [,shell]
 ----
 NAME       STATUS   ROLES                       AGE   VERSION
-node0001   Ready    control-plane,etcd,master   13d   v1.28.9+rke2r1
+node0001   Ready    control-plane,etcd,master   13d   v1.28.10+rke2r1
 ----
 
 What you should find is that your k3s/rke2 installation has detected the NVIDIA Container Toolkit on the host and auto-configured the NVIDIA runtime integration into `containerd` (the Container Runtime Interface that k3s/rke2 use). Confirm this by checking the containerd `config.toml` file:
@@ -467,7 +467,7 @@ operatingSystem:
       - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
     sccRegistrationCode: <snip>
 kubernetes:
-  version: v1.28.9+k3s1
+  version: v1.28.10+k3s1
   helm:
     charts:
       - name: nvidia-device-plugin

--- a/asciidoc/misc/rke2-selinux.adoc
+++ b/asciidoc/misc/rke2-selinux.adoc
@@ -128,7 +128,7 @@ Install RKE2 Using Install Script
 [,bash]
 ----
 curl -sfL https://get.rke2.io | INSTALL_RKE2_EXEC="server" \
- RKE2_SELINUX=true INSTALL_RKE2_VERSION=v1.28.9+rke2r1 sh -
+ RKE2_SELINUX=true INSTALL_RKE2_VERSION=v1.28.10+rke2r1 sh -
 
 # Enable and Start RKE2
 systemctl enable --now rke2-server.service

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -225,9 +225,10 @@ if [ ! -f "${NETWORK_DATA_FILE}" ]; then
 fi
 
 DESIRED_HOSTNAME=$(cat /mnt/openstack/latest/meta_data.json | tr ',{}' '\n' | grep '\"metal3-name\"' | sed 's/.*\"metal3-name\": \"\(.*\)\"/\1/')
+echo "${DESIRED_HOSTNAME}" > /etc/hostname
 
 mkdir -p /tmp/nmc/{desired,generated}
-cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/${DESIRED_HOSTNAME}.yaml
+cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/_all.yaml
 umount /mnt
 
 ./nmc generate --config-dir /tmp/nmc/desired --output-dir /tmp/nmc/generated

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -609,7 +609,7 @@ spec:
 The `RKE2ControlPlane` object specifies the control-plane configuration to be used and the `Metal3MachineTemplate` object specifies the control-plane image to be used.
 Also, it contains the information about the number of replicas to be used (in this case, one) and the `CNI` plug-in to be used (in this case, `Cilium`).
 The agentConfig block contains the `Ignition` format to be used and the `additionalUserData` to be used to configure the `RKE2` node with information like a systemd named `rke2-preinstall.service` to replace automatically the `BAREMETALHOST_UUID` and `node-name` during the provisioning process using the Ironic information.
-The last block of information contains the Kubernetes version to be used. `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.9+rke2r1`).
+The last block of information contains the Kubernetes version to be used. `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.10+rke2r1`).
 
 [,yaml]
 ----
@@ -865,7 +865,7 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
     ** The `storage` block which contains the Helm charts to be used to install the `MetalLB` and the `endpoint-copier-operator`.
     ** The `metalLB` custom resource file with the `IPaddressPool` and the `L2Advertisement` to be used (replacing `$\{EDGE_VIP_ADDRESS\}` with the `VIP` address).
     ** The `endpoint-svc.yaml` file to be used to configure the `kubernetes-vip` service to be used by the `MetalLB` to manage the `VIP` address.
-* The last block of information contains the Kubernetes version to be used. The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.9+rke2r1`).
+* The last block of information contains the Kubernetes version to be used. The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.10+rke2r1`).
 
 [,yaml]
 ----
@@ -1261,7 +1261,7 @@ To make the process clear, the changes required on that block (`RKE2ControlPlane
     ** `cpu-partitioning.service` to enable the isolation cores of the `CPU` (for example, `1-30,33-62`).
     ** `sriov-custom-auto-vfs.service` to install the `sriov` Helm chart, wait until custom resources are created and run the `/var/sriov-auto-filler.sh` to replace the values in the config map `sriov-custom-auto-config` and create the `sriovnetworknodepolicy` to be used by the workloads.
 
-* The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.9+rke2r1`).
+* The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.10+rke2r1`).
 
 With all these changes mentioned, the `RKE2ControlPlane` block in the `capi-provisioning-example.yaml` will look like the following:
 

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -38,7 +38,7 @@ helm get values metal3 -n metal3-system -o yaml > metal3-values.yaml
 helm upgrade metal3 suse-edge/metal3 \
   --namespace metal3-system \
   -f metal3-values.yaml \
-  --version=0.7.1
+  --version=0.7.3
 ----
 
 === Downstream cluster upgrades

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -183,7 +183,7 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.7.1
+        version: 0.7.3
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
@@ -204,7 +204,7 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.8.4
+        version: 2.8.5
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -308,7 +308,7 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.7.1
+        version: 0.7.3
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
@@ -329,7 +329,7 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.8.4
+        version: 2.8.5
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -357,7 +357,7 @@ kubernetes:
 #        type: server
 ----
 
-where `version` is the version of Kubernetes to be installed. In our case, we are using an RKE2 cluster, so the version must be minor less than 1.29 to be compatible with `Rancher` (for example, `v1.28.9+rke2r1`).
+where `version` is the version of Kubernetes to be installed. In our case, we are using an RKE2 cluster, so the version must be minor less than 1.29 to be compatible with `Rancher` (for example, `v1.28.10+rke2r1`).
 
 The `helm` section contains the list of Helm charts to be installed, the repositories to be used, and the version configuration for all of them.
 
@@ -416,7 +416,7 @@ export METAL3_CHART_TARGETNAMESPACE="metal3-system"
 export METAL3_CLUSTERCTLVERSION="1.6.2"
 export METAL3_CAPICOREVERSION="1.6.2"
 export METAL3_CAPIMETAL3VERSION="1.6.0"
-export METAL3_CAPIRKE2VERSION="0.2.6"
+export METAL3_CAPIRKE2VERSION="0.4.1"
 export METAL3_CAPIPROVIDER="rke2"
 export METAL3_CAPISYSTEMNAMESPACE="capi-system"
 export METAL3_RKE2BOOTSTRAPNAMESPACE="rke2-bootstrap-system"
@@ -1126,7 +1126,7 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.7.1
+        version: 0.7.3
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
@@ -1147,7 +1147,7 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.8.4
+        version: 2.8.5
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -1197,14 +1197,14 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/hardened-etcd:v3.5.9-k3s1-build20240418
     - name: registry.rancher.com/rancher/hardened-flannel:v0.25.1-build20240423
     - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
-    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.9-rke2r1-build20240416
+    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.10-rke2r1-build20240416
     - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240208
     - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.14.1-build20230926
     - name: registry.rancher.com/rancher/hardened-whereabouts:v0.6.3-build20240208
     - name: registry.rancher.com/rancher/helm-project-operator:v0.2.1
     - name: registry.rancher.com/rancher/istio-kubectl:1.5.10
     - name: registry.rancher.com/rancher/jimmidyson-configmap-reload:v0.3.0
-    - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.9-k3s1
+    - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.10-k3s1
     - name: registry.rancher.com/rancher/klipper-helm:v0.8.3-build20240228
     - name: registry.rancher.com/rancher/klipper-lb:v0.4.7
     - name: registry.rancher.com/rancher/kube-api-auth:v0.2.1
@@ -1222,18 +1222,18 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/prometheus-federator:v0.3.4
     - name: registry.rancher.com/rancher/pushprox-client:v0.1.0-rancher2-client
     - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.0-rancher2-proxy
-    - name: registry.rancher.com/rancher/rancher-agent:v2.8.4
+    - name: registry.rancher.com/rancher/rancher-agent:v2.8.5
     - name: registry.rancher.com/rancher/rancher-csp-adapter:v3.0.1
     - name: registry.rancher.com/rancher/rancher-webhook:v0.4.5
-    - name: registry.rancher.com/rancher/rancher:v2.8.4
+    - name: registry.rancher.com/rancher/rancher:v2.8.5
     - name: registry.rancher.com/rancher/rke-tools:v0.1.96
     - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
-    - name: registry.rancher.com/rancher/rke2-runtime:v1.28.9-rke2r1
-    - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.9-rke2r1
+    - name: registry.rancher.com/rancher/rke2-runtime:v1.28.10-rke2r1
+    - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.10-rke2r1
     - name: registry.rancher.com/rancher/security-scan:v0.2.15
     - name: registry.rancher.com/rancher/shell:v0.1.24
-    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.9-k3s1
-    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.9-rke2r1
+    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.10-k3s1
+    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.10-rke2r1
     - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
     - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
     - name: registry.rancher.com/rancher/ui-plugin-catalog:1.3.0
@@ -1253,8 +1253,8 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.6.1
     - name: registry.rancher.com/rancher/mirrored-longhornio-longhorn-ui:v1.6.1
     - name: registry.rancher.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.36
-    - name: registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:v0.2.6
-    - name: registry.suse.com/edge/cluster-api-provider-rke2-controlplane:v0.2.6
+    - name: registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:v0.4.1
+    - name: registry.suse.com/edge/cluster-api-provider-rke2-controlplane:v0.4.1
     - name: registry.suse.com/edge/cluster-api-controller:v1.6.2
     - name: registry.suse.com/edge/cluster-api-provider-metal3:v1.6.0
     - name: registry.suse.com/edge/ip-address-manager:v1.6.0
@@ -1388,7 +1388,7 @@ ${KUBECTL} delete configmap ${METAL3LOCKCMNAME} -n ${METAL3LOCKNAMESPACE}
 |-- clusterctl.yaml
 |-- overrides
     |-- bootstrap-rke2
-    |   |-- v0.2.6
+    |   |-- v0.4.1
     |       |-- bootstrap-components.yaml
     |       |-- metadata.yaml
     |-- cluster-api
@@ -1396,7 +1396,7 @@ ${KUBECTL} delete configmap ${METAL3LOCKCMNAME} -n ${METAL3LOCKNAMESPACE}
     |       |-- core-components.yaml
     |       |-- metadata.yaml
     |-- control-plane-rke2
-    |   |-- v0.2.6
+    |   |-- v0.4.1
     |       |-- control-plane-components.yaml
     |       |-- metadata.yaml
     |-- infrastructure-metal3
@@ -1419,10 +1419,10 @@ providers:
     url: "/root/cluster-api/overrides/infrastructure-metal3/v1.6.0/infrastructure-components.yaml"
     type: "InfrastructureProvider"
   - name: "rke2"
-    url: "/root/cluster-api/overrides/bootstrap-rke2/v0.2.6/bootstrap-components.yaml"
+    url: "/root/cluster-api/overrides/bootstrap-rke2/v0.4.1/bootstrap-components.yaml"
     type: "BootstrapProvider"
   - name: "rke2"
-    url: "/root/cluster-api/overrides/control-plane-rke2/v0.2.6/control-plane-components.yaml"
+    url: "/root/cluster-api/overrides/control-plane-rke2/v0.4.1/control-plane-components.yaml"
     type: "ControlPlaneProvider"
 images:
   all:
@@ -1437,12 +1437,12 @@ The `clusterctl` and the rest of the files included in the `overrides` folder ca
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/1.6.2/clusterctl-linux-${GOARCH} -o /usr/local/bin/clusterct
 
 # boostrap-components (boostrap-rke2)
-curl -L https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.2.6/bootstrap-components.yaml
-curl -L https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.2.6/metadata.yaml
+curl -L https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.4.1/bootstrap-components.yaml
+curl -L https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.4.1/metadata.yaml
 
 # control-plane-components (control-plane-rke2)
-curl -L https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.2.6/control-plane-components.yaml
-curl -L https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.2.6/metadata.yaml
+curl -L https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.4.1/control-plane-components.yaml
+curl -L https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.4.1/metadata.yaml
 
 # cluster-api components
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.2/core-components.yaml

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -203,7 +203,7 @@ In this next example, we're going to take our existing image definition and will
 [,yaml]
 ----
 kubernetes:
-  version: v1.28.9+rke2r1
+  version: v1.28.10+rke2r1
   manifests:
     urls:
       - https://k8s.io/examples/application/nginx-app.yaml
@@ -236,7 +236,7 @@ operatingSystem:
     additionalRepos:
       - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
 kubernetes:
-  version: v1.28.9+rke2r1
+  version: v1.28.10+rke2r1
   manifests:
     urls:
       - https://k8s.io/examples/application/nginx-app.yaml

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -391,7 +391,7 @@ metadata:
   name: location-123
   namespace: fleet-default
 spec:
-  kubernetesVersion: v1.28.9+k3s1
+  kubernetesVersion: v1.28.10+k3s1
   rkeConfig:
     machinePools:
       - name: pool1
@@ -414,7 +414,7 @@ The UI extension allows for a few shortcuts to be taken. Note that managing mult
 . As before, open the left three-dot menu and select "OS Management." This brings you back to the main screen for managing your Elemental systems.
 . On the left sidebar, click "Inventory of Machines." This opens the inventory of machines that have registered.
 . To create a cluster from these machines, select the systems you want, click the "Actions" drop-down list, then "Create Elemental Cluster." This opens the Cluster Creation dialog while also creating a MachineSelectorTemplate to use in the background.
-. On this screen, configure the cluster you want to be built. For this quick start, K3s v1.28.9+k3s1 is selected and the rest of the options are left as is.
+. On this screen, configure the cluster you want to be built. For this quick start, K3s v1.28.10+k3s1 is selected and the rest of the options are left as is.
 +
 [TIP]
 ====

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -388,9 +388,10 @@ if [ ! -f "${NETWORK_DATA_FILE}" ]; then
 fi
 
 DESIRED_HOSTNAME=$(cat /mnt/openstack/latest/meta_data.json | tr ',{}' '\n' | grep '\"metal3-name\"' | sed 's/.*\"metal3-name\": \"\(.*\)\"/\1/')
+echo "${DESIRED_HOSTNAME}" > /etc/hostname
 
 mkdir -p /tmp/nmc/{desired,generated}
-cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/${DESIRED_HOSTNAME}.yaml
+cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/_all.yaml
 umount /mnt
 
 ./nmc generate --config-dir /tmp/nmc/desired --output-dir /tmp/nmc/generated
@@ -444,7 +445,8 @@ spec:
 # Remaining content as in previous example
 ----
 
-NOTE: although optional in the nmstate API, the mac-address is mandatory for configuration via NM Configurator and must be provided.
+NOTE: In some circumstances the mac-address may be omitted but the `configure-network.sh` script must use the `_all.yaml` filename described above to enable
+<<networking-unified, Unified node configuration>> in nm-configurator.
 
 ==== BareMetalHost preparation
 

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -191,7 +191,7 @@ Install https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl
 
 [,bash]
 ----
-clusterctl init --core "cluster-api:v1.6.2" --infrastructure "metal3:v1.6.0" --bootstrap "rke2:v0.2.6" --control-plane "rke2:v0.2.6"
+clusterctl init --core "cluster-api:v1.6.2" --infrastructure "metal3:v1.6.0" --bootstrap "rke2:v0.4.1" --control-plane "rke2:v0.4.1"
 ----
 
 After some time, the controller pods should be running in the `capi-system`, `capm3-system`, `rke2-bootstrap-system` and `rke2-control-plane-system` namespaces.
@@ -558,7 +558,7 @@ spec:
                 ExecStartPost=/bin/sh -c "umount /mnt"
                 [Install]
                 WantedBy=multi-user.target
-    version: v1.28.9+rke2r1
+    version: v1.28.10+rke2r1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
@@ -651,7 +651,7 @@ spec:
         kind: Metal3MachineTemplate
         name: sample-cluster-workers
       nodeDrainTimeout: 0s
-      version: v1.28.9+rke2r1
+      version: v1.28.10+rke2r1
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: RKE2ConfigTemplate
@@ -663,7 +663,7 @@ spec:
     spec:
       agentConfig:
         format: ignition
-        version: v1.28.9+rke2r1
+        version: v1.28.10+rke2r1
         kubelet:
           extraArgs:
             - provider-id=metal3://BAREMETALHOST_UUID


### PR DESCRIPTION
This aligns the metal3/atip docs with https://github.com/suse-edge/charts/pull/134, adds release notes and updates all versions to align with the proposed new 3.0.2 baseline.