### PR TITLE
Adding instructions to force Elemental version selection

### DIFF
--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -157,11 +157,13 @@ It can be installed from either the same shell you used to install Rancher or in
 ----
 helm install --create-namespace -n cattle-elemental-system \
  elemental-operator-crds \
- oci://registry.suse.com/rancher/elemental-operator-crds-chart
+ oci://registry.suse.com/rancher/elemental-operator-crds-chart \
+ --version 1.4.4
  
 helm install --create-namespace -n cattle-elemental-system \
  elemental-operator \
- oci://registry.suse.com/rancher/elemental-operator-chart
+ oci://registry.suse.com/rancher/elemental-operator-chart \
+ --version 1.4.4
 ----
 
 ==== (Optionally) Install the Elemental UI extension


### PR DESCRIPTION
In this PR we introduce instructions to install a specific version of Elemental, as per the release notes. If omitted, this deploys the latest version of the operator and CRD's, which is now 1.5.z. In `release-3.0` this needs to be 1.4.z. Until we move to 1.5.z, will push this to main and backport.

Fixes: #323