### PR TITLE
changed Longhorn chart location from longhorn.io to rancher.io

### DIFF
--- a/asciidoc/components/longhorn.adoc
+++ b/asciidoc/components/longhorn.adoc
@@ -55,11 +55,11 @@ For additional help installing open-iscsi, refer to the https://longhorn.io/docs
 There are several ways to install Longhorn on your Kubernetes clusters.
 This guide will follow through the Helm installation, however feel free to follow the https://longhorn.io/docs/1.6.1/deploy/install/[official documentation] if another approach is desired.
 
-. Add the Longhorn Helm repository:
+. Add the Rancher Charts Helm repository:
 +
 [,shell]
 ----
-helm repo add longhorn https://charts.longhorn.io
+helm repo add rancher-charts https://charts.rancher.io/
 ----
 +
 . Fetch the latest charts from the repository:
@@ -73,7 +73,7 @@ helm repo update
 +
 [,shell]
 ----
-helm install longhorn longhorn/longhorn --namespace longhorn-system --create-namespace --version 1.6.1
+helm install longhorn rancher-charts/longhorn --namespace longhorn-system --create-namespace --version 104.2.0+up1.7.1
 ----
 +
 . Confirm that the deployment succeeded:
@@ -267,14 +267,14 @@ kubernetes:
   helm:
     charts:
       - name: longhorn
-        version: 1.6.1
+        version: 104.2.0+up1.7.1
         repositoryName: longhorn
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
     repositories:
       - name: longhorn
-        url: https://charts.longhorn.io
+        url: https://charts.rancher.io
 operatingSystem:
   packages:
     sccRegistrationCode: <reg-code>

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -647,7 +647,7 @@ cronjob.batch/neuvector-updater-pod   0 0 * * *   False     0        <none>     
 
 == Longhorn Installation [[longhorn-install]]
 
-The https://longhorn.io/docs/1.6.1/deploy/install/airgap/[official documentation] for Longhorn contains a `longhorn-images.txt` file which lists all the images required for an air-gapped installation.
+The https://longhorn.io/docs/1.7.1/deploy/install/airgap/[official documentation] for Longhorn contains a `longhorn-images.txt` file which lists all the images required for an air-gapped installation.
 We will be including them in our definition file. Let's create it:
 
 [,console]
@@ -667,13 +667,13 @@ kubernetes:
   helm:
     charts:
       - name: longhorn
-        repositoryName: longhorn
+        repositoryName: rancher-charts
         targetNamespace: longhorn-system
         createNamespace: true
-        version: 1.6.1
+        version: 104.2.0+up1.7.1
     repositories:
-      - name: longhorn
-        url: https://charts.longhorn.io
+      - name: rancher-charts
+        url: https://charts.rancher.io
 embeddedArtifactRegistry:
   images:
     - name: longhornio/csi-attacher:v4.4.2


### PR DESCRIPTION
Update the Longhorn charts location to use charts.rancher.io instead of charts.longhorn.io. See our (internal, sorry) Jira ticket EDGE-552.

Note: The upstream PR has landed (https://github.com/rancher/charts/tree/dev-v2.9/charts/longhorn/104.2.0%2Bup1.7.1) but it's not yet available in the registry, so I wasn't able to actually test these changes yet.

This PR does not include:
* Updates to the release notes. I added a comment to #376 that this is the version that will be available in that registry.
* I didn't touch `downstream-cluster-helm.adoc`. There's an entry in there on line 243 that references the old location. I can update this if it's safe; I didn't want to touch the day 2 stuff in case that was in progress and/or needs more information to update properly. Let me know and I'll update that reference too.