### PR TITLE
longhorn: update longhorn-cli image

### DIFF
--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -580,7 +580,7 @@ embeddedArtifactRegistry:
     - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.7.1
     - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.7.1
     - name: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.42
-    - name: longhornio/longhorn-cli:v1.7.1
+    - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.1
 ----
 
 [NOTE]

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1149,7 +1149,7 @@ embeddedArtifactRegistry:
     - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.7.1
     - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.7.1
     - name: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.42
-    - name: longhornio/longhorn-cli:v1.7.1
+    - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.1
     - name: registry.suse.com/edge/3.1/cluster-api-provider-rke2-bootstrap:v0.7.0
     - name: registry.suse.com/edge/3.1/cluster-api-provider-rke2-controlplane:v0.7.0
     - name: registry.suse.com/edge/3.1/cluster-api-controller:v1.7.5


### PR DESCRIPTION
This is now available via the downstream registry

```
crane ls registry.suse.com/rancher/mirrored-longhornio-longhorn-cli              
v1.7.1
```