### PR TITLE
Introduced version attributes to the documentation - Part 1

### DIFF
--- a/asciidoc/components/edge-image-builder.adoc
+++ b/asciidoc/components/edge-image-builder.adoc
@@ -36,7 +36,7 @@ SUSE Edge uses EIB for the simplified and quick configuration of customized SLE 
 
 == Getting started
 
-Comprehensive documentation for the usage and testing of Edge Image Builder can be found https://github.com/suse-edge/edge-image-builder/tree/release-1.1/docs[here].
+Comprehensive documentation for the usage and testing of Edge Image Builder can be found {link-eib-docs}[here].
 
 Additionally, here is a <<quickstart-eib,quick start guide>> for Edge Image Builder covering a basic deployment scenario.
 

--- a/asciidoc/components/metal3.adoc
+++ b/asciidoc/components/metal3.adoc
@@ -20,7 +20,7 @@ which support management via out-of-band protocols such as https://www.dmtf.org/
 It also has mature support for https://cluster-api.sigs.k8s.io/[Cluster API (CAPI)] which enables management
 of infrastructure resources across multiple infrastructure providers via broadly adopted vendor-neutral APIs.
 
-== How does SUSE Edge use Metal3?
+== How does SUSE Edge use Metal^3^?
 
 This method is useful for scenarios where the target hardware supports out-of-band management, and a fully automated
 infrastructure management flow is desired.

--- a/asciidoc/components/networking.adoc
+++ b/asciidoc/components/networking.adoc
@@ -20,7 +20,7 @@ NetworkManager is a tool that manages the primary network connection and other c
 NetworkManager stores network configurations as connection files that contain the desired state.
 These connections are stored as files in the `/etc/NetworkManager/system-connections/` directory.
 
-Details about NetworkManager can be found in the https://documentation.suse.com/sle-micro/6.0/html/Micro-network-configuration/index.html[SLE Micro documentation].
+Details about NetworkManager can be found in the {link-micro-networkmanager}[SLE Micro documentation].
 
 == Overview of nmstate
 
@@ -54,15 +54,15 @@ If you're following this guide, it's assumed that you've got the following alrea
 
 * An x86_64 physical host (or virtual machine) running SLES 15 SP6 or openSUSE Leap 15.6
 * An available container runtime (e.g. Podman)
-* A copy of the SL Micro 6.0 RAW image found https://www.suse.com/download/sle-micro/[here]
+* A copy of the SL Micro {version-operatingsystem} RAW image found https://www.suse.com/download/sle-micro/[here]
 
 === Getting the Edge Image Builder container image
 
 The EIB container image is publicly available and can be downloaded from the SUSE Edge registry by running:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-podman pull registry.suse.com/edge/3.1/edge-image-builder:1.1.0
+podman pull registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib}
 ----
 
 === Creating the image configuration directory [[image-config-dir-creation]]
@@ -77,19 +77,19 @@ mkdir -p $CONFIG_DIR/base-images
 
 We will now ensure that the downloaded base image copy is moved over to the configuration directory:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-mv /path/to/downloads/SL-Micro.x86_64-6.0-Base-GM2.raw $CONFIG_DIR/base-images/
+mv /path/to/downloads/{micro-base-image} $CONFIG_DIR/base-images/
 ----
 
-> NOTE: EIB is never going to modify the base image input.
+> NOTE: EIB is never going to modify the base image input. It will create a new image with its modifications.
 
 The configuration directory at this point should look like the following:
 
-[,console]
+[,console,subs="attributes"]
 ----
 └── base-images/
-    └── SL-Micro.x86_64-6.0-Base-GM2.raw
+    └── {micro-base-image}
 ----
 
 === Creating the image definition file
@@ -98,14 +98,14 @@ The definition file describes the majority of configurable options that the Edge
 
 Let's start with a very basic definition file for our OS image:
 
-[,shell]
+[,shell,subs="attributes,specialchars"]
 ----
 cat << EOF > $CONFIG_DIR/definition.yaml
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   arch: x86_64
   imageType: raw
-  baseImage: SL-Micro.x86_64-6.0-Base-GM2.raw
+  baseImage: {micro-base-image}
   outputImageName: modified-image.raw
 operatingSystem:
   users:
@@ -121,11 +121,11 @@ The `operatingSystem` section is optional, and contains configuration to enable 
 
 The configuration directory at this point should look like the following:
 
-[,console]
+[,console,subs="attributes"]
 ----
 ├── definition.yaml
 └── base-images/
-    └── SL-Micro.x86_64-6.0-Base-GM2.raw
+    └── {micro-base-image}
 ----
 
 === Defining the network configurations [[default-network-definition]]
@@ -337,7 +337,7 @@ EOF
 
 The configuration directory at this point should look like the following:
 
-[,console]
+[,console,subs="attributes"]
 ----
 ├── definition.yaml
 ├── network/
@@ -345,7 +345,7 @@ The configuration directory at this point should look like the following:
 │   │── node2.suse.com.yaml
 │   └── node3.suse.com.yaml
 └── base-images/
-    └── SL-Micro.x86_64-6.0-Base-GM2.raw
+    └── {micro-base-image}
 ----
 
 > NOTE: The names of the files under the `network/` directory are intentional.
@@ -355,9 +355,9 @@ They correspond to the hostnames which will be set during the provisioning proce
 
 Now that all the necessary configurations are in place, we can build the image by simply running:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/3.1/edge-image-builder:1.1.0 build --definition-file definition.yaml
+podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} build --definition-file definition.yaml
 ----
 
 The output should be similar to the following:
@@ -740,9 +740,9 @@ EOF
 
 Let's build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/3.1/edge-image-builder:1.1.0 build --definition-file definition.yaml
+podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} build --definition-file definition.yaml
 ----
 
 Once the image is successfully built, let's create a virtual machine using it:
@@ -924,7 +924,7 @@ It is NOT possible to configure a network by working with both static configurat
 
 The configuration directory at this point should look like the following:
 
-[,console]
+[,console,subs="attributes"]
 ----
 ├── definition.yaml
 ├── custom/
@@ -933,14 +933,14 @@ The configuration directory at this point should look like the following:
 ├── network/
 │   └── configure-network.sh
 └── base-images/
-    └── SL-Micro.x86_64-6.0-Base-GM2.raw
+    └── {micro-base-image}
 ----
 
 Let's build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/3.1/edge-image-builder:1.1.0 build --definition-file definition.yaml
+podman run --rm -it -v $CONFIG_DIR:/eib registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} build --definition-file definition.yaml
 ----
 
 Once the image is successfully built, let's create a virtual machine using it:

--- a/asciidoc/components/rancher-dashboard-extensions.adoc
+++ b/asciidoc/components/rancher-dashboard-extensions.adoc
@@ -13,11 +13,11 @@ endif::[]
 
 Extensions allow users, developers, partners, and customers to extend and enhance the Rancher UI. SUSE Edge 3.1 provides KubeVirt and Akri dashboard extensions.
 
-See `https://ranchermanager.docs.rancher.com/v2.9/integrations-in-rancher/rancher-extensions[Rancher documentation]` for general information about Rancher Dashboard Extensions.
+See `{link-rancher-extensions}[Rancher documentation]` for general information about Rancher Dashboard Extensions.
 
 == Installation
 
-All SUSE Edge 3.1 components including dashboard extensions are distributed as OCI artifacts. To install SUSE Edge Extensions you can use Rancher Dashboard UI, Helm or Fleet:
+All of the SUSE Edge {version-edge} components, including dashboard extensions, are distributed as OCI artifacts. To install SUSE Edge Extensions you can use Rancher Dashboard UI, Helm or Fleet:
 
 === Installing with Rancher Dashboard UI
 
@@ -30,10 +30,10 @@ Each extension is distributed via it's own OCI artefact. Therefore, you need to 
 . In the form, specify the repository name and OCI artifact URL, and click `Create`.
 +
 Akri Dashboard Extension Repository URL:
-`oci://registry.suse.com/edge/3.1/akri-dashboard-extension-chart`
+`oci://registry.suse.com/edge/{version-edge-chart-repo}/akri-dashboard-extension-chart`
 +
 KubeVirt Dashboard Extension Repository URL:
-`oci://registry.suse.com/edge/3.1/kubevirt-dashboard-extension-chart`
+`oci://registry.suse.com/edge/{version-edge-chart-repo}/kubevirt-dashboard-extension-chart`
 +
 image::dashboard-extensions-create-oci-repository.png[]
 
@@ -55,13 +55,13 @@ Once the extension is installed Rancher UI prompts to reload the page as describ
 
 === Installing with Helm
 
-[,bash]
+[,bash,subs="attributes"]
 ----
 # KubeVirt extension
-helm install kubevirt-dashboard-extension oci://registry.suse.com/edge/3.1/kubevirt-dashboard-extension-chart --version 1.1.0 --namespace cattle-ui-plugin-system
+helm install kubevirt-dashboard-extension oci://registry.suse.com/edge/{version-edge-chart-repo}/kubevirt-dashboard-extension-chart --version {version-kubevirt-dashboard-extension-chart} --namespace cattle-ui-plugin-system
 
 # Akri extension
-helm install akri-dashboard-extension oci://registry.suse.com/edge/3.1/akri-dashboard-extension-chart --version 1.1.0 --namespace cattle-ui-plugin-system
+helm install akri-dashboard-extension oci://registry.suse.com/edge/{version-edge-chart-repo}/akri-dashboard-extension-chart --version {version-akri-dashboard-extension-chart} --namespace cattle-ui-plugin-system
 ----
 
 [NOTE]
@@ -78,24 +78,24 @@ After an extension is installed, Rancher Dashboard UI needs to be reloaded.
 
 Installing Dashboard Extensions with Fleet requires defining a `gitRepo` resource which points to a Git repository with custom `fleet.yaml` bundle configuration file(s).
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 # KubeVirt extension fleet.yaml
 defaultNamespace: cattle-ui-plugin-system
 helm:
   releaseName: kubevirt-dashboard-extension
-  chart: oci://registry.suse.com/edge/3.1/kubevirt-dashboard-extension-chart
-  version: "1.1.0"
+  chart: oci://registry.suse.com/edge/{version-edge-chart-repo}/kubevirt-dashboard-extension-chart
+  version: "{version-kubevirt-dashboard-extension-chart}"
 ----
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 # Akri extension fleet.yaml
 defaultNamespace: cattle-ui-plugin-system
 helm:
   releaseName: akri-dashboard-extension
-  chart: oci://registry.suse.com/edge/3.1/akri-dashboard-extension-chart
-  version: "1.1.0"
+  chart: oci://registry.suse.com/edge/{version-edge-chart-repo}/akri-dashboard-extension-chart
+  version: "{version-akri-dashboard-extension-chart}"
 ----
 
 [NOTE]

--- a/asciidoc/components/rancher-dashboard-extensions.adoc
+++ b/asciidoc/components/rancher-dashboard-extensions.adoc
@@ -30,10 +30,10 @@ Each extension is distributed via it's own OCI artefact. Therefore, you need to 
 . In the form, specify the repository name and OCI artifact URL, and click `Create`.
 +
 Akri Dashboard Extension Repository URL:
-`oci://registry.suse.com/edge/{version-edge-chart-repo}/akri-dashboard-extension-chart`
+`oci://registry.suse.com/edge/{version-edge-registry}/akri-dashboard-extension-chart`
 +
 KubeVirt Dashboard Extension Repository URL:
-`oci://registry.suse.com/edge/{version-edge-chart-repo}/kubevirt-dashboard-extension-chart`
+`oci://registry.suse.com/edge/{version-edge-registry}/kubevirt-dashboard-extension-chart`
 +
 image::dashboard-extensions-create-oci-repository.png[]
 
@@ -58,10 +58,10 @@ Once the extension is installed Rancher UI prompts to reload the page as describ
 [,bash,subs="attributes"]
 ----
 # KubeVirt extension
-helm install kubevirt-dashboard-extension oci://registry.suse.com/edge/{version-edge-chart-repo}/kubevirt-dashboard-extension-chart --version {version-kubevirt-dashboard-extension-chart} --namespace cattle-ui-plugin-system
+helm install kubevirt-dashboard-extension oci://registry.suse.com/edge/{version-edge-registry}/kubevirt-dashboard-extension-chart --version {version-kubevirt-dashboard-extension-chart} --namespace cattle-ui-plugin-system
 
 # Akri extension
-helm install akri-dashboard-extension oci://registry.suse.com/edge/{version-edge-chart-repo}/akri-dashboard-extension-chart --version {version-akri-dashboard-extension-chart} --namespace cattle-ui-plugin-system
+helm install akri-dashboard-extension oci://registry.suse.com/edge/{version-edge-registry}/akri-dashboard-extension-chart --version {version-akri-dashboard-extension-chart} --namespace cattle-ui-plugin-system
 ----
 
 [NOTE]
@@ -84,7 +84,7 @@ Installing Dashboard Extensions with Fleet requires defining a `gitRepo` resourc
 defaultNamespace: cattle-ui-plugin-system
 helm:
   releaseName: kubevirt-dashboard-extension
-  chart: oci://registry.suse.com/edge/{version-edge-chart-repo}/kubevirt-dashboard-extension-chart
+  chart: oci://registry.suse.com/edge/{version-edge-registry}/kubevirt-dashboard-extension-chart
   version: "{version-kubevirt-dashboard-extension-chart}"
 ----
 
@@ -94,7 +94,7 @@ helm:
 defaultNamespace: cattle-ui-plugin-system
 helm:
   releaseName: akri-dashboard-extension
-  chart: oci://registry.suse.com/edge/{version-edge-chart-repo}/akri-dashboard-extension-chart
+  chart: oci://registry.suse.com/edge/{version-edge-registry}/akri-dashboard-extension-chart
   version: "{version-akri-dashboard-extension-chart}"
 ----
 

--- a/asciidoc/components/sle-micro.adoc
+++ b/asciidoc/components/sle-micro.adoc
@@ -12,7 +12,7 @@ ifdef::env-github[]
 endif::[]
 
 
-See https://documentation.suse.com/sle-micro/6.0/[SLE Micro official documentation]
+See {link-micro-official-docs}[SLE Micro official documentation]
 
 [quote]
 ____

--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -14,7 +14,6 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-include::./globals.adoc[]
 include::./versions.adoc[]
 
 [preface]

--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -5,7 +5,6 @@
 //:doctype: book
 //:partnum:
 
-
 ifdef::env-github[]
 :imagesdir: ../images/
 :tip-caption: :bulb:
@@ -14,6 +13,9 @@ ifdef::env-github[]
 :caution-caption: :fire:
 :warning-caption: :warning:
 endif::[]
+
+include::./globals.adoc[]
+include::./versions.adoc[]
 
 [preface]
 include::./welcome.adoc[leveloffset=+1]

--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -15,6 +15,7 @@ ifdef::env-github[]
 endif::[]
 
 include::./versions.adoc[]
+include::./links.adoc[]
 
 [preface]
 include::./welcome.adoc[leveloffset=+1]

--- a/asciidoc/edge-book/globals.adoc
+++ b/asciidoc/edge-book/globals.adoc
@@ -1,1 +1,0 @@
-:micro-base-image: SL-Micro.x86_64-6.0-Base-GM2.raw

--- a/asciidoc/edge-book/globals.adoc
+++ b/asciidoc/edge-book/globals.adoc
@@ -1,0 +1,1 @@
+:micro-base-image: SL-Micro.x86_64-6.0-Base-GM2.raw

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -1,0 +1,5 @@
+// The following are links tied to a particular version of a component (i.e. EIB, Rancher)
+// Rather than derive them based on the version number, these are kept separate so they
+// can be verified to not have broken in the new version documentation.
+
+:link-rancher-extensions: https://ranchermanager.docs.rancher.com/v2.9/integrations-in-rancher/rancher-extensions

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -3,3 +3,10 @@
 // can be verified to not have broken in the new version documentation.
 
 :link-rancher-extensions: https://ranchermanager.docs.rancher.com/v2.9/integrations-in-rancher/rancher-extensions
+
+:eib-release-tag: release-1.1
+:link-eib-full-example: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/pkg/image/testdata/full-valid-example.yaml
+:link-eib-building-images: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/building-images.md
+:link-eib-installing-packages: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/installing-packages.md
+:link-eib-debugging: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/debugging.md
+:link-eib-testing: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/testing-guide.md

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -13,3 +13,4 @@
 :link-eib-testing: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/testing-guide.md
 
 :link-micro-official-docs: https://documentation.suse.com/sle-micro/6.0/
+:link-micro-networkmanager: https://documentation.suse.com/sle-micro/6.0/html/Micro-network-configuration/index.html

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -5,6 +5,7 @@
 :link-rancher-extensions: https://ranchermanager.docs.rancher.com/v2.9/integrations-in-rancher/rancher-extensions
 
 :eib-release-tag: release-1.1
+:link-eib-docs: https://github.com/suse-edge/edge-image-builder/tree/{eib-release-tag}/docs
 :link-eib-full-example: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/pkg/image/testdata/full-valid-example.yaml
 :link-eib-building-images: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/building-images.md
 :link-eib-installing-packages: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/installing-packages.md

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -10,3 +10,5 @@
 :link-eib-installing-packages: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/installing-packages.md
 :link-eib-debugging: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/debugging.md
 :link-eib-testing: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/testing-guide.md
+
+:link-micro-official-docs: https://documentation.suse.com/sle-micro/6.0/

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -1,8 +1,8 @@
 :version-edge: 3.2.0
-:version-edge-charts: 3.2
+:version-edge-chart-repo: 3.2
 
 :version-eib: 1.1.0
-:version-rancher-prime: 2.9.3
+:version-rancher-chart-prime: 2.9.3
 
 :micro-base-image: SL-Micro.x86_64-6.0-Base-GM2.raw
 
@@ -13,22 +13,22 @@
 
 :version-operatingsystem: 6.0
 
-:version-rancher: v2.9.3
-:version-longhorn: 104.2.0+up1.7.1
-:version-longhorn-crd: 104.2.0+up1.7.1
-:version-metallb: 0.14.9
-:version-cdi: 0.4.0
-:version-kubevirt: 0.4.0
-:version-kubevirt-dashboard-extension: 1.1.0
-:version-neuvector: 104.0.2+up2.8.0
-:version-neuvector-crd: 104.0.2+up2.8.0
-:version-neuvector-ui-ext: 2.0.0
-:version-endpoint-copier-operator: 0.2.1
-:version-elemental-operator: 1.6.4
-:version-elemental-operator-crds: 1.6.4
-:version-sriov-network-operator: 1.3.0
-:version-sriov-crd: 1.3.0
-:version-akri: 0.12.20
-:version-akri-dashboard-extension: 1.1.0
-:version-metal3: 0.8.3
+:version-rancher-chart: v2.9.3
+:version-longhorn-chart: 104.2.0+up1.7.1
+:version-longhorn-crd-chart: 104.2.0+up1.7.1
+:version-metallb-chart: 0.14.9
+:version-cdi-chart: 0.4.0
+:version-kubevirt-chart: 0.4.0
+:version-kubevirt-dashboard-extension-chart: 1.1.0
+:version-neuvector-chart: 104.0.2+up2.8.0
+:version-neuvector-crd-chart: 104.0.2+up2.8.0
+:version-neuvector-dashboard-extension-chart: 2.0.0
+:version-endpoint-copier-operator-chart: 0.2.1
+:version-elemental-operator-chart: 1.6.4
+:version-elemental-operator-crds-chart: 1.6.4
+:version-sriov-network-operator-chart: 1.3.0
+:version-sriov-crd-chart: 1.3.0
+:version-akri-chart: 0.12.20
+:version-akri-dashboard-extension-chart: 1.1.0
+:version-metal3-chart: 0.8.3
 :version-rancher-turtles: 0.3.3

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -1,0 +1,29 @@
+:version-edge: 3.2.0
+:version-edge-charts: 3.2
+
+:version-kubernetes-k3s: v1.30.5+k3s1
+:version-kubernetes-rke2: v1.30.5+rke2r1
+
+:version-operatingsystem: 6.0
+
+:version-rancher: v2.9.3
+:version-longhorn: 104.2.0+up1.7.1
+:version-longhorn-crd: 104.2.0+up1.7.1
+:version-metallb: 0.14.9
+:version-cdi: 0.4.0
+:version-kubevirt: 0.4.0
+:version-kubevirt-dashboard-extension: 1.1.0
+:version-neuvector: 104.0.2+up2.8.0
+:version-neuvector-crd: 104.0.2+up2.8.0
+:version-neuvector-ui-ext: 2.0.0
+:version-endpoint-copier-operator: 0.2.1
+:version-elemetal-operator: 1.6.4
+:version-elemental-operator-crds: 1.6.4
+:version-sriov-network-operator: 1.3.0
+:version-sriov-crd: 1.3.0
+:version-akri: 0.12.20
+:version-akri-dashboard-extension: 1.1.0
+:version-metal3: 0.8.3
+:version-rancher-turtles: 0.3.3
+
+:version-eib: 1.1.0

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -1,12 +1,17 @@
-:version-edge: 3.2.0
-:version-edge-chart-repo: 3.2
+:version-edge: 3.1.0
+:version-edge-chart-repo: 3.1
 
 :version-eib: 1.1.0
+// Used for links to upstream docs pinned to a release
+:version-eib-release-tag: release-1.1
+:version-eib-api-latest: 1.1
+
 :version-rancher-chart-prime: 2.9.3
 
 :micro-base-image: SL-Micro.x86_64-6.0-Base-GM2.raw
 
 // Release Manifest Versions
+// The following are derived from the `releaseName` field of the release manifest
 
 :version-kubernetes-k3s: v1.30.5+k3s1
 :version-kubernetes-rke2: v1.30.5+rke2r1

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -1,5 +1,5 @@
 :version-edge: 3.1.0
-:version-edge-chart-repo: 3.1
+:version-edge-registry: 3.1
 
 :version-eib: 1.1.0
 :version-eib-api-latest: 1.1

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -1,6 +1,13 @@
 :version-edge: 3.2.0
 :version-edge-charts: 3.2
 
+:version-eib: 1.1.0
+:version-rancher-prime: 2.9.3
+
+:micro-base-image: SL-Micro.x86_64-6.0-Base-GM2.raw
+
+// Release Manifest Versions
+
 :version-kubernetes-k3s: v1.30.5+k3s1
 :version-kubernetes-rke2: v1.30.5+rke2r1
 
@@ -17,7 +24,7 @@
 :version-neuvector-crd: 104.0.2+up2.8.0
 :version-neuvector-ui-ext: 2.0.0
 :version-endpoint-copier-operator: 0.2.1
-:version-elemetal-operator: 1.6.4
+:version-elemental-operator: 1.6.4
 :version-elemental-operator-crds: 1.6.4
 :version-sriov-network-operator: 1.3.0
 :version-sriov-crd: 1.3.0
@@ -25,5 +32,3 @@
 :version-akri-dashboard-extension: 1.1.0
 :version-metal3: 0.8.3
 :version-rancher-turtles: 0.3.3
-
-:version-eib: 1.1.0

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -2,8 +2,6 @@
 :version-edge-chart-repo: 3.1
 
 :version-eib: 1.1.0
-// Used for links to upstream docs pinned to a release
-:version-eib-release-tag: release-1.1
 :version-eib-api-latest: 1.1
 
 :version-rancher-chart-prime: 2.9.3

--- a/asciidoc/edge-book/welcome.adoc
+++ b/asciidoc/edge-book/welcome.adoc
@@ -1,4 +1,4 @@
-= SUSE Edge Documentation
+= SUSE Edge {version-edge} Documentation
 
 ifdef::env-github[]
 :imagesdir: ../images/

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -35,7 +35,7 @@ The EIB container image is publicly available and can be downloaded from the SUS
 
 [,shell,subs="attributes"]
 ----
-podman pull registry.suse.com/edge/{version-edge-chart-repo}/edge-image-builder:{version-eib}
+podman pull registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib}
 ----
 
 == Creating the image configuration directory
@@ -220,7 +220,7 @@ kubernetes:
         repositoryName: suse-edge
     repositories:
       - name: suse-edge
-        url: oci://registry.suse.com/edge/{version-edge-chart-repo}
+        url: oci://registry.suse.com/edge/{version-edge-registry}
 ----
 
 The resulting full definition file should now look like:
@@ -253,7 +253,7 @@ kubernetes:
         repositoryName: suse-edge
     repositories:
       - name: suse-edge
-        url: oci://registry.suse.com/edge/{version-edge-chart-repo}
+        url: oci://registry.suse.com/edge/{version-edge-registry}
 ----
 
 [NOTE]
@@ -338,7 +338,7 @@ Now that we've got a base image and an image definition for EIB to consume, let'
 [,bash,subs="attributes"]
 ----
 podman run --rm -it --privileged -v $CONFIG_DIR:/eib \
-registry.suse.com/edge/{version-edge-chart-repo}/edge-image-builder:{version-eib} \
+registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
 build --definition-file iso-definition.yaml
 ----
 

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -72,7 +72,7 @@ The configuration directory at this point should look like the following:
 [#quickstart-eib-definition-file]
 == Creating the image definition file
 
-The definition file describes the majority of configurable options that the Edge Image Builder supports, a full example of options can be found https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/pkg/image/testdata/full-valid-example.yaml[here], and we would recommend that you take a look at the https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/docs/building-images.md[upstream building images guide] for more comprehensive examples than the one we're going to run through below. Let's start with a very basic definition file for our OS image:
+The definition file describes the majority of configurable options that the Edge Image Builder supports, a full example of options can be found {link-eib-full-example}[here], and we would recommend that you take a look at the {link-eib-building-images}[upstream building images guide] for more comprehensive examples than the one we're going to run through below. Let's start with a very basic definition file for our OS image:
 
 [,console,subs="attributes,specialchars"]
 ----
@@ -133,7 +133,7 @@ operatingSystem:
 
 [NOTE]
 ====
-It's also possible to add additional users, create the home directories, set user-id's, add ssh-key authentication, and modify group information. Please refer to the https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/docs/building-images.md[upstream building images guide] for further examples.
+It's also possible to add additional users, create the home directories, set user-id's, add ssh-key authentication, and modify group information. Please refer to the {link-eib-building-images}[upstream building images guide] for further examples.
 ====
 
 === Configuring RPM packages
@@ -195,7 +195,7 @@ Adding in additional RPM's via this method is meant for the addition of supporte
 
 [NOTE]
 ====
-A more comprehensive guide with additional examples can be found in the https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/docs/installing-packages.md[upstream installing packages guide].
+A more comprehensive guide with additional examples can be found in the {link-eib-installing-packages}[upstream installing packages guide].
 ====
 
 === Configuring Kubernetes cluster and user workloads
@@ -258,7 +258,7 @@ kubernetes:
 
 [NOTE]
 ====
-Further examples of options such as multi-node deployments, custom networking, and Helm chart options/values can be found in the https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/docs/building-images.md#kubernetes[upstream documentation].
+Further examples of options such as multi-node deployments, custom networking, and Helm chart options/values can be found in the {link-eib-building-images}[upstream documentation].
 ====
 
 [#quickstart-eib-network]
@@ -494,9 +494,9 @@ At this point, you should have a ready-to-use image that will:
 [#quickstart-eib-image-debug]
 == Debugging the image build process
 
-If the image build process fails, refer to the https://github.com/suse-edge/edge-image-builder/blob/release-1.1/docs/debugging.md[upstream debugging guide].
+If the image build process fails, refer to the {link-eib-debugging}[upstream debugging guide].
 
 [#quickstart-eib-image-test]
 == Testing your newly built image
 
-For instructions on how to test the newly built CRB image, refer to the https://github.com/suse-edge/edge-image-builder/blob/release-1.1/docs/testing-guide.md[upstream image testing guide].
+For instructions on how to test the newly built CRB image, refer to the {link-eib-testing}[upstream image testing guide].

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -18,7 +18,7 @@ For more information, read the <<components-eib,Edge Image Builder Introduction>
 [WARNING]
 ====
 Edge Image Builder v1.1 supports customizing SUSE Linux Micro 6.0 images.
-Older versions e.g. SUSE Linux Enterprise Micro 5.5 are not supported.
+Older versions, such as SUSE Linux Enterprise Micro 5.5, are not supported.
 ====
 
 == Prerequisites
@@ -33,9 +33,9 @@ NOTE: Other operating systems may function so long as a compatible container run
 
 The EIB container image is publicly available and can be downloaded from the SUSE Edge registry by running the following command on your image build host:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-podman pull registry.suse.com/edge/3.1/edge-image-builder:1.1.0
+podman pull registry.suse.com/edge/{version-edge-chart-repo}/edge-image-builder:{version-eib}
 ----
 
 == Creating the image configuration directory
@@ -50,9 +50,9 @@ mkdir -p $CONFIG_DIR/base-images
 
 In the previous step we created a "base-images" directory that will host the SLE Micro 6.0 input image, let's ensure that the downloaded image is copied over to the configuration directory:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-cp /path/to/downloads/SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso $CONFIG_DIR/base-images/slemicro.iso
+cp /path/to/downloads/{micro-base-image} $CONFIG_DIR/base-images/slemicro.iso
 ----
 
 
@@ -72,12 +72,12 @@ The configuration directory at this point should look like the following:
 [#quickstart-eib-definition-file]
 == Creating the image definition file
 
-The definition file describes the majority of configurable options that the Edge Image Builder supports, a full example of options can be found https://github.com/suse-edge/edge-image-builder/blob/release-1.1/pkg/image/testdata/full-valid-example.yaml[here], and we would recommend that you take a look at the https://github.com/suse-edge/edge-image-builder/blob/release-1.1/docs/building-images.md[upstream building images guide] for more comprehensive examples than the one we're going to run through below. Let's start with a very basic definition file for our OS image:
+The definition file describes the majority of configurable options that the Edge Image Builder supports, a full example of options can be found https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/pkg/image/testdata/full-valid-example.yaml[here], and we would recommend that you take a look at the https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/docs/building-images.md[upstream building images guide] for more comprehensive examples than the one we're going to run through below. Let's start with a very basic definition file for our OS image:
 
-[,console]
+[,console,subs="attributes,specialchars"]
 ----
 cat << EOF > $CONFIG_DIR/iso-definition.yaml
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -117,9 +117,9 @@ $6$G392FCbxVgnLaFw1$Ujt00mdpJ3tDHxEg1snBU3GjujQf6f8kvopu7jiCBIhRbRvMmKUqwcmXAKgg
 
 We can then add a section in the definition file called `operatingSystem` with a `users` array inside it. The resulting file should look like:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -133,7 +133,7 @@ operatingSystem:
 
 [NOTE]
 ====
-It's also possible to add additional users, create the home directories, set user-id's, add ssh-key authentication, and modify group information. Please refer to the https://github.com/suse-edge/edge-image-builder/blob/release-1.1/docs/building-images.md[upstream building images guide] for further examples.
+It's also possible to add additional users, create the home directories, set user-id's, add ssh-key authentication, and modify group information. Please refer to the https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/docs/building-images.md[upstream building images guide] for further examples.
 ====
 
 === Configuring RPM packages
@@ -159,11 +159,11 @@ As a simple example to demonstrate this, we are going to install the `nvidia-con
       - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
 ----
 
-The resulting definition file looks like:
+The resulting definition file looks like the following:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -195,38 +195,38 @@ Adding in additional RPM's via this method is meant for the addition of supporte
 
 [NOTE]
 ====
-A more comprehensive guide with additional examples can be found in the https://github.com/suse-edge/edge-image-builder/blob/release-1.1/docs/installing-packages.md[upstream installing packages guide].
+A more comprehensive guide with additional examples can be found in the https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/docs/installing-packages.md[upstream installing packages guide].
 ====
 
 === Configuring Kubernetes cluster and user workloads
 
-Another feature of EIB is the ability to use it to automate the deployment of both single-node and multi-node highly-available Kubernetes clusters that "bootstrap in place", i.e. don't require any form of centralized management infrastructure to coordinate. The primary driver behind this approach is for air-gapped deployments, or network restricted environments, but it also serves as a way of quickly bootstrapping standalone clusters, even if full and unrestricted network access is available.
+Another feature of EIB is the ability to use it to automate the deployment of both single-node and multi-node highly-available Kubernetes clusters that "bootstrap in place" (i.e. don't require any form of centralized management infrastructure to coordinate). The primary driver behind this approach is for air-gapped deployments, or network restricted environments, but it also serves as a way of quickly bootstrapping standalone clusters, even if full and unrestricted network access is available.
 
 This method enables not only the deployment of the customized operating system, but also the ability to specify Kubernetes configuration, any additional layered components via Helm charts, and any user workloads via supplied Kubernetes manifests. However, the design principle behind using this method is that we default to assuming that the user is wanting to air-gap and therefore any items specified in the image definition will be pulled into the image, which includes user-supplied workloads, where EIB will make sure that any discovered images that are required by definitions supplied are copied locally, and are served by the embedded image registry in the resulting deployed system.
 
 In this next example, we're going to take our existing image definition and will specify a Kubernetes configuration (in this example it doesn't list the systems and their roles, so we default to assuming single-node), which will instruct EIB to provision a single-node RKE2 Kubernetes cluster. To show the automation of both the deployment of both user-supplied workloads (via manifest) and layered components (via Helm), we are going to install KubeVirt via the SUSE Edge Helm chart, as well as NGINX via a Kubernetes manifest. The additional configuration we need to append to the existing image definition is as follows:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 kubernetes:
-  version: v1.30.5+rke2r1
+  version: {version-kubernetes-rke2}
   manifests:
     urls:
       - https://k8s.io/examples/application/nginx-app.yaml
   helm:
     charts:
       - name: kubevirt-chart
-        version: 0.4.0
+        version: {version-kubevirt-chart}
         repositoryName: suse-edge
     repositories:
       - name: suse-edge
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/{version-edge-chart-repo}
 ----
 
 The resulting full definition file should now look like:
-[,yaml]
+[,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -242,23 +242,23 @@ operatingSystem:
     additionalRepos:
       - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
 kubernetes:
-  version: v1.30.5+rke2r1
+  version: {version-kubernetes-k3s}
   manifests:
     urls:
       - https://k8s.io/examples/application/nginx-app.yaml
   helm:
     charts:
       - name: kubevirt-chart
-        version: 0.4.0
+        version: {version-kubevirt-chart}
         repositoryName: suse-edge
     repositories:
       - name: suse-edge
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/{version-edge-chart-repo}
 ----
 
 [NOTE]
 ====
-Further examples of options such as multi-node deployments, custom networking, and Helm chart options/values can be found in the https://github.com/suse-edge/edge-image-builder/blob/release-1.1/docs/building-images.md#kubernetes[upstream documentation].
+Further examples of options such as multi-node deployments, custom networking, and Helm chart options/values can be found in the https://github.com/suse-edge/edge-image-builder/blob/{version-eib-release-tag}/docs/building-images.md#kubernetes[upstream documentation].
 ====
 
 [#quickstart-eib-network]
@@ -335,10 +335,10 @@ Please refer to the <<components-nmc, Edge Networking component>> for a more com
 
 Now that we've got a base image and an image definition for EIB to consume, let's go ahead and build the image. For this, we simply use `podman` to call the EIB container with the "build" command, specifying the definition file:
 
-[,bash]
+[,bash,subs="attributes"]
 ----
 podman run --rm -it --privileged -v $CONFIG_DIR:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/{version-edge-chart-repo}/edge-image-builder:{version-eib} \
 build --definition-file iso-definition.yaml
 ----
 
@@ -482,7 +482,7 @@ If the build fails, `eib-build.log` is the first log that contains information. 
 
 At this point, you should have a ready-to-use image that will:
 
-1. Deploy SLE Micro 6.0
+1. Deploy SLE Micro {version-operatingsystem}
 2. Configure the root password
 3. Install the `nvidia-container-toolkit` package
 4. Configure an embedded container registry to serve content locally

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -90,7 +90,7 @@ helm install rancher rancher-prime/rancher \
   --set hostname=<DNS or sslip from above> \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN> \
-  --version {version-rancher-prime}
+  --version {version-rancher-chart-prime}
 ----
 
 [NOTE]
@@ -110,12 +110,12 @@ It can be installed from either the same shell you used to install Rancher or in
 helm install --create-namespace -n cattle-elemental-system \
  elemental-operator-crds \
  oci://registry.suse.com/rancher/elemental-operator-crds-chart \
- --version {version-elemental-operator-crds}
+ --version {version-elemental-operator-crds-chart}
  
 helm install -n cattle-elemental-system \
  elemental-operator \
  oci://registry.suse.com/rancher/elemental-operator-chart \
- --version {version-elemental-operator}
+ --version {version-elemental-operator-chart}
 ----
 
 === (Optionally) Install the Elemental UI extension
@@ -271,7 +271,7 @@ EOF
 [,bash,subs="attributes"]
 ----
 podman run --privileged --rm -it -v $ELEM/eib_quickstart/:/eib \
- registry.suse.com/edge/{version-edge-charts}/edge-image-builder:{version-eib} \
+ registry.suse.com/edge/{version-edge-chart-repo}/edge-image-builder:{version-eib} \
  build --definition-file eib-config.yaml
 ----
 

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -271,7 +271,7 @@ EOF
 [,bash,subs="attributes"]
 ----
 podman run --privileged --rm -it -v $ELEM/eib_quickstart/:/eib \
- registry.suse.com/edge/{version-edge-chart-repo}/edge-image-builder:{version-eib} \
+ registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
  build --definition-file eib-config.yaml
 ----
 

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -32,7 +32,7 @@ The following describes the minimum system and environmental requirements to run
  ** Running SLES 15 SP6, openSUSE Leap 15.6, or another compatible operating system that supports Podman.
  ** With https://kubernetes.io/docs/reference/kubectl/kubectl/[Kubectl], https://podman.io[Podman], and https://helm.sh[Helm] installed
 * A USB flash drive to boot from (if using physical hardware)
-* A downloaded copy of the latest SLE Micro 6.0 SelfInstall "GM2" ISO image found https://www.suse.com/download/sle-micro/[here].
+* A downloaded copy of the latest SLE Micro {version-operatingsystem} SelfInstall "GM2" ISO image found https://www.suse.com/download/sle-micro/[here].
 
 NOTE: Existing data found on target machines will be overwritten as part of the process, please make sure you backup any data on any USB storage devices and disks attached to target deployment nodes.
 
@@ -80,7 +80,7 @@ helm install cert-manager jetstack/cert-manager \
 
 Then install Rancher itself:
 
-[,bash]
+[,bash,subs="attributes,specialchars"]
 ----
 helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
 helm repo update
@@ -90,7 +90,7 @@ helm install rancher rancher-prime/rancher \
   --set hostname=<DNS or sslip from above> \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN> \
-  --version 2.9.3
+  --version {version-rancher-prime}
 ----
 
 [NOTE]
@@ -105,17 +105,17 @@ Browse to the host name you set up and log in to Rancher with the `bootstrapPass
 With Rancher installed, you can now install the Elemental operator and required CRD's. The Helm chart for Elemental is published as an OCI artifact so the installation is a little simpler than other charts.
 It can be installed from either the same shell you used to install Rancher or in the browser from within Rancher's shell.
 
-[,bash]
+[,bash,subs="attributes"]
 ----
 helm install --create-namespace -n cattle-elemental-system \
  elemental-operator-crds \
  oci://registry.suse.com/rancher/elemental-operator-crds-chart \
- --version 1.6.4
+ --version {version-elemental-operator-crds}
  
 helm install -n cattle-elemental-system \
  elemental-operator \
  oci://registry.suse.com/rancher/elemental-operator-chart \
- --version 1.6.4
+ --version {version-elemental-operator}
 ----
 
 === (Optionally) Install the Elemental UI extension
@@ -222,7 +222,7 @@ This URL is used in the next step.
 
 == Build the image [[build-installation-media]]
 
-While the current version of Elemental has a way to build its own installation media, in SUSE Edge 3.1 we do this with the Edge Image Builder instead, so the resulting system is built with https://www.suse.com/products/micro/[SLE Micro] as the base Operating System.
+While the current version of Elemental has a way to build its own installation media, in SUSE Edge {version-edge} we do this with the Edge Image Builder instead, so the resulting system is built with https://www.suse.com/products/micro/[SLE Micro] as the base Operating System.
 
 [TIP]
 ====
@@ -243,14 +243,14 @@ mkdir -p $ELEM/eib_quickstart/elemental
 curl $REGISURL -o $ELEM/eib_quickstart/elemental/elemental_config.yaml
 ----
 
-[,bash]
+[,bash,subs="attributes,specialchars"]
 ----
 cat << EOF > $ELEM/eib_quickstart/eib-config.yaml
 apiVersion: 1.0
 image:
     imageType: iso
     arch: x86_64
-    baseImage: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
+    baseImage: {micro-base-image}
     outputImageName: elemental-image.iso
 operatingSystem:
   isoConfiguration:
@@ -268,10 +268,10 @@ EOF
 * The installation device will be wiped during the installation.
 ====
 
-[,bash]
+[,bash,subs="attributes"]
 ----
 podman run --privileged --rm -it -v $ELEM/eib_quickstart/:/eib \
- registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+ registry.suse.com/edge/{version-edge-charts}/edge-image-builder:{version-eib} \
  build --definition-file eib-config.yaml
 ----
 
@@ -338,7 +338,7 @@ kubectl label MachineInventory -n fleet-default \
 +
 . Create a simple single-node K3s cluster resource and apply it to the cluster:
 +
-[,bash]
+[,bash,subs="attributes,specialchars"]
 ----
 cat << EOF > $ELEM/cluster.yaml
 apiVersion: provisioning.cattle.io/v1
@@ -347,7 +347,7 @@ metadata:
   name: location-123
   namespace: fleet-default
 spec:
-  kubernetesVersion: v1.30.5+k3s1
+  kubernetesVersion: {version-kubernetes-k3s}
   rkeConfig:
     machinePools:
       - name: pool1

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -89,7 +89,7 @@ TIP: If the management cluster is a single node, the requirement for an addition
 [,bash,subs="attributes"]
 ----
 helm install \
-  metallb oci://registry.suse.com/edge/{version-edge-chart-repo}/metallb-chart \
+  metallb oci://registry.suse.com/edge/{version-edge-registry}/metallb-chart \
   --namespace metallb-system \
   --create-namespace
 ----
@@ -136,7 +136,7 @@ EOF
 [,bash,subs="attributes"]
 ----
 helm install \
-  metal3 oci://registry.suse.com/edge/{version-edge-chart-repo}/metal3-chart \
+  metal3 oci://registry.suse.com/edge/{version-edge-registry}/metal3-chart \
   --namespace metal3-system \
   --create-namespace \
   --set global.ironicIP="$STATIC_IRONIC_IP"
@@ -171,7 +171,7 @@ rancherTurtles:
 EOF
 
 helm install \
-  rancher-turtles oci://registry.suse.com/edge/{version-edge-chart-repo}/rancher-turtles-chart \
+  rancher-turtles oci://registry.suse.com/edge/{version-edge-registry}/rancher-turtles-chart \
   --namespace rancher-turtles-system \
   --create-namespace \
   -f values.yaml
@@ -281,7 +281,7 @@ Once the directory structure is prepared following the previous sections, run th
 [,shell,subs="attributes"]
 ----
 podman run --rm --privileged -it -v $PWD:/eib \
- registry.suse.com/edge/{version-edge-chart-repo}/edge-image-builder:{version-eib} \
+ registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
  build --definition-file downstream-cluster-config.yaml
 ----
 

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -50,7 +50,7 @@ Some tools are required, these can be installed either on the management cluster
 * https://kubernetes.io/docs/reference/kubectl/kubectl/[Kubectl], https://helm.sh[Helm] and https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl[Clusterctl]
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop]
 
-The `SL-Micro.x86_64-6.0-Base-GM2.raw.xz` OS image file must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
+The `{micro-base-image}` OS image file must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
 
 === Setup Management Cluster
 
@@ -86,10 +86,10 @@ TIP: If the management cluster is a single node, the requirement for an addition
 
 . First, we install MetalLB:
 +
-[,bash]
+[,bash,subs="attributes"]
 ----
 helm install \
-  metallb oci://registry.suse.com/edge/3.1/metallb-chart \
+  metallb oci://registry.suse.com/edge/{version-edge-charts}/metallb-chart \
   --namespace metallb-system \
   --create-namespace
 ----
@@ -133,13 +133,13 @@ EOF
 +
 . Now Metal^3^ can be installed:
 +
-[,bash]
+[,bash,subs="attributes"]
 ----
 helm install \
-  metal3 oci://registry.suse.com/edge/3.1/metal3-chart \
+  metal3 oci://registry.suse.com/edge/{version-edge-charts}/metal3-chart \
   --namespace metal3-system \
   --create-namespace \
-  --set global.ironicIP="${STATIC_IRONIC_IP}"
+  --set global.ironicIP="$STATIC_IRONIC_IP"
 ----
 +
 . It can take around two minutes for the initContainer to run on this deployment, so ensure the pods are all running before proceeding:
@@ -159,7 +159,7 @@ WARNING: Do not proceed to the following steps until all pods in the `metal3-sys
 
 Cluster API dependencies are managed via the Rancher Turtles Helm chart:
 
-[,bash]
+[,bash,subs="attributes"]
 ----
 cat > values.yaml <<EOF
 rancherTurtles:
@@ -171,7 +171,7 @@ rancherTurtles:
 EOF
 
 helm install \
-  rancher-turtles oci://registry.suse.com/edge/3.1/rancher-turtles-chart \
+  rancher-turtles oci://registry.suse.com/edge/{version-edge-charts}/rancher-turtles-chart \
   --namespace rancher-turtles-system \
   --create-namespace \
   -f values.yaml
@@ -194,11 +194,11 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
 * The `network` folder is optional, see <<metal3-add-network-eib>> for more details.
 * The custom/scripts directory contains scripts to be run on first-boot; currently a `01-fix-growfs.sh` script is required to resize the OS root partition on deployment
 
-[,console]
+[,console,subs="attributes"]
 ----
 ├── downstream-cluster-config.yaml
 ├── base-images/
-│   └ SL-Micro.x86_64-6.0-Base-GM2.raw
+│   └ {micro-base-image}
 ├── network/
 |   └ configure-network.sh
 └── custom/
@@ -210,13 +210,13 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
 
 The `downstream-cluster-config.yaml` file is the main configuration file for the downstream cluster image. The following is a minimal example for deployment via Metal^3^:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
   imageType: RAW
   arch: x86_64
-  baseImage: SL-Micro.x86_64-6.0-Base-GM2.raw
+  baseImage: {micro-base-image}
   outputImageName: SLE-Micro-eib-output.raw
 operatingSystem:
   kernelArgs:
@@ -227,14 +227,14 @@ operatingSystem:
       - rebootmgr
   users:
     - username: root
-      encryptedPassword: ${ROOT_PASSWORD}
+      encryptedPassword: $ROOT_PASSWORD
       sshKeys:
-      - ${USERKEY1}
+      - $USERKEY1
 ----
 
-`$\{ROOT_PASSWORD\}` is the encrypted password for the root user, which can be useful for test/debugging.  It can be generated with the `openssl passwd -6 PASSWORD` command
+`$ROOT_PASSWORD` is the encrypted password for the root user, which can be useful for test/debugging.  It can be generated with the `openssl passwd -6 PASSWORD` command
 
-For the production environments, it is recommended to use the SSH keys that can be added to the users block replacing the `$\{USERKEY1\}` with the real SSH keys.
+For the production environments, it is recommended to use the SSH keys that can be added to the users block replacing the `$USERKEY1` with the real SSH keys.
 
 [NOTE]
 ====
@@ -278,10 +278,10 @@ For more information, see <<quickstart-eib>>.
 
 Once the directory structure is prepared following the previous sections, run the following command to build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm --privileged -it -v $PWD:/eib \
- registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+ registry.suse.com/edge/{version-edge-charts}/edge-image-builder:{version-eib} \
  build --definition-file downstream-cluster-config.yaml
 ----
 

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -159,7 +159,7 @@ WARNING: Do not proceed to the following steps until all pods in the `metal3-sys
 
 Cluster API dependencies are managed via the Rancher Turtles Helm chart:
 
-[,bash,subs="attributes"]
+[,bash,subs="attributes,specialchars"]
 ----
 cat > values.yaml <<EOF
 rancherTurtles:

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -89,7 +89,7 @@ TIP: If the management cluster is a single node, the requirement for an addition
 [,bash,subs="attributes"]
 ----
 helm install \
-  metallb oci://registry.suse.com/edge/{version-edge-charts}/metallb-chart \
+  metallb oci://registry.suse.com/edge/{version-edge-chart-repo}/metallb-chart \
   --namespace metallb-system \
   --create-namespace
 ----
@@ -136,7 +136,7 @@ EOF
 [,bash,subs="attributes"]
 ----
 helm install \
-  metal3 oci://registry.suse.com/edge/{version-edge-charts}/metal3-chart \
+  metal3 oci://registry.suse.com/edge/{version-edge-chart-repo}/metal3-chart \
   --namespace metal3-system \
   --create-namespace \
   --set global.ironicIP="$STATIC_IRONIC_IP"
@@ -171,7 +171,7 @@ rancherTurtles:
 EOF
 
 helm install \
-  rancher-turtles oci://registry.suse.com/edge/{version-edge-charts}/rancher-turtles-chart \
+  rancher-turtles oci://registry.suse.com/edge/{version-edge-chart-repo}/rancher-turtles-chart \
   --namespace rancher-turtles-system \
   --create-namespace \
   -f values.yaml
@@ -281,7 +281,7 @@ Once the directory structure is prepared following the previous sections, run th
 [,shell,subs="attributes"]
 ----
 podman run --rm --privileged -it -v $PWD:/eib \
- registry.suse.com/edge/{version-edge-charts}/edge-image-builder:{version-eib} \
+ registry.suse.com/edge/{version-edge-chart-repo}/edge-image-builder:{version-eib} \
  build --definition-file downstream-cluster-config.yaml
 ----
 


### PR DESCRIPTION
Currently, the process of updating the documentation is painful due to the sheer number of places that need to have their version numbers updated, such as the overall edge registry version and each individual chart. Asciidoc supports attribute substitution and this PR introduces two files for defining those attributes, as well as migrations for about a third of the overall documentation.

The two files that will contain this sort of volatile information are:
* `versions.adoc` - Currently, there is a divider in this file. Above the divider is information that we don't have a way to programmatically deduce and will need to manually be updated. Below it are values that can be ripped from a release manifest. After the docs conversion, I'm going to work on a tool that will generate (at very least) the fields below the divider from a given release manifest. I'm going to talk with the release manifest devs to see what else of this data makes sense to include in the manifest to further automate things, but I suspect it'll never completely be derived data.
* `links.adoc` - I pulled out any links that I encountered that are version-specific. I thought about having the URLs derived inline based on the version, but there's no guarantee that these links will remain valid from version to version. The list is short enough that we should verify each of the links per documentation release to ensure they haven't moved.

The remainder of the file changes are updating the quickstarts and about half of the component guides to use the attributes. I had a feeling this PR was going to get long with all of those changes (spoiler: it did), so I wanted to get this out there and landed so that subsequent updates I do in the next few days are hopefully smaller.

I think this PR is in a good place to land. However, I may still change some of the attribute names or organization as I see how the rest of the conversion goes, so don't be surprised if a future PR refines some of the attributes themselves. Like I said, I wanted to keep this from being a mountain of a PR, so the results of this PR will be functionally equivalent to what is produced by the docs before it lands, with the rest of the changes coming in the next few days.

Other notes:
* If a code block is going to use attribute substitution, the block must have the `subs="attributes"` annotation.
* If such a code block also contains certain characters (in particular, `<` in my experiences), it must have a second annotation (`subs="attributes,specialchars"`) to escape those characters. Otherwise, you'll get obtuse errors about invalid XML. That's why you only see a few code blocks with the longer annotation.
* I'm debating if `versions.adoc` will have attributes for the component versions themselves in addition to the chart versions. For example, the Longhorn version is `1.7.1` but the chart version is `104.2.0+up1.7.1` (yuck). This may make sense to include in the release manifest, or they may be manually entered into `versions.adoc`. We'll see how the conversations with the manifest engineers go.