### PR TITLE
Rearranged the release notes so the latest z-stream is at the top

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -24,7 +24,203 @@ These Release Notes are, unless explicitly specified and explained, identical ac
 
 Entries are only listed once, but they can be referenced in several places if they are important and belong to more than one section. Release notes usually only list changes that happened between two subsequent releases. Certain important entries from the release notes of previous product versions may be repeated. To make these entries easier to identify, they contain a note to that effect.
 
-However, repeated entries are provided as a courtesy only. Therefore, if you are skipping one or releases, check the release notes of the skipped releases also. If you are only reading the release notes of the current release, you could miss important changes that may affect system behavior.
+However, repeated entries are provided as a courtesy only. Therefore, if you are skipping one or releases, check the release notes of the skipped releases also. If you are only reading the release notes of the current release, you could miss important changes that may affect system behavior. SUSE Edge versions are defined as x.y.z, where 'x' denotes the major version, 'y' denotes the minor, and 'z' denotes the patch version, also known as the "z-stream". SUSE Edge product lifecycles are defined based around a given minor release, e.g. "3.0", but ship with subsequent patch updates through its lifecycle, e.g. "3.0.1".
+
+NOTE: SUSE Edge z-stream releases are tightly integrated and thoroughly tested as a versioned stack. Upgrade of any individual components to a different versions to those listed above is likely to result in system downtime. While it's possible to run Edge clusters in untested configurations, it is not recommended, and it may take longer to provide resolution through the support channels.
+
+= Release 3.0.2
+
+Availability Date: 16th August 2024
+
+Summary: SUSE Edge 3.0.2 is the second z-stream release in the SUSE Edge 3.0 portfolio.
+
+== New Features
+
+* The Metal^3^ chart now supports static network configuration without any `mac-address`: https://github.com/suse-edge/charts/pull/134[SUSE Edge issue #134]
+* KubeVirt is updated from `1.1.1` to `1.2.2` for details of new features refer to the: https://github.com/kubevirt/kubevirt/releases[Upstream Release Notes]
+
+== Bug & Security Fixes
+
+* The Metal^3^ chart fixes an issue where host reprovisioning may use stale static static network configuration: https://github.com/suse-edge/charts/pull/133[SUSE Edge issue #133]
+* The RKE2 Cluster API provider fixes an issue when specifying TLS configuration for a local registry: https://github.com/rancher/cluster-api-provider-rke2/pull/357[RKE2 Provider issue #357]
+* The RKE2 Cluster API provider fixes an issue causing rke2-install to error after system reboot: https://github.com/rancher/cluster-api-provider-rke2/pull/346[RKE2 Provider issue #346]
+* KubeVirt is updated to include several security fixes: https://www.suse.com/support/update/announcement/2024/suse-su-20242669-1[Kubevirt Update]
+
+== Components Versions
+
+The following table describes the individual components that make up the 3.0.2 release, including the version, the Helm chart version (if applicable), and from where the released artifact can be pulled in the binary format. Please follow the associated documentation for usage and deployment examples. Note that items in bold are highlighted changes from the previous z-stream release.
+
+|======
+| Name | Version | Helm Chart Version | Artifact Location (URL/Image)
+| SLE Micro | 5.5 (latest) | N/A | https://www.suse.com/download/sle-micro/[SLE Micro Download Page] +
+SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso (sha256 4f672a4a0f8ec421e7c25797def05598037c56b7f306283566a9f921bdce904a) +
+SLE-Micro.x86_64-5.5.0-Default-RT-SelfInstall-GM2.install.iso (sha256 527a5a7cdbf11e3e6238e386533755257676ad8b4c80be3b159d0904cb637678) +
+SLE-Micro.x86_64-5.5.0-Default-GM.raw.xz (sha256 13243a737ca219bad6a7aa41fa747c06e8b825fef10a756cf4d575f4493ed68b) +
+SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw.xz (sha256 6c2af94e7ac785c8f6a276032c8e6a4b493c294e6cd72809c75089522f01bc93)
+| SUSE Manager | 4.3.11 | N/A | https://www.suse.com/download/suse-manager/[SUSE Manager Download Page]
+s| K3s s| 1.28.10 | N/A | https://github.com/k3s-io/k3s/releases/tag/v1.28.10%2Bk3s1[Upstream K3s Release]
+s| RKE2 s| 1.28.10 | N/A | https://github.com/rancher/rke2/releases/tag/v1.28.10%2Brke2r1[Upstream RKE2 Release]
+s| Rancher Prime s| 2.8.5 s| 2.8.5 | https://github.com/rancher/rancher/releases/download/v2.8.5/rancher-images.txt[Rancher 2.8.5 Images] +
+ https://charts.rancher.com/server-charts/prime[Rancher Prime Helm Repo]
+| Longhorn | 1.6.1 | 103.3.0 | https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn-images.txt[Longhorn 1.6.1 Images] +
+https://charts.longhorn.io[Longhorn Helm Repo]
+| NM Configurator | 0.3.0 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.0[NMConfigurator Upstream Release]
+| NeuVector| 5.3.0 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.0 +
+registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.0 +
+registry.suse.com/rancher/mirrored-neuvector-manager:5.3.0 +
+registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.0 +
+registry.suse.com/rancher mirrored-neuvector-registry-adapter:0.1.1-s1 +
+registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
+registry.suse.com/rancher/mirrored-neuvector-updater:latest
+s| Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-controller:1.6.2 +
+registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
+*registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.4.1* +
+*registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.4.1*
+s| Metal^3^ s| 1.16.0 s| 0.7.3 | registry.suse.com/edge/metal3-chart:0.7.3 +
+registry.suse.com/edge/baremetal-operator:0.5.1 +
+registry.suse.com/edge/ip-address-manager:1.6.0 +
+registry.suse.com/edge/ironic:23.0.2.1 +
+*registry.suse.com/edge/ironic-ipa-downloader:1.3.4* +
+registry.suse.com/edge/kube-rbac-proxy:v0.14.2 +.1
+registry.suse.com/edge/mariadb:10.6.15.1
+| MetalLB | 0.14.3 | 0.14.3 | registry.suse.com/edge/metallb-chart:0.14.3 +
+registry.suse.com/edge/metallb-controller:v0.14.3 +
+registry.suse.com/edge/metallb-speaker:v0.14.3 +
+registry.suse.com/edge/frr:8.4 +
+registry.suse.com/edge/frr-k8s:v0.0.8
+| Elemental | 1.4.4 | 1.4.4 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
+registry.suse.com/rancher/elemental-operator-crds-chart:1.4.4 +
+registry.suse.com/rancher/elemental-operator:1.4.4
+| Edge Image Builder | 1.0.2 | N/A | registry.suse.com/edge/edge-image-builder:1.0.2
+s| KubeVirt s| 1.2.2 s| 0.3.0 s| registry.suse.com/edge/kubevirt-chart:0.3.0 +
+registry.suse.com/suse/sles/15.5/virt-operator:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-api:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-controller:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-exportproxy:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-exportserver:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-handler:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-launcher:1.2.2
+| KubeVirt Dashboard Extension | 1.0.0 | 1.0.0 | registry.suse.com/edge/kubevirt-dashboard-extension-chart:1.0.0
+s| Containerized Data Importer s| 1.59.0 s| 0.3.0 s| registry.suse.com/edge/cdi-chart:0.3.0 +
+registry.suse.com/suse/sles/15.5/cdi-operator:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-controller:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-importer:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-cloner:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-apiserver:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadserver:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadproxy:1.59.0
+| Endpoint Copier Operator | 0.2.0 | 0.2.0 | registry.suse.com/edge/endpoint-copier-operator:v0.2.0 +
+registry.suse.com/edge/endpoint-copier-operator-chart:0.2.0
+| Akri (Tech Preview) | 0.12.20 | 0.12.20 | registry.suse.com/edge/akri-chart:0.12.20 +
+registry.suse.com/edge/akri-dashboard-extension-chart:1.0.0 +
+registry.suse.com/edge/akri-agent:v0.12.20 +
+registry.suse.com/edge/akri-controller:v0.12.20 +
+registry.suse.com/edge/akri-debug-echo-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-onvif-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-opcua-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-udev-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-webhook-configuration:v0.12.20
+| SR-IOV Network Operator | 1.2.2 | 1.2.2+up0.1.0 | registry.suse.com/edge/sriov-network-operator-chart:1.2.2 +
+registry.suse.com/edge/sriov-crd-chart:1.2.2
+|======
+
+= Release 3.0.1
+
+Availability Date: 14th June 2024
+
+Summary: SUSE Edge 3.0.1 is the first z-stream release in the SUSE Edge 3.0 portfolio.
+
+== New Features
+
+* Elemental and EIB now support node reset for unmanaged hosts
+* SR-IOV Network Operator chart is now included
+* The Metal^3^ chart now supports providing additional trusted CA certificates
+* NM Configurator now supports applying unified configurations without any MAC specification
+* Added `version` subcommand to EIB; the version will also automatically be included in each image built by EIB
+
+== Bug & Security Fixes
+
+* EIB now automatically sets the execute bit on custom scripts: https://github.com/suse-edge/edge-image-builder/issues/429[SUSE Edge issue #429]
+* EIB now supports disks which are >512 byte sector size: https://github.com/suse-edge/edge-image-builder/issues/447[SUSE Edge issue #447]
+* Enhance EIB's ability to detect container images in Helm charts: https://github.com/suse-edge/edge-image-builder/issues/442[SUSE Edge issue #442]
+
+== Components Versions
+
+The following table describes the individual components that make up the 3.0.1 release, including the version, the Helm chart version (if applicable), and where the released artifact can be pulled from in binary format. Please follow the associated documentation for usage and deployment examples. Note that items in bold are highlighted changes from the previous z-stream release.
+
+|======
+| Name | Version | Helm Chart Version | Artifact Location (URL/Image)
+| SLE Micro | 5.5 (latest) | N/A | https://www.suse.com/download/sle-micro/[SLE Micro Download Page] +
+SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso (sha256 4f672a4a0f8ec421e7c25797def05598037c56b7f306283566a9f921bdce904a) +
+SLE-Micro.x86_64-5.5.0-Default-RT-SelfInstall-GM2.install.iso (sha256 527a5a7cdbf11e3e6238e386533755257676ad8b4c80be3b159d0904cb637678) +
+SLE-Micro.x86_64-5.5.0-Default-GM.raw.xz (sha256 13243a737ca219bad6a7aa41fa747c06e8b825fef10a756cf4d575f4493ed68b) +
+SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw.xz (sha256 6c2af94e7ac785c8f6a276032c8e6a4b493c294e6cd72809c75089522f01bc93)
+| SUSE Manager | 4.3.11 | N/A | https://www.suse.com/download/suse-manager/[SUSE Manager Download Page]
+s| K3s s| 1.28.9 | N/A | https://github.com/k3s-io/k3s/releases/tag/v1.28.9%2Bk3s1[Upstream K3s Release]
+s| RKE2 s| 1.28.9 | N/A | https://github.com/rancher/rke2/releases/tag/v1.28.9%2Brke2r1[Upstream RKE2 Release]
+s| Rancher Prime s| 2.8.4 s| 2.8.4 | https://github.com/rancher/rancher/releases/download/v2.8.4/rancher-images.txt[Rancher 2.8.4 Images] +
+ https://charts.rancher.com/server-charts/prime[Rancher Prime Helm Repo]
+| Longhorn | 1.6.1 | 103.3.0 | https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn-images.txt[Longhorn 1.6.1 Images] +
+https://charts.longhorn.io[Longhorn Helm Repo]
+s| NM Configurator s| 0.3.0 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.0[NMConfigurator Upstream Release]
+| NeuVector| 5.3.2 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-manager:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2 +
+registry.suse.com/rancher mirrored-neuvector-registry-adapter:0.1.1-s1 +
+registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
+registry.suse.com/rancher/mirrored-neuvector-updater:latest
+| Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-controller:1.6.2 +
+registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
+registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.2.6 +
+registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.2.6
+s| Metal^3^ s| 1.16.0 s| 0.7.1 | registry.suse.com/edge/metal3-chart:0.7.1 +
+registry.suse.com/edge/baremetal-operator:0.5.1 +
+registry.suse.com/edge/ip-address-manager:1.6.0 +
+registry.suse.com/edge/ironic:23.0.2.1 +
+registry.suse.com/edge/ironic-ipa-downloader:1.3.2 +
+registry.suse.com/edge/kube-rbac-proxy:v0.14.2 +.1
+registry.suse.com/edge/mariadb:10.6.15.1
+| MetalLB | 0.14.3 | 0.14.3 | registry.suse.com/edge/metallb-chart:0.14.3 +
+registry.suse.com/edge/metallb-controller:v0.14.3 +
+registry.suse.com/edge/metallb-speaker:v0.14.3 +
+registry.suse.com/edge/frr:8.4 +
+registry.suse.com/edge/frr-k8s:v0.0.8
+s| Elemental s| 1.4.4 s| 1.4.4 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
+registry.suse.com/rancher/elemental-operator-crds-chart:1.4.4 +
+registry.suse.com/rancher/elemental-operator:1.4.4
+s| Edge Image Builder s| 1.0.2 | N/A | registry.suse.com/edge/edge-image-builder:1.0.2
+| KubeVirt | 1.1.1 | 0.2.4 | registry.suse.com/edge/kubevirt-chart:0.2.4 +
+registry.suse.com/suse/sles/15.5/virt-operator:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-api:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-controller:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-exportproxy:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-exportserver:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-handler:1.1.1 +
+registry.suse.com/suse/sles/15.5/virt-launcher:1.1.1
+| KubeVirt Dashboard Extension | 1.0.0 | 1.0.0 | registry.suse.com/edge/kubevirt-dashboard-extension-chart:1.0.0
+| Containerized Data Importer | 1.58.0 | 0.2.3 | registry.suse.com/edge/cdi-chart:0.2.3 +
+registry.suse.com/suse/sles/15.5/cdi-operator:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-controller:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-importer:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-cloner:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-apiserver:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadserver:1.58.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadproxy:1.58.0
+| Endpoint Copier Operator | 0.2.0 | 0.2.0 | registry.suse.com/edge/endpoint-copier-operator:v0.2.0 +
+registry.suse.com/edge/endpoint-copier-operator-chart:0.2.0
+| Akri (Tech Preview) | 0.12.20 | 0.12.20 | registry.suse.com/edge/akri-chart:0.12.20 +
+registry.suse.com/edge/akri-dashboard-extension-chart:1.0.0 +
+registry.suse.com/edge/akri-agent:v0.12.20 +
+registry.suse.com/edge/akri-controller:v0.12.20 +
+registry.suse.com/edge/akri-debug-echo-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-onvif-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-opcua-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-udev-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-webhook-configuration:v0.12.20
+s| SR-IOV Network Operator s| 1.2.2 s| 1.2.2+up0.1.0 | registry.suse.com/edge/sriov-network-operator-chart:1.2.2 +
+registry.suse.com/edge/sriov-crd-chart:1.2.2
+|======
 
 = Release 3.0.0
 
@@ -114,202 +310,6 @@ registry.suse.com/edge/akri-onvif-discovery-handler:v0.12.20 +
 registry.suse.com/edge/akri-opcua-discovery-handler:v0.12.20 +
 registry.suse.com/edge/akri-udev-discovery-handler:v0.12.20 +
 registry.suse.com/edge/akri-webhook-configuration:v0.12.20
-|======
-
-NOTE: SUSE Edge z-stream releases are tightly integrated and thoroughly tested as a versioned stack. Upgrade of any individual components to a different versions to those listed above is likely to result in system downtime. While it's possible to run Edge clusters in untested configurations, it is not recommended, and it may take longer to provide resolution through the support channels.
-
-= Release 3.0.1
-
-Availability Date: 14th June 2024
-
-Summary: SUSE Edge 3.0.1 is the first z-stream release in the SUSE Edge 3.0 portfolio.
-
-== New Features
-
-* Elemental and EIB now support node reset for unmanaged hosts
-* SR-IOV Network Operator chart is now included
-* The Metal^3^ chart now supports providing additional trusted CA certificates
-* NM Configurator now supports applying unified configurations without any MAC specification
-* Added `version` subcommand to EIB; the version will also automatically be included in each image built by EIB
-
-== Bug & Security Fixes
-
-* EIB now automatically sets the execute bit on custom scripts: https://github.com/suse-edge/edge-image-builder/issues/429[SUSE Edge issue #429]
-* EIB now supports disks which are >512 byte sector size: https://github.com/suse-edge/edge-image-builder/issues/447[SUSE Edge issue #447]
-* Enhance EIB's ability to detect container images in Helm charts: https://github.com/suse-edge/edge-image-builder/issues/442[SUSE Edge issue #442]
-
-== Components Versions
-
-The following table describes the individual components that make up the 3.0.1 release, including the version, the Helm chart version (if applicable), and where the released artifact can be pulled from in binary format. Please follow the associated documentation for usage and deployment examples.
-
-|======
-| Name | Version | Helm Chart Version | Artifact Location (URL/Image)
-| SLE Micro | 5.5 (latest) | N/A | https://www.suse.com/download/sle-micro/[SLE Micro Download Page] +
-SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso (sha256 4f672a4a0f8ec421e7c25797def05598037c56b7f306283566a9f921bdce904a) +
-SLE-Micro.x86_64-5.5.0-Default-RT-SelfInstall-GM2.install.iso (sha256 527a5a7cdbf11e3e6238e386533755257676ad8b4c80be3b159d0904cb637678) +
-SLE-Micro.x86_64-5.5.0-Default-GM.raw.xz (sha256 13243a737ca219bad6a7aa41fa747c06e8b825fef10a756cf4d575f4493ed68b) +
-SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw.xz (sha256 6c2af94e7ac785c8f6a276032c8e6a4b493c294e6cd72809c75089522f01bc93)
-| SUSE Manager | 4.3.11 | N/A | https://www.suse.com/download/suse-manager/[SUSE Manager Download Page]
-s| K3s s| 1.28.9 | N/A | https://github.com/k3s-io/k3s/releases/tag/v1.28.9%2Bk3s1[Upstream K3s Release]
-s| RKE2 s| 1.28.9 | N/A | https://github.com/rancher/rke2/releases/tag/v1.28.9%2Brke2r1[Upstream RKE2 Release]
-s| Rancher Prime s| 2.8.4 s| 2.8.4 | https://github.com/rancher/rancher/releases/download/v2.8.4/rancher-images.txt[Rancher 2.8.4 Images] +
- https://charts.rancher.com/server-charts/prime[Rancher Prime Helm Repo]
-| Longhorn | 1.6.1 | 103.3.0 | https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn-images.txt[Longhorn 1.6.1 Images] +
-https://charts.longhorn.io[Longhorn Helm Repo]
-s| NM Configurator s| 0.3.0 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.0[NMConfigurator Upstream Release]
-| NeuVector| 5.3.2 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.2 +
-registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.2 +
-registry.suse.com/rancher/mirrored-neuvector-manager:5.3.2 +
-registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2 +
-registry.suse.com/rancher mirrored-neuvector-registry-adapter:0.1.1-s1 +
-registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
-registry.suse.com/rancher/mirrored-neuvector-updater:latest
-| Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-controller:1.6.2 +
-registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
-registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.2.6 +
-registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.2.6
-s| Metal^3^ s| 1.16.0 s| 0.7.1 | registry.suse.com/edge/metal3-chart:0.7.1 +
-registry.suse.com/edge/baremetal-operator:0.5.1 +
-registry.suse.com/edge/ip-address-manager:1.6.0 +
-registry.suse.com/edge/ironic:23.0.2.1 +
-registry.suse.com/edge/ironic-ipa-downloader:1.3.2 +
-registry.suse.com/edge/kube-rbac-proxy:v0.14.2 +.1
-registry.suse.com/edge/mariadb:10.6.15.1
-| MetalLB | 0.14.3 | 0.14.3 | registry.suse.com/edge/metallb-chart:0.14.3 +
-registry.suse.com/edge/metallb-controller:v0.14.3 +
-registry.suse.com/edge/metallb-speaker:v0.14.3 +
-registry.suse.com/edge/frr:8.4 +
-registry.suse.com/edge/frr-k8s:v0.0.8
-s| Elemental s| 1.4.4 s| 1.4.4 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
-registry.suse.com/rancher/elemental-operator-crds-chart:1.4.4 +
-registry.suse.com/rancher/elemental-operator:1.4.4
-s| Edge Image Builder s| 1.0.2 | N/A | registry.suse.com/edge/edge-image-builder:1.0.2
-| KubeVirt | 1.1.1 | 0.2.4 | registry.suse.com/edge/kubevirt-chart:0.2.4 +
-registry.suse.com/suse/sles/15.5/virt-operator:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-api:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-controller:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-exportproxy:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-exportserver:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-handler:1.1.1 +
-registry.suse.com/suse/sles/15.5/virt-launcher:1.1.1
-| KubeVirt Dashboard Extension | 1.0.0 | 1.0.0 | registry.suse.com/edge/kubevirt-dashboard-extension-chart:1.0.0
-| Containerized Data Importer | 1.58.0 | 0.2.3 | registry.suse.com/edge/cdi-chart:0.2.3 +
-registry.suse.com/suse/sles/15.5/cdi-operator:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-controller:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-importer:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-cloner:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-apiserver:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-uploadserver:1.58.0 +
-registry.suse.com/suse/sles/15.5/cdi-uploadproxy:1.58.0
-| Endpoint Copier Operator | 0.2.0 | 0.2.0 | registry.suse.com/edge/endpoint-copier-operator:v0.2.0 +
-registry.suse.com/edge/endpoint-copier-operator-chart:0.2.0
-| Akri (Tech Preview) | 0.12.20 | 0.12.20 | registry.suse.com/edge/akri-chart:0.12.20 +
-registry.suse.com/edge/akri-dashboard-extension-chart:1.0.0 +
-registry.suse.com/edge/akri-agent:v0.12.20 +
-registry.suse.com/edge/akri-controller:v0.12.20 +
-registry.suse.com/edge/akri-debug-echo-discovery-handler:v0.12.20 +
-registry.suse.com/edge/akri-onvif-discovery-handler:v0.12.20 +
-registry.suse.com/edge/akri-opcua-discovery-handler:v0.12.20 +
-registry.suse.com/edge/akri-udev-discovery-handler:v0.12.20 +
-registry.suse.com/edge/akri-webhook-configuration:v0.12.20
-s| SR-IOV Network Operator s| 1.2.2 s| 1.2.2+up0.1.0 | registry.suse.com/edge/sriov-network-operator-chart:1.2.2 +
-registry.suse.com/edge/sriov-crd-chart:1.2.2
-|======
-
-= Release 3.0.2
-
-Availability Date: 16th August 2024
-
-Summary: SUSE Edge 3.0.2 is the second z-stream release in the SUSE Edge 3.0 portfolio.
-
-== New Features
-
-* The Metal^3^ chart now supports static network configuration without any `mac-address`: https://github.com/suse-edge/charts/pull/134[SUSE Edge issue #134]
-* Kubevirt is updated from `1.1.1` to `1.2.2` for details of new features refer to the: https://github.com/kubevirt/kubevirt/releases[Upstream Release Notes]
-
-== Bug & Security Fixes
-
-* The Metal^3^ chart fixes an issue where host reprovisioning may use stale static static network configuration: https://github.com/suse-edge/charts/pull/133[SUSE Edge issue #133]
-* The RKE2 Cluster API provider fixes an issue when specifying TLS configuration for a local registry: https://github.com/rancher/cluster-api-provider-rke2/pull/357[RKE2 Provider issue #357]
-* The RKE2 Cluster API provider fixes an issue causing rke2-install to error after system reboot: https://github.com/rancher/cluster-api-provider-rke2/pull/346[RKE2 Provider issue #346]
-* Kubevirt is updated to include several security fixes: https://www.suse.com/support/update/announcement/2024/suse-su-20242669-1[Kubevirt Update]
-
-== Components Versions
-
-The following table describes the individual components that make up the 3.0.2 release, including the version, the Helm chart version (if applicable), and from where the released artifact can be pulled in the binary format. Please follow the associated documentation for usage and deployment examples.
-
-|======
-| Name | Version | Helm Chart Version | Artifact Location (URL/Image)
-| SLE Micro | 5.5 (latest) | N/A | https://www.suse.com/download/sle-micro/[SLE Micro Download Page] +
-SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso (sha256 4f672a4a0f8ec421e7c25797def05598037c56b7f306283566a9f921bdce904a) +
-SLE-Micro.x86_64-5.5.0-Default-RT-SelfInstall-GM2.install.iso (sha256 527a5a7cdbf11e3e6238e386533755257676ad8b4c80be3b159d0904cb637678) +
-SLE-Micro.x86_64-5.5.0-Default-GM.raw.xz (sha256 13243a737ca219bad6a7aa41fa747c06e8b825fef10a756cf4d575f4493ed68b) +
-SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw.xz (sha256 6c2af94e7ac785c8f6a276032c8e6a4b493c294e6cd72809c75089522f01bc93)
-| SUSE Manager | 4.3.11 | N/A | https://www.suse.com/download/suse-manager/[SUSE Manager Download Page]
-s| K3s s| 1.28.10 | N/A | https://github.com/k3s-io/k3s/releases/tag/v1.28.10%2Bk3s1[Upstream K3s Release]
-s| RKE2 s| 1.28.10 | N/A | https://github.com/rancher/rke2/releases/tag/v1.28.10%2Brke2r1[Upstream RKE2 Release]
-s| Rancher Prime s| 2.8.5 s| 2.8.5 | https://github.com/rancher/rancher/releases/download/v2.8.5/rancher-images.txt[Rancher 2.8.5 Images] +
- https://charts.rancher.com/server-charts/prime[Rancher Prime Helm Repo]
-| Longhorn | 1.6.1 | 103.3.0 | https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn-images.txt[Longhorn 1.6.1 Images] +
-https://charts.longhorn.io[Longhorn Helm Repo]
-| NM Configurator | 0.3.0 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.0[NMConfigurator Upstream Release]
-| NeuVector| 5.3.0 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-manager:5.3.0 +
-registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.0 +
-registry.suse.com/rancher mirrored-neuvector-registry-adapter:0.1.1-s1 +
-registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
-registry.suse.com/rancher/mirrored-neuvector-updater:latest
-s| Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-controller:1.6.2 +
-registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
-*registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.4.1* +
-*registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.4.1*
-s| Metal^3^ s| 1.16.0 s| 0.7.3 | registry.suse.com/edge/metal3-chart:0.7.3 +
-registry.suse.com/edge/baremetal-operator:0.5.1 +
-registry.suse.com/edge/ip-address-manager:1.6.0 +
-registry.suse.com/edge/ironic:23.0.2.1 +
-*registry.suse.com/edge/ironic-ipa-downloader:1.3.4* +
-registry.suse.com/edge/kube-rbac-proxy:v0.14.2 +.1
-registry.suse.com/edge/mariadb:10.6.15.1
-| MetalLB | 0.14.3 | 0.14.3 | registry.suse.com/edge/metallb-chart:0.14.3 +
-registry.suse.com/edge/metallb-controller:v0.14.3 +
-registry.suse.com/edge/metallb-speaker:v0.14.3 +
-registry.suse.com/edge/frr:8.4 +
-registry.suse.com/edge/frr-k8s:v0.0.8
-| Elemental | 1.4.4 | 1.4.4 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
-registry.suse.com/rancher/elemental-operator-crds-chart:1.4.4 +
-registry.suse.com/rancher/elemental-operator:1.4.4
-| Edge Image Builder | 1.0.2 | N/A | registry.suse.com/edge/edge-image-builder:1.0.2
-s| KubeVirt s| 1.2.2 s| 0.3.0 s| registry.suse.com/edge/kubevirt-chart:0.3.0 +
-registry.suse.com/suse/sles/15.5/virt-operator:1.2.2 +
-registry.suse.com/suse/sles/15.5/virt-api:1.2.2 +
-registry.suse.com/suse/sles/15.5/virt-controller:1.2.2 +
-registry.suse.com/suse/sles/15.5/virt-exportproxy:1.2.2 +
-registry.suse.com/suse/sles/15.5/virt-exportserver:1.2.2 +
-registry.suse.com/suse/sles/15.5/virt-handler:1.2.2 +
-registry.suse.com/suse/sles/15.5/virt-launcher:1.2.2
-| KubeVirt Dashboard Extension | 1.0.0 | 1.0.0 | registry.suse.com/edge/kubevirt-dashboard-extension-chart:1.0.0
-s| Containerized Data Importer s| 1.59.0 s| 0.3.0 s| registry.suse.com/edge/cdi-chart:0.3.0 +
-registry.suse.com/suse/sles/15.5/cdi-operator:1.59.0 +
-registry.suse.com/suse/sles/15.5/cdi-controller:1.59.0 +
-registry.suse.com/suse/sles/15.5/cdi-importer:1.59.0 +
-registry.suse.com/suse/sles/15.5/cdi-cloner:1.59.0 +
-registry.suse.com/suse/sles/15.5/cdi-apiserver:1.59.0 +
-registry.suse.com/suse/sles/15.5/cdi-uploadserver:1.59.0 +
-registry.suse.com/suse/sles/15.5/cdi-uploadproxy:1.59.0
-| Endpoint Copier Operator | 0.2.0 | 0.2.0 | registry.suse.com/edge/endpoint-copier-operator:v0.2.0 +
-registry.suse.com/edge/endpoint-copier-operator-chart:0.2.0
-| Akri (Tech Preview) | 0.12.20 | 0.12.20 | registry.suse.com/edge/akri-chart:0.12.20 +
-registry.suse.com/edge/akri-dashboard-extension-chart:1.0.0 +
-registry.suse.com/edge/akri-agent:v0.12.20 +
-registry.suse.com/edge/akri-controller:v0.12.20 +
-registry.suse.com/edge/akri-debug-echo-discovery-handler:v0.12.20 +
-registry.suse.com/edge/akri-onvif-discovery-handler:v0.12.20 +
-registry.suse.com/edge/akri-opcua-discovery-handler:v0.12.20 +
-registry.suse.com/edge/akri-udev-discovery-handler:v0.12.20 +
-registry.suse.com/edge/akri-webhook-configuration:v0.12.20
-| SR-IOV Network Operator | 1.2.2 | 1.2.2+up0.1.0 | registry.suse.com/edge/sriov-network-operator-chart:1.2.2 +
-registry.suse.com/edge/sriov-crd-chart:1.2.2
 |======
 
 = Components Verification


### PR DESCRIPTION
In this PR I'm rearranging the order in which we show the z-stream versions in the release notes page so that the newest version is always at the top.