### PR TITLE
elemental quickstart: Fix GM image reference

### DIFF
--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -297,7 +297,7 @@ apiVersion: 1.0
 image:
     imageType: iso
     arch: x86_64
-    baseImage: SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM.install.iso
+    baseImage: SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso
     outputImageName: elemental-image.iso
 operatingSystem:
   users:


### PR DESCRIPTION
This should be GM2 to align with all other references

Fixes: #365