### PR TITLE
rancher-turtles: align with atip examples

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -524,8 +524,8 @@ if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o
 	EOF
 
   # Disable Rancher webhooks for CAPI
-  ${KUBECTL} delete mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
-  ${KUBECTL} delete validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
+  ${KUBECTL} delete --ignore-not-found=true mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
+  ${KUBECTL} delete --ignore-not-found=true validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
   ${KUBECTL} wait --for=delete namespace/cattle-provisioning-capi-system --timeout=300s
 fi
 

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -161,10 +161,20 @@ Cluster API dependencies are managed via the Rancher Turtles Helm chart:
 
 [,bash]
 ----
+cat > values.yaml <<EOF
+rancherTurtles:
+  features:
+    embedded-capi:
+      disabled: true
+    rancher-webhook:
+      cleanup: true
+EOF
+
 helm install \
   rancher-turtles oci://registry.suse.com/edge/3.1/rancher-turtles-chart \
   --namespace rancher-turtles-system \
-  --create-namespace
+  --create-namespace \
+  -f values.yaml
 ----
 
 After some time, the controller pods should be running in the `capi-system`, `capm3-system`, `rke2-bootstrap-system` and `rke2-control-plane-system` namespaces.


### PR DESCRIPTION
In the ATIP EIB flow we align with https://github.com/suse-edge/atip/pull/9

In the metal3 demo interactive flow we have to override some defaults which we changed in the suse-edge wrapper chart to make the rancher-turtles chart install cleanly via EIB when using the RKE2 helm controller, so revert those in the interactive flow (since we expect Rancher to be up and running in that case)