### PR TITLE
Remove references to ui-plugin-operator

### DIFF
--- a/asciidoc/demo_setup/elemental-utm-aarch64.adoc
+++ b/asciidoc/demo_setup/elemental-utm-aarch64.adoc
@@ -52,22 +52,10 @@ The trick here is there is no ARM64 image yet, but just a Raspberry Pi one... so
 
 == Elemental UI Rancher extension
 
-This is an optional step to enable the Elemental UI extension in Rancher (see https://ranchermanager.docs.rancher.com/integrations-in-rancher/rancher-extensions[more about Rancher extensions]):
+This is an optional step to enable the Elemental UI extension in Rancher (see https://ranchermanager.docs.rancher.com/v2.9/integrations-in-rancher/rancher-extensions[more about Rancher extensions]):
 
 [,bash]
 ----
-helm repo add rancher-charts https://charts.rancher.io/
-helm upgrade --create-namespace -n cattle-ui-plugin-system \
-  --install ui-plugin-operator rancher-charts/ui-plugin-operator
-helm upgrade --create-namespace -n cattle-ui-plugin-system \
-  --install ui-plugin-operator-crd rancher-charts/ui-plugin-operator-crd
-
-# Wait for the operator to be up
-while ! kubectl wait --for condition=ready -n cattle-ui-plugin-system \
-  $(kubectl get pods -n cattle-ui-plugin-system \
-    -l app.kubernetes.io/instance=ui-plugin-operator -o name) \
-    --timeout=10s; do sleep 2 ; done
-
 # Deploy the elemental UI plugin
 # NOTE: TABs and then spaces...
 cat <<- FOO | kubectl apply -f -

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -303,7 +303,6 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
     - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
     - name: registry.rancher.com/rancher/ui-plugin-catalog:1.4.0
-    - name: registry.rancher.com/rancher/ui-plugin-operator:v0.1.1
     - name: registry.rancher.com/rancher/webhook-receiver:v0.2.5
     - name: registry.rancher.com/rancher/kubectl:v1.20.2
     - name: registry.rancher.com/rancher/shell:v0.1.24

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1235,7 +1235,6 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
     - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
     - name: registry.rancher.com/rancher/ui-plugin-catalog:1.3.0
-    - name: registry.rancher.com/rancher/ui-plugin-operator:v0.1.1
     - name: registry.rancher.com/rancher/webhook-receiver:v0.2.5
     - name: registry.rancher.com/rancher/kubectl:v1.20.2
     - name: registry.rancher.com/rancher/mirrored-longhornio-csi-attacher:v4.4.2


### PR DESCRIPTION
Since Rancher 2.9 the ui-plugin-operator is built in the Rancher Dashboard. The code is deprecated https://github.com/rancher/ui-plugin-operator?tab=readme-ov-file and moved to Rancher dashboard controllers codebase https://github.com/rancher/rancher/tree/release/v2.9/pkg/controllers/dashboard/plugin

This is a follow-up PR to https://github.com/suse-edge/suse-edge.github.io/pull/375