### PR TITLE
atip-requirements: remove ISO reference

### DIFF
--- a/asciidoc/product/atip-requirements.adoc
+++ b/asciidoc/product/atip-requirements.adoc
@@ -64,7 +64,7 @@ Some external services like `DHCP`, `DNS`, etc. could be required depending on t
 
 * **Connected environment**: In this case, the ATIP nodes will be connected to the Internet (via routing L3 protocols) and the external services will be provided by the customer.
 * **Disconnected / air-gap environment**: In this case, the ATIP nodes will not have Internet IP connectivity and additional services will be required to locally mirror content required by the ATIP directed network provisioning workflow.
-* **File server**: A file server is used to store the ISO images to be provisioned on the ATIP nodes during the directed network provisioning workflow. The `metal^3^` Helm chart can deploy a media server to store the ISO images — check the following xref:metal3-media-server[section], but it is also possible to use an existing local webserver.
+* **File server**: A file server is used to store the OS images to be provisioned on the ATIP nodes during the directed network provisioning workflow. The `metal^3^` Helm chart can deploy a media server to store the OS images — check the following xref:metal3-media-server[section], but it is also possible to use an existing local webserver.
 
 === Disabling rebootmgr
 


### PR DESCRIPTION
The downstream cluster nodes can use several formats but it's typically a raw image, not ISO, to remove the ISO reference to avoid confusion

Fixes: #415