### PR TITLE
atip-management-cluster: clarify helm folder usage

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -54,7 +54,7 @@ The following are the main steps to set up the management cluster using a declar
         ** Scripts: Contains the scripts to be used by the management cluster.
   - xref:mgmt-cluster-kubernetes-folder[Kubernetes folder]: The `kubernetes` folder contains the configuration files to be used by the management cluster.
         ** Manifests: Contains the manifests to be used by the management cluster.
-        ** Helm: Contains the Helm charts to be used by the management cluster.
+        ** Helm: Contains the Helm values files to be used by the management cluster.
         ** Config: Contains the configuration files to be used by the management cluster.
   - xref:mgmt-cluster-network-folder[Network folder]: The `network` folder contains the network configuration files to be used by the management cluster nodes.
 


### PR DESCRIPTION
Clarify the folder contains values files, not charts

Fixes: #437