### PR TITLE
Fixing the broken links

### DIFF
--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -515,7 +515,7 @@ kube-system   job.batch/helm-install-rke2-snapshot-controller-crd       1/1     
 kube-system   job.batch/helm-install-rke2-snapshot-validation-webhook   1/1           60s        8m14s
 ----
 
-And when we go to `https://192.168.100.50.sslip.io` and log in with the `adminadminadmin` password that we set earlier, we are greeted with the Rancher dashboard:
+And when we go to `\https://192.168.100.50.sslip.io` and log in with the `adminadminadmin` password that we set earlier, we are greeted with the Rancher dashboard:
 
 image::air-gapped-rancher.png[]
 

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -854,7 +854,7 @@ spec:
 
 The `kubernetes/helm/values` folder contains the following files:
 
-- `rancher.yaml`: contains the configuration to create the `Rancher` component. The `$\{INGRESS_VIP\}` must be set properly to define the IP address to be consumed by the `Rancher` component. The URL to access the `Rancher` component will be `https://rancher-$\{INGRESS_VIP\}.sslip.io`.
+- `rancher.yaml`: contains the configuration to create the `Rancher` component. The `$\{INGRESS_VIP\}` must be set properly to define the IP address to be consumed by the `Rancher` component. The URL to access the `Rancher` component will be `\https://rancher-$\{INGRESS_VIP\}.sslip.io`.
 +
 [,yaml]
 ----


### PR DESCRIPTION
Edited the hyperlinks in the following sections:
1. Air-gapped deployments with Edge Image Builder -  sub section: Setting up the management cluster
2. Setting up the management cluster  - sub section: Custom folder