### PR TITLE
[Backport] Replace yq package example in EIB Quickstart

### DIFF
--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -138,19 +138,19 @@ One of the major features of EIB is to provide a mechanism to add additional sof
 * Network repositories to search for these packages in
 * SUSE Customer Center (SCC) credentials to search official SUSE repositories for the listed packages
 * Via an `$CONFIG_DIR/rpms` directory, side-load custom RPM's that don't exist in network repositories
-* Via the same directory (`$CONFIG_DIR/rpms/gpg-keys`), GPG-keys to enable validation of 3rd party packages
+* Via the same directory (`$CONFIG_DIR/rpms/gpg-keys`), GPG-keys to enable validation of third party packages
 
 EIB will then run through a package resolution process at image build time, taking the base image as the input, and attempts to pull and install all supplied packages, either specified via the list or provided locally. EIB downloads all of the packages, including any dependencies into a repository that exists within the output image and instructs the system to install these during the first boot process. Doing this process during the image build guarantees that the packages will successfully install during first-boot on the desired platform, e.g. the node at the edge. This is also advantageous in environments where you want to bake the additional packages into the image rather than pull them over the network when in operation, e.g. for air-gapped or restricted network environments.
 
-As a simple example to demonstrate this, we are going to install the `yq` RPM package found in the openSUSE PackageHub repository:
+As a simple example to demonstrate this, we are going to install the `nvidia-container-toolkit` RPM package found in the third party vendor-supported NVIDIA repository:
 
 [,yaml]
 ----
   packages:
     packageList:
-      - yq
+      - nvidia-container-toolkit
     additionalRepos:
-      - url: https://download.opensuse.org/repositories/openSUSE:Factory/standard
+      - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
 ----
 
 The resulting definition file looks like:
@@ -169,10 +169,23 @@ operatingSystem:
       encryptedPassword: $6$G392FCbxVgnLaFw1$Ujt00mdpJ3tDHxEg1snBU3GjujQf6f8kvopu7jiCBIhRbRvMmKUqwcmXAKggaSSKeUUOEtCP3ZUoZQY7zTXnC1
   packages:
     packageList:
-      - yq
+      - nvidia-container-toolkit
     additionalRepos:
-      - url: https://download.opensuse.org/repositories/openSUSE:Factory/standard
+      - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
 ----
+
+The above is a simple example, but for completeness, download the NVIDIA package signing key before running the image generation:
+
+[,bash]
+----
+$ mkdir -p $CONFIG_DIR/rpms/gpg-keys
+$ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey > rpms/gpg-keys/nvidia.gpg
+----
+
+[WARNING]
+====
+Adding in additional RPM's via this method is meant for the addition of supported third party components or user-supplied (and maintained) packages; this mechanism should not be used to add packages that would not usually be supported on SLE Micro. If this mechanism is used to add components from openSUSE repositories (which are not supported), including from newer releases or service packs, you may end up with an unsupported configuration, especially when dependency resolution results in core parts of the operating system being replaced, even though the resulting system may appear to function as expected. If you're unsure, contact your SUSE representative for assistance in determining the supportability of your desired configuration.
+====
 
 [NOTE]
 ====
@@ -219,9 +232,9 @@ operatingSystem:
       encryptedPassword: $6$G392FCbxVgnLaFw1$Ujt00mdpJ3tDHxEg1snBU3GjujQf6f8kvopu7jiCBIhRbRvMmKUqwcmXAKggaSSKeUUOEtCP3ZUoZQY7zTXnC1
   packages:
     packageList:
-      - yq
+      - nvidia-container-toolkit
     additionalRepos:
-      - url: https://download.opensuse.org/repositories/openSUSE:Factory/standard
+      - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
 kubernetes:
   version: v1.28.9+rke2r1
   manifests:
@@ -408,6 +421,7 @@ The contents of this directory should look like:
 │   │   │   └── rpm-repo
 │   │   │       ├── addrepo0
 │   │   │       │   └── x86_64
+│   │   │       │       ├── nvidia-container-toolkit-1.15.0-1.x86_64.rpm
 │   │   │       │       ├── ...
 │   │   │       ├── repodata
 │   │   │       │   ├── ...
@@ -456,7 +470,16 @@ The contents of this directory should look like:
 
 If the build fails, `eib-build.log` is the first log that contains information. From there, it will direct you to the component that failed for debugging.
 
-At this point, you should have a ready-to-use image that will deploy SLE Micro 5.5, configure the root password, install yq, configure an embedded registry to serve content locally, install single-node RKE2, configure static networking, install KubeVirt, and deploy a user-manifest.
+At this point, you should have a ready-to-use image that will:
+
+1. Deploy SLE Micro 5.5
+2. Configure the root password
+3. Install the `nvidia-container-toolkit` package
+4. Configure an embedded container registry to serve content locally
+5. Install single-node RKE2
+6. Configure static networking
+7. Install KubeVirt
+8. Deploy a user-supplied manifest
 
 [#quickstart-eib-image-debug]
 == Debugging the image build process


### PR DESCRIPTION
Backport of #318 as reported in #316

cherry-picked from 1170adaa28391fab0045157b5c6257c46895bda3