### PR TITLE
[Backport] Adding instructions to force Elemental version selection when installing for Edge

### DIFF
--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -157,11 +157,13 @@ It can be installed from either the same shell you used to install Rancher or in
 ----
 helm install --create-namespace -n cattle-elemental-system \
  elemental-operator-crds \
- oci://registry.suse.com/rancher/elemental-operator-crds-chart
+ oci://registry.suse.com/rancher/elemental-operator-crds-chart \
+ --version 1.4.4
  
 helm install --create-namespace -n cattle-elemental-system \
  elemental-operator \
- oci://registry.suse.com/rancher/elemental-operator-chart
+ oci://registry.suse.com/rancher/elemental-operator-chart \
+ --version 1.4.4
 ----
 
 ==== (Optionally) Install the Elemental UI extension


### PR DESCRIPTION
Backporting #342, as referenced in #323.

cherry-picked from b1f86410304d0068a62e4e572875a1d7d09cc2cd