### PR TITLE
Fixed broken link - Git issue 339

### DIFF
--- a/asciidoc/components/rancher-dashboard-extensions.adoc
+++ b/asciidoc/components/rancher-dashboard-extensions.adoc
@@ -110,7 +110,7 @@ image::installed-dashboard-extensions.png[]
 
 == KubeVirt Dashboard Extension
 
-KubeVirt Extension provides basic virtual machine management for Rancher dashboard UI. Its capabilities are described in in <<kubevirt-dashboard-extension, Using KubeVirt Rancher Dashboard Extension>>. 
+KubeVirt Extension provides basic virtual machine management for Rancher dashboard UI. Its capabilities are described in <<kubevirt-dashboard-extension, Using KubeVirt Rancher Dashboard Extension>>. 
 
 == Akri Dashboard Extension
 

--- a/asciidoc/components/rancher-dashboard-extensions.adoc
+++ b/asciidoc/components/rancher-dashboard-extensions.adoc
@@ -110,7 +110,7 @@ image::installed-dashboard-extensions.png[]
 
 == KubeVirt Dashboard Extension
 
-KubeVirt Extension provides basic virtual machine management for Rancher dashboard UI. It's capabilities are described in xref:virtualization.adoc#kubevirt-dashboard-extension[Edge Virtualization]. 
+KubeVirt Extension provides basic virtual machine management for Rancher dashboard UI. Its capabilities are described in <<kubevirt-dashboard-extension, Using KubeVirt Rancher Dashboard Extension>>. 
 
 == Akri Dashboard Extension
 

--- a/asciidoc/components/rancher-dashboard-extensions.adoc
+++ b/asciidoc/components/rancher-dashboard-extensions.adoc
@@ -110,7 +110,7 @@ image::installed-dashboard-extensions.png[]
 
 == KubeVirt Dashboard Extension
 
-KubeVirt Extension provides basic virtual machine management for Rancher dashboard UI. Its capabilities are described in <<kubevirt-dashboard-extension, Using KubeVirt Rancher Dashboard Extension>>. 
+KubeVirt Extension provides basic virtual machine management for Rancher dashboard UI. Its capabilities are described in in <<kubevirt-dashboard-extension, Using KubeVirt Rancher Dashboard Extension>>. 
 
 == Akri Dashboard Extension
 


### PR DESCRIPTION
https://github.com/suse-edge/suse-edge.github.io/issues/339

KubeVirt Dashboard Extension:

https://documentation.suse.com/en-us/suse-edge/3.0/html/edge/components-rancher-dashboard-extensions.html#id-kubevirt-dashboard-extension

link shows 404

Fixes: #339