### PR TITLE
[release-3.0] Prepare release notes for 3.0.3

### DIFF
--- a/asciidoc/components/longhorn.adoc
+++ b/asciidoc/components/longhorn.adoc
@@ -263,7 +263,7 @@ image:
   arch: x86_64
   outputImageName: eib-image.iso
 kubernetes:
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1
   helm:
     charts:
       - name: longhorn

--- a/asciidoc/components/virtualization.adoc
+++ b/asciidoc/components/virtualization.adoc
@@ -66,9 +66,9 @@ This should show something similar to the following:
 [,shell]
 ----
 NAME                   STATUS   ROLES                       AGE     VERSION
-node1.edge.rdo.wales   Ready    control-plane,etcd,master   4h20m   v1.28.10+rke2r1
-node2.edge.rdo.wales   Ready    control-plane,etcd,master   4h15m   v1.28.10+rke2r1
-node3.edge.rdo.wales   Ready    control-plane,etcd,master   4h15m   v1.28.10+rke2r1
+node1.edge.rdo.wales   Ready    control-plane,etcd,master   4h20m   v1.28.13+rke2r1
+node2.edge.rdo.wales   Ready    control-plane,etcd,master   4h15m   v1.28.13+rke2r1
+node3.edge.rdo.wales   Ready    control-plane,etcd,master   4h15m   v1.28.13+rke2r1
 ----
 
 Now you can proceed to install the *KubeVirt* and *Containerized Data Importer (CDI)* Helm charts:

--- a/asciidoc/day2/downstream-cluster-helm.adoc
+++ b/asciidoc/day2/downstream-cluster-helm.adoc
@@ -525,7 +525,7 @@ kubernetes:
   # - hostname: agent2rke2.example.com
   #   type: agent
   # version depending on the distribution
-  version: v1.28.10+k3s1/v1.28.10+rke2r1
+  version: v1.28.13+k3s1/v1.28.13+rke2r1
   helm:
     charts:
     - name: longhorn

--- a/asciidoc/day2/mgmt-cluster.adoc
+++ b/asciidoc/day2/mgmt-cluster.adoc
@@ -332,20 +332,20 @@ server-version   v2.8.5
 [#day2-mgmt-cluster-eib-helm-chart-upgrade-examples-metal3]
 ===== Metal^3^ upgrade
 
-This example shows how to upgrade Metal^3^ to the `0.7.3` version.
+This example shows how to upgrade Metal^3^ to the `0.7.4` version.
 
 . Pull the latest `Metal^3^` helm chart version:
 +
 [source,bash]
 ----
-helm pull oci://registry.suse.com/edge/metal3-chart --version 0.7.3
+helm pull oci://registry.suse.com/edge/metal3-chart --version 0.7.4
 ----
 
 . Encode `.tgz` archive so that it can be passed to a `HelmChart` CR config:
 +
 [source,bash]
 ----
-base64 -w 0 metal3-chart-0.7.3.tgz  > metal3-chart-0.7.3-encoded.txt
+base64 -w 0 metal3-chart-0.7.4.tgz  > metal3-chart-0.7.4-encoded.txt
 ----
 
 . Make a copy of the `Metal^3^` manifest file that we will edit:
@@ -359,7 +359,7 @@ cp /var/lib/rancher/rke2/server/manifests/metal3.yaml ./metal3.yaml
 +
 [source,bash]
 ----
-sed -i -e "s|chartContent:.*|chartContent: $(<metal3-chart-0.7.3-encoded.txt)|" -e "s|version:.*|version: 0.7.3|" metal3.yaml
+sed -i -e "s|chartContent:.*|chartContent: $(<metal3-chart-0.7.4-encoded.txt)|" -e "s|version:.*|version: 0.7.4|" metal3.yaml
 ----
 +
 [NOTE]
@@ -418,7 +418,7 @@ kubectl get helmchart metal3 -n default
 
 # Example output
 NAME     JOB                   CHART   TARGETNAMESPACE   VERSION   REPO   HELMVERSION   BOOTSTRAP
-metal3   helm-install-metal3           metal3-system     0.7.3
+metal3   helm-install-metal3           metal3-system     0.7.4
 ----
 
 [#day2-mgmt-cluster-helm-chart-upgrade]
@@ -503,7 +503,7 @@ _For additional information on the Rancher helm chart upgrade, check link:https:
 [#day2-mgmt-cluster-helm-chart-upgrade-examples-metal3]
 ===== Metal^3^
 
-This example shows how to upgrade Metal^3^ to the `0.7.3` version.
+This example shows how to upgrade Metal^3^ to the `0.7.4` version.
 
 . Get the values for the current Rancher release and print them to a `rancher-values.yaml` file:
 +
@@ -519,7 +519,7 @@ helm get values metal3 -n metal3-system -o yaml > metal3-values.yaml
 helm upgrade metal3 oci://registry.suse.com/edge/metal3-chart \
   --namespace metal3-system \
   -f metal3-values.yaml \
-  --version=0.7.3
+  --version=0.7.4
 ----
 
 . Verify `Metal^3^` pods are running:
@@ -543,7 +543,7 @@ helm ls -n metal3-system
 
 # Expected output
 NAME    NAMESPACE      REVISION  UPDATED                                  STATUS    CHART         APP VERSION
-metal3  metal3-system  2         2024-06-17 12:43:06.774802846 +0000 UTC  deployed  metal3-0.7.3  1.16.0
+metal3  metal3-system  2         2024-06-17 12:43:06.774802846 +0000 UTC  deployed  metal3-0.7.4  1.16.0
 ----
 
 == Cluster API upgrade

--- a/asciidoc/day2/mgmt-cluster.adoc
+++ b/asciidoc/day2/mgmt-cluster.adoc
@@ -228,7 +228,7 @@ This section offer examples on how to upgrade a:
 To ensure disaster recovery, we advise to do a Rancher backup. For information on how to do this, check link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher[here].
 ====
 
-This example shows how to upgrade Rancher to the `2.8.5` version.
+This example shows how to upgrade Rancher to the `2.8.8` version.
 
 . Add the `Rancher Prime` Helm repository:
 +
@@ -241,14 +241,14 @@ helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
 +
 [source,bash]
 ----
-helm pull rancher-prime/rancher --version=2.8.5
+helm pull rancher-prime/rancher --version=2.8.8
 ----
 
 . Encode `.tgz` archive so that it can be passed to a `HelmChart` CR config:
 +
 [source,bash]
 ----
-base64 -w 0 rancher-2.8.5.tgz  > rancher-2.8.5-encoded.txt
+base64 -w 0 rancher-2.8.8.tgz  > rancher-2.8.8-encoded.txt
 ----
 
 . Make a copy of the `rancher.yaml` file that we will edit:
@@ -262,7 +262,7 @@ cp /var/lib/rancher/rke2/server/manifests/rancher.yaml ./rancher.yaml
 +
 [source,bash]
 ----
-sed -i -e "s|chartContent:.*|chartContent: $(<rancher-2.8.5-encoded.txt)|" -e "s|version:.*|version: 2.8.5|" rancher.yaml
+sed -i -e "s|chartContent:.*|chartContent: $(<rancher-2.8.8-encoded.txt)|" -e "s|version:.*|version: 2.8.8|" rancher.yaml
 ----
 +
 [NOTE]
@@ -326,7 +326,7 @@ kubectl get settings.management.cattle.io server-version
 
 # Example output
 NAME             VALUE
-server-version   v2.8.5
+server-version   v2.8.8
 ----
 
 [#day2-mgmt-cluster-eib-helm-chart-upgrade-examples-metal3]
@@ -467,7 +467,7 @@ This section offer examples on how to upgrade a:
 To ensure disaster recovery, we advise to do a Rancher backup. For information on how to do this, check link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher[here].
 ====
 
-This example shows how to upgrade Rancher to the `2.8.5` version.
+This example shows how to upgrade Rancher to the `2.8.8` version.
 
 . Get the values for the current Rancher release and print them to a `rancher-values.yaml` file:
 +
@@ -483,7 +483,7 @@ helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
 helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   -f rancher-values.yaml \
-  --version=2.8.5
+  --version=2.8.8
 ----
 
 . Verify `Rancher` version upgrade:
@@ -494,7 +494,7 @@ kubectl get settings.management.cattle.io server-version
 
 # Example output
 NAME             VALUE
-server-version   v2.8.5
+server-version   v2.8.8
 ----
 
 _For additional information on the Rancher helm chart upgrade, check link:https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades[here]._

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -28,6 +28,100 @@ However, repeated entries are provided as a courtesy only. Therefore, if you are
 
 NOTE: SUSE Edge z-stream releases are tightly integrated and thoroughly tested as a versioned stack. Upgrade of any individual components to a different versions to those listed above is likely to result in system downtime. While it's possible to run Edge clusters in untested configurations, it is not recommended, and it may take longer to provide resolution through the support channels.
 
+= Release 3.0.3
+
+Availability Date: 15th November 2024
+
+Summary: SUSE Edge 3.0.3 is the third z-stream release in the SUSE Edge 3.0 portfolio.
+
+== Bug & Security Fixes
+
+* The Rancher version is updated to `2.8.8`: https://github.com/rancher/rancher/releases/tag/v2.8.8[Release Notes]
+* The RKE2 version is updated to `1.28.13`: https://docs.rke2.io/release-notes/v1.28.X#release-v12813rke2r1[Release Notes]
+* The K3s version is updated to `1.28.13`:  https://docs.k3s.io/release-notes/v1.28.X#release-v12813k3s1[Release Notes]
+* The Metal^3^ chart fixes an issue where with the handling of the `predictableNicNames` parameter: https://github.com/suse-edge/charts/pull/163[SUSE Edge issue #163]
+* The Metal^3^ chart resolves security issues identified in https://www.cve.org/CVERecord?id=CVE-2024-43803:[CVE-2024-43803]: https://github.com/suse-edge/charts/pull/163[SUSE Edge issue #163]
+* The Metal^3^ chart resolves security issues identified in https://www.cve.org/CVERecord?id=CVE-2024-44082:[CVE-2024-44082]: https://github.com/suse-edge/charts/pull/163[SUSE Edge issue #163]
+
+== Components Versions
+
+The following table describes the individual components that make up the 3.0.3 release, including the version, the Helm chart version (if applicable), and from where the released artifact can be pulled in the binary format. Please follow the associated documentation for usage and deployment examples. Note that items in bold are highlighted changes from the previous z-stream release.
+
+|======
+| Name | Version | Helm Chart Version | Artifact Location (URL/Image)
+| SLE Micro | 5.5 (latest) | N/A | https://www.suse.com/download/sle-micro/[SLE Micro Download Page] +
+SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso (sha256 4f672a4a0f8ec421e7c25797def05598037c56b7f306283566a9f921bdce904a) +
+SLE-Micro.x86_64-5.5.0-Default-RT-SelfInstall-GM2.install.iso (sha256 527a5a7cdbf11e3e6238e386533755257676ad8b4c80be3b159d0904cb637678) +
+SLE-Micro.x86_64-5.5.0-Default-GM.raw.xz (sha256 13243a737ca219bad6a7aa41fa747c06e8b825fef10a756cf4d575f4493ed68b) +
+SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw.xz (sha256 6c2af94e7ac785c8f6a276032c8e6a4b493c294e6cd72809c75089522f01bc93)
+| SUSE Manager | 4.3.11 | N/A | https://www.suse.com/download/suse-manager/[SUSE Manager Download Page]
+s| K3s s| 1.28.13 | N/A | https://github.com/k3s-io/k3s/releases/tag/v1.28.13%2Bk3s1[Upstream K3s Release]
+s| RKE2 s| 1.28.13 | N/A | https://github.com/rancher/rke2/releases/tag/v1.28.13%2Brke2r1[Upstream RKE2 Release]
+s| Rancher Prime s| 2.8.8 s| 2.8.8 | https://github.com/rancher/rancher/releases/download/v2.8.8/rancher-images.txt[Rancher 2.8.8 Images] +
+ https://charts.rancher.com/server-charts/prime[Rancher Prime Helm Repo]
+| Longhorn | 1.6.1 | 103.3.0 | https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn-images.txt[Longhorn 1.6.1 Images] +
+https://charts.longhorn.io[Longhorn Helm Repo]
+| NM Configurator | 0.3.0 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.0[NMConfigurator Upstream Release]
+| NeuVector| 5.3.2 | 103.0.3 | registry.suse.com/rancher/mirrored-neuvector-controller:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-enforcer:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-manager:5.3.2 +
+registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2 +
+registry.suse.com/rancher mirrored-neuvector-registry-adapter:0.1.1-s1 +
+registry.suse.com/rancher/mirrored-neuvector-scanner:latest +
+registry.suse.com/rancher/mirrored-neuvector-updater:latest
+| Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-controller:1.6.2 +
+registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
+registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.4.1 +
+registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.4.1
+s| Metal^3^ s| 1.16.0 s| 0.7.4 | registry.suse.com/edge/metal3-chart:0.7.4 +
+*registry.suse.com/edge/baremetal-operator:0.5.2* +
+registry.suse.com/edge/ip-address-manager:1.6.0 +
+*registry.suse.com/edge/ironic:23.0.3.1* +
+*registry.suse.com/edge/ironic-ipa-downloader:1.3.5* +
+registry.suse.com/edge/kube-rbac-proxy:v0.14.2 +.1
+registry.suse.com/edge/mariadb:10.6.15.1
+| MetalLB | 0.14.3 | 0.14.3 | registry.suse.com/edge/metallb-chart:0.14.3 +
+registry.suse.com/edge/metallb-controller:v0.14.3 +
+registry.suse.com/edge/metallb-speaker:v0.14.3 +
+registry.suse.com/edge/frr:8.4 +
+registry.suse.com/edge/frr-k8s:v0.0.8
+| Elemental | 1.4.4 | 1.4.4 | registry.suse.com/rancher/elemental-operator-chart:1.4.4 +
+registry.suse.com/rancher/elemental-operator-crds-chart:1.4.4 +
+registry.suse.com/rancher/elemental-operator:1.4.4
+| Edge Image Builder | 1.0.2 | N/A | registry.suse.com/edge/edge-image-builder:1.0.2
+| KubeVirt | 1.2.2 | 0.3.0 | registry.suse.com/edge/kubevirt-chart:0.3.0 +
+registry.suse.com/suse/sles/15.5/virt-operator:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-api:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-controller:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-exportproxy:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-exportserver:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-handler:1.2.2 +
+registry.suse.com/suse/sles/15.5/virt-launcher:1.2.2
+| KubeVirt Dashboard Extension | 1.0.0 | 1.0.0 | registry.suse.com/edge/kubevirt-dashboard-extension-chart:1.0.0
+| Containerized Data Importer | 1.59.0 | 0.3.0 | registry.suse.com/edge/cdi-chart:0.3.0 +
+registry.suse.com/suse/sles/15.5/cdi-operator:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-controller:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-importer:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-cloner:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-apiserver:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadserver:1.59.0 +
+registry.suse.com/suse/sles/15.5/cdi-uploadproxy:1.59.0
+| Endpoint Copier Operator | 0.2.0 | 0.2.0 | registry.suse.com/edge/endpoint-copier-operator:v0.2.0 +
+registry.suse.com/edge/endpoint-copier-operator-chart:0.2.0
+| Akri (Tech Preview) | 0.12.20 | 0.12.20 | registry.suse.com/edge/akri-chart:0.12.20 +
+registry.suse.com/edge/akri-dashboard-extension-chart:1.0.0 +
+registry.suse.com/edge/akri-agent:v0.12.20 +
+registry.suse.com/edge/akri-controller:v0.12.20 +
+registry.suse.com/edge/akri-debug-echo-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-onvif-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-opcua-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-udev-discovery-handler:v0.12.20 +
+registry.suse.com/edge/akri-webhook-configuration:v0.12.20
+| SR-IOV Network Operator | 1.2.2 | 1.2.2+up0.1.0 | registry.suse.com/edge/sriov-network-operator-chart:1.2.2 +
+registry.suse.com/edge/sriov-crd-chart:1.2.2
+|======
+
+
 = Release 3.0.2
 
 Availability Date: 16th August 2024

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -73,7 +73,7 @@ registry.suse.com/rancher/mirrored-neuvector-updater:latest
 registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
 registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.4.1 +
 registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.4.1
-s| Metal^3^ s| 1.16.0 s| 0.7.4 | registry.suse.com/edge/metal3-chart:0.7.4 +
+s| Metal^3^ s| 0.7.4 s| 0.7.4 | registry.suse.com/edge/metal3-chart:0.7.4 +
 *registry.suse.com/edge/baremetal-operator:0.5.2* +
 registry.suse.com/edge/ip-address-manager:1.6.0 +
 *registry.suse.com/edge/ironic:23.0.3.1* +
@@ -170,7 +170,7 @@ s| Cluster API (CAPI) | 1.6.2 | N/A | registry.suse.com/edge/cluster-api-control
 registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
 *registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.4.1* +
 *registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.4.1*
-s| Metal^3^ s| 1.16.0 s| 0.7.3 | registry.suse.com/edge/metal3-chart:0.7.3 +
+s| Metal^3^ s| 0.7.3 s| 0.7.3 | registry.suse.com/edge/metal3-chart:0.7.3 +
 registry.suse.com/edge/baremetal-operator:0.5.1 +
 registry.suse.com/edge/ip-address-manager:1.6.0 +
 registry.suse.com/edge/ironic:23.0.2.1 +
@@ -268,7 +268,7 @@ registry.suse.com/rancher/mirrored-neuvector-updater:latest
 registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
 registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.2.6 +
 registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.2.6
-s| Metal^3^ s| 1.16.0 s| 0.7.1 | registry.suse.com/edge/metal3-chart:0.7.1 +
+s| Metal^3^ s| 0.7.1 s| 0.7.1 | registry.suse.com/edge/metal3-chart:0.7.1 +
 registry.suse.com/edge/baremetal-operator:0.5.1 +
 registry.suse.com/edge/ip-address-manager:1.6.0 +
 registry.suse.com/edge/ironic:23.0.2.1 +
@@ -360,7 +360,7 @@ registry.suse.com/rancher/mirrored-neuvector-updater:latest
 registry.suse.com/edge/cluster-api-provider-metal3:1.6.0 +
 registry.suse.com/edge/cluster-api-provider-rke2-bootstrap:0.2.6 +
 registry.suse.com/edge/cluster-api-provider-rke2-controlplane:0.2.6
-| Metal^3^ | 1.16.0 | 0.6.5 | registry.suse.com/edge/metal3-chart:0.6.5 +
+| Metal^3^ | 0.6.5 | 0.6.5 | registry.suse.com/edge/metal3-chart:0.6.5 +
 registry.suse.com/edge/baremetal-operator:0.5.1 +
 registry.suse.com/edge/ip-address-manager:1.6.0 +
 registry.suse.com/edge/ironic:23.0.1.2 +

--- a/asciidoc/edge-book/version-matrix.adoc
+++ b/asciidoc/edge-book/version-matrix.adoc
@@ -17,8 +17,8 @@ endif::[]
 |======
 | Name | Version | Chart Version
 | SLE Micro | 5.5 | N/A
-| Rancher Prime | 2.8.5 | 2.8.5
-| Fleet | 0.9.2 | 0.9.2
+| Rancher Prime | 2.8.8 | 2.8.8
+| Fleet | 0.9.9 | 0.9.9
 | K3s | 1.28.13 | N/A
 | RKE2 | 1.28.13 | N/A
 | Metal^3^ | 1.16.0 | 0.7.4

--- a/asciidoc/edge-book/version-matrix.adoc
+++ b/asciidoc/edge-book/version-matrix.adoc
@@ -19,8 +19,8 @@ endif::[]
 | SLE Micro | 5.5 | N/A
 | Rancher Prime | 2.8.5 | 2.8.5
 | Fleet | 0.9.2 | 0.9.2
-| K3s | 1.28.10 | N/A
-| RKE2 | 1.28.10 | N/A
+| K3s | 1.28.13 | N/A
+| RKE2 | 1.28.13 | N/A
 | Metal^3^ | 1.16.0 | 0.7.3
 | MetalLB | 0.14.3 | 0.14.3
 | Elemental | 1.4.4 | 103.1.0

--- a/asciidoc/edge-book/version-matrix.adoc
+++ b/asciidoc/edge-book/version-matrix.adoc
@@ -21,7 +21,7 @@ endif::[]
 | Fleet | 0.9.2 | 0.9.2
 | K3s | 1.28.13 | N/A
 | RKE2 | 1.28.13 | N/A
-| Metal^3^ | 1.16.0 | 0.7.3
+| Metal^3^ | 1.16.0 | 0.7.4
 | MetalLB | 0.14.3 | 0.14.3
 | Elemental | 1.4.4 | 103.1.0
 | Edge Image Builder | 1.0.2 | N/A

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -243,43 +243,43 @@ kubernetes:
         url:  https://charts.rancher.com/server-charts/prime
 embeddedArtifactRegistry:
   images:
-    - name: registry.rancher.com/rancher/backup-restore-operator:v4.0.2
-    - name: registry.rancher.com/rancher/calico-cni:v3.27.0-rancher1
-    - name: registry.rancher.com/rancher/cis-operator:v1.0.13
+    - name: registry.rancher.com/rancher/backup-restore-operator:v4.0.3
+    - name: registry.rancher.com/rancher/calico-cni:v3.27.4-rancher1
+    - name: registry.rancher.com/rancher/cis-operator:v1.0.15
     - name: registry.rancher.com/rancher/coreos-kube-state-metrics:v1.9.7
     - name: registry.rancher.com/rancher/coreos-prometheus-config-reloader:v0.38.1
     - name: registry.rancher.com/rancher/coreos-prometheus-operator:v0.38.1
     - name: registry.rancher.com/rancher/flannel-cni:v0.3.0-rancher9
-    - name: registry.rancher.com/rancher/fleet-agent:v0.9.5
-    - name: registry.rancher.com/rancher/fleet:v0.9.5
-    - name: registry.rancher.com/rancher/gitjob:v0.9.8
+    - name: registry.rancher.com/rancher/fleet-agent:v0.9.9
+    - name: registry.rancher.com/rancher/fleet:v0.9.9
+    - name: registry.rancher.com/rancher/gitjob:v0.9.13
     - name: registry.rancher.com/rancher/grafana-grafana:7.1.5
     - name: registry.rancher.com/rancher/hardened-addon-resizer:1.8.20-build20240410
-    - name: registry.rancher.com/rancher/hardened-calico:v3.27.3-build20240423
+    - name: registry.rancher.com/rancher/hardened-calico:v3.28.1-build20240806
     - name: registry.rancher.com/rancher/hardened-cluster-autoscaler:v1.8.10-build20240124
-    - name: registry.rancher.com/rancher/hardened-cni-plugins:v1.4.1-build20240325
+    - name: registry.rancher.com/rancher/hardened-cni-plugins:v1.5.1-build20240805
     - name: registry.rancher.com/rancher/hardened-coredns:v1.11.1-build20240305
     - name: registry.rancher.com/rancher/hardened-dns-node-cache:1.22.28-build20240125
-    - name: registry.rancher.com/rancher/hardened-etcd:v3.5.9-k3s1-build20240418
-    - name: registry.rancher.com/rancher/hardened-flannel:v0.25.1-build20240423
+    - name: registry.rancher.com/rancher/hardened-etcd:v3.5.13-k3s1-build20240531
+    - name: registry.rancher.com/rancher/hardened-flannel:v0.25.5-build20240801
     - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
-    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.13-rke2r1-build20240514
-    - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240208
-    - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.14.1-build20230926
-    - name: registry.rancher.com/rancher/hardened-whereabouts:v0.6.3-build20240208
+    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.13-rke2r1-build20240815
+    - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240612
+    - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.15.4-build20240513
+    - name: registry.rancher.com/rancher/hardened-whereabouts:v0.7.0-build20240429
     - name: registry.rancher.com/rancher/helm-project-operator:v0.2.1
     - name: registry.rancher.com/rancher/istio-kubectl:1.5.10
     - name: registry.rancher.com/rancher/jimmidyson-configmap-reload:v0.3.0
     - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.13-k3s1
-    - name: registry.rancher.com/rancher/klipper-helm:v0.8.3-build20240228
-    - name: registry.rancher.com/rancher/klipper-lb:v0.4.7
+    - name: registry.rancher.com/rancher/klipper-helm:v0.8.4-build20240523
+    - name: registry.rancher.com/rancher/klipper-lb:v0.4.9
     - name: registry.rancher.com/rancher/kube-api-auth:v0.2.1
-    - name: registry.rancher.com/rancher/kubectl:v1.28.7
+    - name: registry.rancher.com/rancher/kubectl:v1.28.12
     - name: registry.rancher.com/rancher/library-nginx:1.19.2-alpine
-    - name: registry.rancher.com/rancher/local-path-provisioner:v0.0.26
-    - name: registry.rancher.com/rancher/machine:v0.15.0-rancher112
+    - name: registry.rancher.com/rancher/local-path-provisioner:v0.0.28
+    - name: registry.rancher.com/rancher/machine:v0.15.0-rancher116
     - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.4.4
-    - name: registry.rancher.com/rancher/nginx-ingress-controller:nginx-1.9.6-rancher1
+    - name: registry.rancher.com/rancher/nginx-ingress-controller:v1.10.4-hardened2
     - name: registry.rancher.com/rancher/pause:3.6
     - name: registry.rancher.com/rancher/prom-alertmanager:v0.21.0
     - name: registry.rancher.com/rancher/prom-node-exporter:v1.0.1
@@ -290,23 +290,28 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.3-rancher2-proxy
     - name: registry.rancher.com/rancher/rancher-agent:v2.8.8
     - name: registry.rancher.com/rancher/rancher-csp-adapter:v3.0.1
-    - name: registry.rancher.com/rancher/rancher-webhook:v0.4.7
+    - name: registry.rancher.com/rancher/rancher-webhook:v0.4.11
     - name: registry.rancher.com/rancher/rancher:v2.8.8
-    - name: registry.rancher.com/rancher/rke-tools:v0.1.96
-    - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
+    - name: registry.rancher.com/rancher/rke-tools:v0.1.102
+    - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240515
     - name: registry.rancher.com/rancher/rke2-runtime:v1.28.13-rke2r1
     - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.13-rke2r1
-    - name: registry.rancher.com/rancher/security-scan:v0.2.15
-    - name: registry.rancher.com/rancher/shell:v0.1.25
+    - name: registry.rancher.com/rancher/security-scan:v0.2.17
+    - name: registry.rancher.com/rancher/shell:v0.1.26
     - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.13-k3s1
     - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.13-rke2r1
-    - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
-    - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
-    - name: registry.rancher.com/rancher/ui-plugin-catalog:1.4.0
+    - name: registry.rancher.com/rancher/system-agent:v0.3.9-suc
+    - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.4
+    - name: registry.rancher.com/rancher/ui-plugin-catalog:2.1.0
     - name: registry.rancher.com/rancher/ui-plugin-operator:v0.1.1
     - name: registry.rancher.com/rancher/webhook-receiver:v0.2.5
     - name: registry.rancher.com/rancher/kubectl:v1.20.2
     - name: registry.rancher.com/rancher/shell:v0.1.24
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.1
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20231011-8b53cabe0
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
 ----
 
 As compared to the full list of 602 container images, this slimmed down version only contains 62 which makes the new CRB image only about 7GB.

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -174,7 +174,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1
 embeddedArtifactRegistry:
   images:
     - ...
@@ -184,8 +184,8 @@ The `image` section is required, and it specifies the input image, its architect
 
 The `operatingSystem` section is optional, and contains configuration to enable login on the provisioned systems with the `root/eib` username/password.
 
-The `kubernetes` section is optional, and it defines the Kubernetes type and version. We are going to use Kubernetes 1.28.10 and RKE2 by default.
-Use `kubernetes.version: v1.28.10+k3s1` if K3s is desired instead. Unless explicitly configured via the `kubernetes.nodes` field, all clusters we bootstrap in this guide will be single-node ones.
+The `kubernetes` section is optional, and it defines the Kubernetes type and version. We are going to use Kubernetes 1.28.13 and RKE2 by default.
+Use `kubernetes.version: v1.28.13+k3s1` if K3s is desired instead. Unless explicitly configured via the `kubernetes.nodes` field, all clusters we bootstrap in this guide will be single-node ones.
 
 The `embeddedArtifactRegistry` section will include all images which are only referenced and pulled at runtime for the specific component.
 
@@ -215,7 +215,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1
   network:
     apiVIP: 192.168.100.151
   manifests:
@@ -263,14 +263,14 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/hardened-etcd:v3.5.9-k3s1-build20240418
     - name: registry.rancher.com/rancher/hardened-flannel:v0.25.1-build20240423
     - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
-    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.10-rke2r1-build20240514
+    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.13-rke2r1-build20240514
     - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240208
     - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.14.1-build20230926
     - name: registry.rancher.com/rancher/hardened-whereabouts:v0.6.3-build20240208
     - name: registry.rancher.com/rancher/helm-project-operator:v0.2.1
     - name: registry.rancher.com/rancher/istio-kubectl:1.5.10
     - name: registry.rancher.com/rancher/jimmidyson-configmap-reload:v0.3.0
-    - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.10-k3s1
+    - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.13-k3s1
     - name: registry.rancher.com/rancher/klipper-helm:v0.8.3-build20240228
     - name: registry.rancher.com/rancher/klipper-lb:v0.4.7
     - name: registry.rancher.com/rancher/kube-api-auth:v0.2.1
@@ -294,12 +294,12 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/rancher:v2.8.5
     - name: registry.rancher.com/rancher/rke-tools:v0.1.96
     - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
-    - name: registry.rancher.com/rancher/rke2-runtime:v1.28.10-rke2r1
-    - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.10-rke2r1
+    - name: registry.rancher.com/rancher/rke2-runtime:v1.28.13-rke2r1
+    - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.13-rke2r1
     - name: registry.rancher.com/rancher/security-scan:v0.2.15
     - name: registry.rancher.com/rancher/shell:v0.1.25
-    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.10-k3s1
-    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.10-rke2r1
+    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.13-k3s1
+    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.13-rke2r1
     - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
     - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
     - name: registry.rancher.com/rancher/ui-plugin-catalog:1.4.0
@@ -537,7 +537,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1
   helm:
     charts:
       - name: neuvector-crd
@@ -663,7 +663,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1
   helm:
     charts:
       - name: longhorn
@@ -813,7 +813,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1
   helm:
     charts:
       - name: kubevirt-chart

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -196,7 +196,7 @@ The `embeddedArtifactRegistry` section will include all images which are only re
 The <<components-rancher,Rancher>> deployment that will be demonstrated will be highly slimmed down for demonstration purposes. For your actual deployments, additional artifacts may be necessary depending on your configuration.
 ====
 
-The https://github.com/rancher/rancher/releases/tag/v2.8.5[Rancher v2.8.5] release assets contain a `rancher-images.txt` file which lists all the images required for an air-gapped installation.
+The https://github.com/rancher/rancher/releases/tag/v2.8.8[Rancher v2.8.8] release assets contain a `rancher-images.txt` file which lists all the images required for an air-gapped installation.
 
 There are about 602 container images in total which means that the resulting CRB image would be roughly 28GB+. For our Rancher installation, we will strip down that list to the smallest working configuration. From there, you can add back any images you may need for your deployments.
 
@@ -224,7 +224,7 @@ kubernetes:
   helm:
     charts:
       - name: rancher
-        version: 2.8.5
+        version: 2.8.8
         repositoryName: rancher-prime
         valuesFile: rancher-values.yaml
         targetNamespace: cattle-system
@@ -288,10 +288,10 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/prometheus-federator:v0.3.4
     - name: registry.rancher.com/rancher/pushprox-client:v0.1.3-rancher2-client
     - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.3-rancher2-proxy
-    - name: registry.rancher.com/rancher/rancher-agent:v2.8.5
+    - name: registry.rancher.com/rancher/rancher-agent:v2.8.8
     - name: registry.rancher.com/rancher/rancher-csp-adapter:v3.0.1
     - name: registry.rancher.com/rancher/rancher-webhook:v0.4.7
-    - name: registry.rancher.com/rancher/rancher:v2.8.5
+    - name: registry.rancher.com/rancher/rancher:v2.8.8
     - name: registry.rancher.com/rancher/rke-tools:v0.1.96
     - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
     - name: registry.rancher.com/rancher/rke2-runtime:v1.28.13-rke2r1

--- a/asciidoc/integrations/nvidia-slemicro.adoc
+++ b/asciidoc/integrations/nvidia-slemicro.adoc
@@ -272,7 +272,7 @@ This should show something similar to the following:
 [,shell]
 ----
 NAME       STATUS   ROLES                       AGE   VERSION
-node0001   Ready    control-plane,etcd,master   13d   v1.28.10+rke2r1
+node0001   Ready    control-plane,etcd,master   13d   v1.28.13+rke2r1
 ----
 
 What you should find is that your k3s/rke2 installation has detected the NVIDIA Container Toolkit on the host and auto-configured the NVIDIA runtime integration into `containerd` (the Container Runtime Interface that k3s/rke2 use). Confirm this by checking the containerd `config.toml` file:
@@ -467,7 +467,7 @@ operatingSystem:
       - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
     sccRegistrationCode: <snip>
 kubernetes:
-  version: v1.28.10+k3s1
+  version: v1.28.13+k3s1
   helm:
     charts:
       - name: nvidia-device-plugin

--- a/asciidoc/misc/rke2-selinux.adoc
+++ b/asciidoc/misc/rke2-selinux.adoc
@@ -128,7 +128,7 @@ Install RKE2 Using Install Script
 [,bash]
 ----
 curl -sfL https://get.rke2.io | INSTALL_RKE2_EXEC="server" \
- RKE2_SELINUX=true INSTALL_RKE2_VERSION=v1.28.10+rke2r1 sh -
+ RKE2_SELINUX=true INSTALL_RKE2_VERSION=v1.28.13+rke2r1 sh -
 
 # Enable and Start RKE2
 systemctl enable --now rke2-server.service

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -601,7 +601,7 @@ spec:
 The `RKE2ControlPlane` object specifies the control-plane configuration to be used and the `Metal3MachineTemplate` object specifies the control-plane image to be used.
 Also, it contains the information about the number of replicas to be used (in this case, one) and the `CNI` plug-in to be used (in this case, `Cilium`).
 The agentConfig block contains the `Ignition` format to be used and the `additionalUserData` to be used to configure the `RKE2` node with information like a systemd named `rke2-preinstall.service` to replace automatically the `BAREMETALHOST_UUID` and `node-name` during the provisioning process using the Ironic information.
-The last block of information contains the Kubernetes version to be used. `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.10+rke2r1`).
+The last block of information contains the Kubernetes version to be used. `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.13+rke2r1`).
 
 [,yaml]
 ----
@@ -857,7 +857,7 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
     ** The `storage` block which contains the Helm charts to be used to install the `MetalLB` and the `endpoint-copier-operator`.
     ** The `metalLB` custom resource file with the `IPaddressPool` and the `L2Advertisement` to be used (replacing `$\{EDGE_VIP_ADDRESS\}` with the `VIP` address).
     ** The `endpoint-svc.yaml` file to be used to configure the `kubernetes-vip` service to be used by the `MetalLB` to manage the `VIP` address.
-* The last block of information contains the Kubernetes version to be used. The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.10+rke2r1`).
+* The last block of information contains the Kubernetes version to be used. The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.13+rke2r1`).
 
 [,yaml]
 ----
@@ -1253,7 +1253,7 @@ To make the process clear, the changes required on that block (`RKE2ControlPlane
     ** `cpu-partitioning.service` to enable the isolation cores of the `CPU` (for example, `1-30,33-62`).
     ** `sriov-custom-auto-vfs.service` to install the `sriov` Helm chart, wait until custom resources are created and run the `/var/sriov-auto-filler.sh` to replace the values in the config map `sriov-custom-auto-config` and create the `sriovnetworknodepolicy` to be used by the workloads.
 
-* The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.10+rke2r1`).
+* The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.28.13+rke2r1`).
 
 With all these changes mentioned, the `RKE2ControlPlane` block in the `capi-provisioning-example.yaml` will look like the following:
 

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -38,7 +38,7 @@ helm get values metal3 -n metal3-system -o yaml > metal3-values.yaml
 helm upgrade metal3 suse-edge/metal3 \
   --namespace metal3-system \
   -f metal3-values.yaml \
-  --version=0.7.3
+  --version=0.7.4
 ----
 
 === Downstream cluster upgrades

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -204,7 +204,7 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.8.5
+        version: 2.8.8
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -327,7 +327,7 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.8.5
+        version: 2.8.8
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -1146,7 +1146,7 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.8.5
+        version: 2.8.8
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -1220,10 +1220,10 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/prometheus-federator:v0.3.4
     - name: registry.rancher.com/rancher/pushprox-client:v0.1.0-rancher2-client
     - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.0-rancher2-proxy
-    - name: registry.rancher.com/rancher/rancher-agent:v2.8.5
+    - name: registry.rancher.com/rancher/rancher-agent:v2.8.8
     - name: registry.rancher.com/rancher/rancher-csp-adapter:v3.0.1
     - name: registry.rancher.com/rancher/rancher-webhook:v0.4.5
-    - name: registry.rancher.com/rancher/rancher:v2.8.5
+    - name: registry.rancher.com/rancher/rancher:v2.8.8
     - name: registry.rancher.com/rancher/rke-tools:v0.1.96
     - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
     - name: registry.rancher.com/rancher/rke2-runtime:v1.28.13-rke2r1

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -183,7 +183,7 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.7.3
+        version: 0.7.4
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
@@ -306,7 +306,7 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.7.3
+        version: 0.7.4
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
@@ -1125,7 +1125,7 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.7.3
+        version: 0.7.4
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -355,7 +355,7 @@ kubernetes:
 #     type: server
 ----
 
-where `version` is the version of Kubernetes to be installed. In our case, we are using an RKE2 cluster, so the version must be minor less than 1.29 to be compatible with `Rancher` (for example, `v1.28.10+rke2r1`).
+where `version` is the version of Kubernetes to be installed. In our case, we are using an RKE2 cluster, so the version must be minor less than 1.29 to be compatible with `Rancher` (for example, `v1.28.13+rke2r1`).
 
 The `helm` section contains the list of Helm charts to be installed, the repositories to be used, and the version configuration for all of them.
 
@@ -1195,14 +1195,14 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/hardened-etcd:v3.5.9-k3s1-build20240418
     - name: registry.rancher.com/rancher/hardened-flannel:v0.25.1-build20240423
     - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
-    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.10-rke2r1-build20240416
+    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.13-rke2r1-build20240416
     - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240208
     - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.14.1-build20230926
     - name: registry.rancher.com/rancher/hardened-whereabouts:v0.6.3-build20240208
     - name: registry.rancher.com/rancher/helm-project-operator:v0.2.1
     - name: registry.rancher.com/rancher/istio-kubectl:1.5.10
     - name: registry.rancher.com/rancher/jimmidyson-configmap-reload:v0.3.0
-    - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.10-k3s1
+    - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.13-k3s1
     - name: registry.rancher.com/rancher/klipper-helm:v0.8.3-build20240228
     - name: registry.rancher.com/rancher/klipper-lb:v0.4.7
     - name: registry.rancher.com/rancher/kube-api-auth:v0.2.1
@@ -1226,12 +1226,12 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/rancher:v2.8.5
     - name: registry.rancher.com/rancher/rke-tools:v0.1.96
     - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
-    - name: registry.rancher.com/rancher/rke2-runtime:v1.28.10-rke2r1
-    - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.10-rke2r1
+    - name: registry.rancher.com/rancher/rke2-runtime:v1.28.13-rke2r1
+    - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.13-rke2r1
     - name: registry.rancher.com/rancher/security-scan:v0.2.15
     - name: registry.rancher.com/rancher/shell:v0.1.24
-    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.10-k3s1
-    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.10-rke2r1
+    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.13-k3s1
+    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.13-rke2r1
     - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
     - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
     - name: registry.rancher.com/rancher/ui-plugin-catalog:1.3.0

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1175,69 +1175,75 @@ kubernetes:
 #       type: server
 embeddedArtifactRegistry:
   images:
-    - name: registry.rancher.com/rancher/backup-restore-operator:v4.0.2
-    - name: registry.rancher.com/rancher/calico-cni:v3.27.0-rancher1
-    - name: registry.rancher.com/rancher/cis-operator:v1.0.13
+    - name: registry.rancher.com/rancher/backup-restore-operator:v4.0.3
+    - name: registry.rancher.com/rancher/calico-cni:v3.27.4-rancher1
+    - name: registry.rancher.com/rancher/cis-operator:v1.0.15
     - name: registry.rancher.com/rancher/coreos-kube-state-metrics:v1.9.7
     - name: registry.rancher.com/rancher/coreos-prometheus-config-reloader:v0.38.1
     - name: registry.rancher.com/rancher/coreos-prometheus-operator:v0.38.1
     - name: registry.rancher.com/rancher/flannel-cni:v0.3.0-rancher9
-    - name: registry.rancher.com/rancher/fleet-agent:v0.9.4
-    - name: registry.rancher.com/rancher/fleet:v0.9.4
-    - name: registry.rancher.com/rancher/gitjob:v0.9.7
+    - name: registry.rancher.com/rancher/fleet-agent:v0.9.9
+    - name: registry.rancher.com/rancher/fleet:v0.9.9
+    - name: registry.rancher.com/rancher/gitjob:v0.9.13
     - name: registry.rancher.com/rancher/grafana-grafana:7.1.5
     - name: registry.rancher.com/rancher/hardened-addon-resizer:1.8.20-build20240410
-    - name: registry.rancher.com/rancher/hardened-calico:v3.27.3-build20240423
+    - name: registry.rancher.com/rancher/hardened-calico:v3.28.1-build20240806
     - name: registry.rancher.com/rancher/hardened-cluster-autoscaler:v1.8.10-build20240124
-    - name: registry.rancher.com/rancher/hardened-cni-plugins:v1.4.1-build20240325
+    - name: registry.rancher.com/rancher/hardened-cni-plugins:v1.5.1-build20240805
     - name: registry.rancher.com/rancher/hardened-coredns:v1.11.1-build20240305
     - name: registry.rancher.com/rancher/hardened-dns-node-cache:1.22.28-build20240125
-    - name: registry.rancher.com/rancher/hardened-etcd:v3.5.9-k3s1-build20240418
-    - name: registry.rancher.com/rancher/hardened-flannel:v0.25.1-build20240423
+    - name: registry.rancher.com/rancher/hardened-etcd:v3.5.13-k3s1-build20240531
+    - name: registry.rancher.com/rancher/hardened-flannel:v0.25.5-build20240801
     - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
-    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.13-rke2r1-build20240416
-    - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240208
-    - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.14.1-build20230926
-    - name: registry.rancher.com/rancher/hardened-whereabouts:v0.6.3-build20240208
+    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.28.13-rke2r1-build20240815
+    - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240612
+    - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.15.4-build20240513
+    - name: registry.rancher.com/rancher/hardened-whereabouts:v0.7.0-build20240429
     - name: registry.rancher.com/rancher/helm-project-operator:v0.2.1
     - name: registry.rancher.com/rancher/istio-kubectl:1.5.10
     - name: registry.rancher.com/rancher/jimmidyson-configmap-reload:v0.3.0
     - name: registry.rancher.com/rancher/k3s-upgrade:v1.28.13-k3s1
-    - name: registry.rancher.com/rancher/klipper-helm:v0.8.3-build20240228
-    - name: registry.rancher.com/rancher/klipper-lb:v0.4.7
+    - name: registry.rancher.com/rancher/klipper-helm:v0.8.4-build20240523
+    - name: registry.rancher.com/rancher/klipper-lb:v0.4.9
     - name: registry.rancher.com/rancher/kube-api-auth:v0.2.1
-    - name: registry.rancher.com/rancher/kubectl:v1.28.7
+    - name: registry.rancher.com/rancher/kubectl:v1.28.12
     - name: registry.rancher.com/rancher/library-nginx:1.19.2-alpine
-    - name: registry.rancher.com/rancher/local-path-provisioner:v0.0.26
-    - name: registry.rancher.com/rancher/machine:v0.15.0-rancher112
+    - name: registry.rancher.com/rancher/local-path-provisioner:v0.0.28
+    - name: registry.rancher.com/rancher/machine:v0.15.0-rancher116
     - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.4.4
-    - name: registry.rancher.com/rancher/nginx-ingress-controller:nginx-1.9.6-rancher1
+    - name: registry.rancher.com/rancher/nginx-ingress-controller:v1.10.4-hardened2
     - name: registry.rancher.com/rancher/pause:3.6
     - name: registry.rancher.com/rancher/prom-alertmanager:v0.21.0
     - name: registry.rancher.com/rancher/prom-node-exporter:v1.0.1
     - name: registry.rancher.com/rancher/prom-prometheus:v2.18.2
     - name: registry.rancher.com/rancher/prometheus-auth:v0.2.2
     - name: registry.rancher.com/rancher/prometheus-federator:v0.3.4
-    - name: registry.rancher.com/rancher/pushprox-client:v0.1.0-rancher2-client
-    - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.0-rancher2-proxy
+    - name: registry.rancher.com/rancher/pushprox-client:v0.1.3-rancher2-client
+    - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.3-rancher2-proxy
     - name: registry.rancher.com/rancher/rancher-agent:v2.8.8
     - name: registry.rancher.com/rancher/rancher-csp-adapter:v3.0.1
-    - name: registry.rancher.com/rancher/rancher-webhook:v0.4.5
+    - name: registry.rancher.com/rancher/rancher-webhook:v0.4.11
     - name: registry.rancher.com/rancher/rancher:v2.8.8
-    - name: registry.rancher.com/rancher/rke-tools:v0.1.96
-    - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240412
+    - name: registry.rancher.com/rancher/rke-tools:v0.1.102
+    - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240515
     - name: registry.rancher.com/rancher/rke2-runtime:v1.28.13-rke2r1
     - name: registry.rancher.com/rancher/rke2-upgrade:v1.28.13-rke2r1
-    - name: registry.rancher.com/rancher/security-scan:v0.2.15
-    - name: registry.rancher.com/rancher/shell:v0.1.24
+    - name: registry.rancher.com/rancher/security-scan:v0.2.17
+    - name: registry.rancher.com/rancher/shell:v0.1.26
     - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.28.13-k3s1
     - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.28.13-rke2r1
-    - name: registry.rancher.com/rancher/system-agent:v0.3.6-suc
-    - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.1
-    - name: registry.rancher.com/rancher/ui-plugin-catalog:1.3.0
+    - name: registry.rancher.com/rancher/system-agent:v0.3.9-suc
+    - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.4
+    - name: registry.rancher.com/rancher/ui-plugin-catalog:2.1.0
     - name: registry.rancher.com/rancher/ui-plugin-operator:v0.1.1
     - name: registry.rancher.com/rancher/webhook-receiver:v0.2.5
     - name: registry.rancher.com/rancher/kubectl:v1.20.2
+    - name: registry.rancher.com/rancher/shell:v0.1.24
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.1
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20231011-8b53cabe0
+    - name: registry.rancher.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
     - name: registry.rancher.com/rancher/mirrored-longhornio-csi-attacher:v4.4.2
     - name: registry.rancher.com/rancher/mirrored-longhornio-csi-provisioner:v3.6.2
     - name: registry.rancher.com/rancher/mirrored-longhornio-csi-resizer:v1.9.2

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -203,7 +203,7 @@ In this next example, we're going to take our existing image definition and will
 [,yaml]
 ----
 kubernetes:
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1
   manifests:
     urls:
       - https://k8s.io/examples/application/nginx-app.yaml
@@ -236,7 +236,7 @@ operatingSystem:
     additionalRepos:
       - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
 kubernetes:
-  version: v1.28.10+rke2r1
+  version: v1.28.13+rke2r1
   manifests:
     urls:
       - https://k8s.io/examples/application/nginx-app.yaml

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -101,7 +101,7 @@ helm install rancher rancher-prime/rancher \
   --set hostname=<DNS or sslip from above> \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN> \
-  --version 2.8.5
+  --version 2.8.8
 ----
 
 [NOTE]

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -357,7 +357,7 @@ metadata:
   name: location-123
   namespace: fleet-default
 spec:
-  kubernetesVersion: v1.28.10+k3s1
+  kubernetesVersion: v1.28.13+k3s1
   rkeConfig:
     machinePools:
       - name: pool1
@@ -380,7 +380,7 @@ The UI extension allows for a few shortcuts to be taken. Note that managing mult
 . As before, open the left three-dot menu and select "OS Management." This brings you back to the main screen for managing your Elemental systems.
 . On the left sidebar, click "Inventory of Machines." This opens the inventory of machines that have registered.
 . To create a cluster from these machines, select the systems you want, click the "Actions" drop-down list, then "Create Elemental Cluster." This opens the Cluster Creation dialog while also creating a MachineSelectorTemplate to use in the background.
-. On this screen, configure the cluster you want to be built. For this quick start, K3s v1.28.10+k3s1 is selected and the rest of the options are left as is.
+. On this screen, configure the cluster you want to be built. For this quick start, K3s v1.28.13+k3s1 is selected and the rest of the options are left as is.
 +
 [TIP]
 ====

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -557,7 +557,7 @@ spec:
                 ExecStartPost=/bin/sh -c "umount /mnt"
                 [Install]
                 WantedBy=multi-user.target
-    version: v1.28.10+rke2r1
+    version: v1.28.13+rke2r1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
@@ -650,7 +650,7 @@ spec:
         kind: Metal3MachineTemplate
         name: sample-cluster-workers
       nodeDrainTimeout: 0s
-      version: v1.28.10+rke2r1
+      version: v1.28.13+rke2r1
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: RKE2ConfigTemplate
@@ -662,7 +662,7 @@ spec:
     spec:
       agentConfig:
         format: ignition
-        version: v1.28.10+rke2r1
+        version: v1.28.13+rke2r1
         kubelet:
           extraArgs:
             - provider-id=metal3://BAREMETALHOST_UUID


### PR DESCRIPTION
Prepare release notes and related version bumps for the planned 3.0.3 release.

Note this is proposed directly to release-3.0 since main now only contains 3.1.x release information