### PR TITLE
Fix NeuVector versions

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -59,10 +59,10 @@ SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw.xz (sha256 6c2af94e7ac785c8f6a276032c8e
 | Longhorn | 1.6.1 | 103.3.0 | https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn-images.txt[Longhorn 1.6.1 Images] +
 https://charts.longhorn.io[Longhorn Helm Repo]
 | NM Configurator | 0.2.3 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.2.3[NMConfigurator Upstream Release]
-| NeuVector| 5.3.0 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-manager:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.0 +
+| NeuVector| 5.3.2 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-manager:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2 +
 registry.suse.com/rancher mirrored-neuvector-registry-adapter:0.1.1-s1 +
 registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
 registry.suse.com/rancher/mirrored-neuvector-updater:latest
@@ -157,10 +157,10 @@ s| Rancher Prime s| 2.8.4 s| 2.8.4 | https://github.com/rancher/rancher/releases
 | Longhorn | 1.6.1 | 103.3.0 | https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn-images.txt[Longhorn 1.6.1 Images] +
 https://charts.longhorn.io[Longhorn Helm Repo]
 s| NM Configurator s| 0.3.0 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.0[NMConfigurator Upstream Release]
-| NeuVector| 5.3.0 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-manager:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.0 +
+| NeuVector| 5.3.2 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-manager:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2 +
 registry.suse.com/rancher mirrored-neuvector-registry-adapter:0.1.1-s1 +
 registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
 registry.suse.com/rancher/mirrored-neuvector-updater:latest

--- a/asciidoc/edge-book/version-matrix.adoc
+++ b/asciidoc/edge-book/version-matrix.adoc
@@ -27,7 +27,7 @@ endif::[]
 | Edge Image Builder | 1.0.2 | N/A
 | NM Configurator | 0.3.0 | N/A
 | Longhorn | 1.6.1 | 103.3.0
-| NeuVector| 5.3.0 | 103.0.3
+| NeuVector| 5.3.2 | 103.0.3
 | KubeVirt | 1.1.1 | 0.2.4
 | Containerized Data Importer | 1.58.0 | 0.2.3
 | KubeVirt Dashboard Extension | 1.0.0 | 1.0.0


### PR DESCRIPTION
The NeuVector charts we use (v103.0.3+up2.7.6) are in fact deploying NeuVector 5.3.2. This PR fixes all such occurrences in our docs.