### PR TITLE
Elemental quickstart fixes

### DIFF
--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -32,33 +32,23 @@ The following describes the minimum system and environmental requirements to run
  ** Running SLES 15 SP5, openSUSE Leap 15.5, or another compatible operating system that supports Podman.
  ** With https://kubernetes.io/docs/reference/kubectl/kubectl/[Kubectl], https://podman.io[Podman], and https://helm.sh[Helm] installed
 * A USB flash drive to boot from (if using physical hardware)
+* A downloaded copy of the latest SLE Micro 6.0 SelfInstall "GM" ISO image found https://www.suse.com/download/sle-micro/[here].
 
 NOTE: Existing data found on target machines will be overwritten as part of the process, please make sure you backup any data on any USB storage devices and disks attached to target deployment nodes.
 
 This guide is created using a Digital Ocean droplet to host the upstream cluster and an Intel NUC as the downstream device. For building the installation media, SUSE Linux Enterprise Server is used.
 
-== How to use Elemental
-
-The basic steps to install and use Elemental are:
-
-* <<build-bootstrap-cluster>>
-* <<install-rancher>>
-* <<install-elemental>>
-* <<build-installation-media>>
-* <<boot-downstream-nodes>>
-* <<create-downstream-clusters>>
-
-=== Build bootstrap cluster [[build-bootstrap-cluster]]
+== Build bootstrap cluster [[build-bootstrap-cluster]]
 
 Start by creating a cluster capable of hosting Rancher and Elemental. This cluster needs to be routable from the network that the downstream nodes are connected to.
 
-==== Create Kubernetes cluster
+=== Create Kubernetes cluster
 
 If you are using a hyperscaler (such as Azure, AWS or Google Cloud), the easiest way to set up a cluster is using their built-in tools. For the sake of conciseness in this guide, we do not detail the process of each of these options.
 
 If you are installing onto bare-metal or another hosting service where you need to also provide the Kubernetes distribution itself, we recommend using https://docs.rke2.io/install/quickstart[RKE2].
 
-==== Set up DNS
+=== Set up DNS
 
 Before continuing, you need to set up access to your cluster. As with the setup of the cluster itself, how you configure DNS will be different depending on where it is being hosted.
 
@@ -67,7 +57,7 @@ Before continuing, you need to set up access to your cluster. As with the setup 
 If you do not want to handle setting up DNS records (for example, this is just an ephemeral test server), you can use a service like https://sslip.io[sslip.io] instead. With this service, you can resolve any IP address with `<address>.sslip.io`.
 ====
 
-=== Install Rancher [[install-rancher]]
+== Install Rancher [[install-rancher]]
 
 To install Rancher, you need to get access to the Kubernetes API of the cluster you just created. This looks differently depending on what distribution of Kubernetes is being used.
 
@@ -77,8 +67,7 @@ You may need to edit the file to include the correct externally routable IP addr
 
 Install Rancher easily with the commands from the https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster[Rancher Documentation]:
 
-. Install https://cert-manager.io[cert-manager]:
-+
+Install https://cert-manager.io[cert-manager]:
 [,bash]
 ----
 helm repo add jetstack https://charts.jetstack.io
@@ -88,9 +77,9 @@ helm install cert-manager jetstack/cert-manager \
  --create-namespace \
  --set crds.enabled=true
 ----
-+
-. Then install Rancher itself:
-+
+
+Then install Rancher itself:
+
 [,bash]
 ----
 helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
@@ -111,7 +100,7 @@ If this is intended to be a production system, please use cert-manager to config
 
 Browse to the host name you set up and log in to Rancher with the `bootstrapPassword` you used. You will be guided through a short setup process.
 
-=== Install Elemental [[install-elemental]]
+== Install Elemental [[install-elemental]]
 
 With Rancher installed, you can now install the Elemental operator and required CRD's. The Helm chart for Elemental is published as an OCI artifact so the installation is a little simpler than other charts.
 It can be installed from either the same shell you used to install Rancher or in the browser from within Rancher's shell.
@@ -129,7 +118,7 @@ helm install -n cattle-elemental-system \
  --version 1.6.4
 ----
 
-==== (Optionally) Install the Elemental UI extension
+=== (Optionally) Install the Elemental UI extension
 
 . To use the Elemental UI, log in to your Rancher instance, click the three-dot menu in the upper left:
 +
@@ -151,7 +140,7 @@ image::installing-elemental-extension-4.png[Installing Elemental extension 4]
 +
 image::accessing-elemental-extension.png[Accessing Elemental extension]
 
-==== Configure Elemental
+== Configure Elemental
 
 For simplicity, we recommend setting the variable `$ELEM` to the full path of where you want the configuration directory:
 
@@ -231,7 +220,7 @@ If you clicked away from that screen, you can click "Registration Endpoints" in 
 
 This URL is used in the next step.
 
-=== Build the installation media [[build-installation-media]]
+== Build the image [[build-installation-media]]
 
 While the current version of Elemental has a way to build its own installation media, in SUSE Edge 3.0 we do this with the Edge Image Builder instead, so the resulting system is built with https://www.suse.com/products/micro/[SLE Micro] as the base Operating System.
 
@@ -240,11 +229,12 @@ While the current version of Elemental has a way to build its own installation m
 For more details on the Edge Image Builder, check out the <<quickstart-eib,Getting Started Guide for it>> and also the <<components-eib,Component Documentation>>.
 ====
 
-From a Linux system with Podman installed, run:
+From a Linux system with Podman installed, create the directories and place the base image:
 
 [,bash]
 ----
 mkdir -p $ELEM/eib_quickstart/base-images
+cp /path/to/downloads/SL-Micro.x86_64-6.0-Base-SelfInstall-GM.install.iso $ELEM/eib_quickstart/base-images/
 mkdir -p $ELEM/eib_quickstart/elemental
 ----
 
@@ -292,7 +282,7 @@ If you are booting a physical device, we need to burn the image to a USB flash d
 sudo dd if=/eib_quickstart/elemental-image.iso of=/dev/<PATH_TO_DISK_DEVICE> status=progress
 ----
 
-=== Boot the downstream nodes [[boot-downstream-nodes]]
+== Boot the downstream nodes [[boot-downstream-nodes]]
 
 Now that we have created the installation media, we can boot our downstream nodes with it.
 
@@ -302,7 +292,7 @@ If you are using the UI extension, you should see your node appear in the "Inven
 
 NOTE: Do not remove the installation medium until you've seen the login prompt; during first-boot files are still accessed on the USB stick.
 
-=== Create downstream clusters [[create-downstream-clusters]]
+== Create downstream clusters [[create-downstream-clusters]]
 
 There are two objects we need to create when provisioning a new cluster using Elemental.
 
@@ -405,7 +395,7 @@ elemental-register --label "network=$INET" \
 ----
 ====
 
-== Node Reset
+== Node Reset (Optional)
 
 SUSE Rancher Elemental supports the ability to perform a "node reset" which can optionally trigger when either a whole cluster is deleted from Rancher, a single node is deleted from a cluster, or a node is manually deleted from the machine inventory. This is useful when you want to reset and clean-up any orphaned resources and want to automatically bring the cleaned node back into the machine inventory so it can be reused. This is not enabled by default, and thus any system that is removed, will not be cleaned up (i.e. data will not be removed, and any Kubernetes cluster resources will continue to operate on the downstream clusters) and it will require manual intervention to wipe data and re-register the machine to Rancher via Elemental.
 


### PR DESCRIPTION
* Remove the instructions for Windows which is unsupported platform
* Update the required resources from 3 hosts to 2 hosts. EIB can run on management node. This is to make quickstart simple to lower the entry barrier for first timers
* Add the missing prerequisite of SLE Micro base image
* Bump up the key steps from subsub-sections to sub-sections. This makes the key steps appear on table of content, which improves readability.

Previous table of content:
<img width="211" alt="Screenshot 2024-09-16 at 9 17 23 AM" src="https://github.com/user-attachments/assets/02d4fbc4-dfcd-4940-9656-6e14d892e6dc">

With this update:
<img width="217" alt="new" src="https://github.com/user-attachments/assets/4559f249-31f6-4eaf-8d65-4872b9a23251">