### PR TITLE
Version attributes - Part 3

### DIFF
--- a/asciidoc/components/networking.adoc
+++ b/asciidoc/components/networking.adoc
@@ -79,7 +79,7 @@ We will now ensure that the downloaded base image copy is moved over to the conf
 
 [,shell,subs="attributes"]
 ----
-mv /path/to/downloads/{micro-base-image} $CONFIG_DIR/base-images/
+mv /path/to/downloads/{micro-base-image-raw} $CONFIG_DIR/base-images/
 ----
 
 > NOTE: EIB is never going to modify the base image input. It will create a new image with its modifications.
@@ -89,7 +89,7 @@ The configuration directory at this point should look like the following:
 [,console,subs="attributes"]
 ----
 └── base-images/
-    └── {micro-base-image}
+    └── {micro-base-image-raw}
 ----
 
 === Creating the image definition file
@@ -105,7 +105,7 @@ apiVersion: {version-eib-api-latest}
 image:
   arch: x86_64
   imageType: raw
-  baseImage: {micro-base-image}
+  baseImage: {micro-base-image-raw}
   outputImageName: modified-image.raw
 operatingSystem:
   users:
@@ -125,7 +125,7 @@ The configuration directory at this point should look like the following:
 ----
 ├── definition.yaml
 └── base-images/
-    └── {micro-base-image}
+    └── {micro-base-image-raw}
 ----
 
 === Defining the network configurations [[default-network-definition]]
@@ -345,7 +345,7 @@ The configuration directory at this point should look like the following:
 │   │── node2.suse.com.yaml
 │   └── node3.suse.com.yaml
 └── base-images/
-    └── {micro-base-image}
+    └── {micro-base-image-raw}
 ----
 
 > NOTE: The names of the files under the `network/` directory are intentional.
@@ -933,7 +933,7 @@ The configuration directory at this point should look like the following:
 ├── network/
 │   └── configure-network.sh
 └── base-images/
-    └── {micro-base-image}
+    └── {micro-base-image-raw}
 ----
 
 Let's build the image:

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -6,68 +6,78 @@
 // versions.adoc will be included before this so attributes defined in there may be used here
 // ============================================================================
 
-// == SL Micro ==
+// ============================================================================
+// SUSE Linux Micro
+
 :link-micro-official-docs: https://documentation.suse.com/sle-micro/{version-operatingsystem}/
 :link-micro-networkmanager: https://documentation.suse.com/sle-micro/{version-operatingsystem}/html/Micro-network-configuration/index.html
 :link-micro-transactional-updates: https://documentation.suse.com/sle-micro/{version-operatingsystem}/html/Micro-transactional-updates/transactional-updates.html
 
 :link-bci: https://registry.suse.com/repositories/bci-bci-base-15sp6
 
-// == Edge Image Builder ==
-:eib-release-tag: release-1.1
+// ============================================================================
+// Edge Image Builder
 
-:link-eib-docs: https://github.com/suse-edge/edge-image-builder/tree/{eib-release-tag}/docs
-:link-eib-full-example: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/pkg/image/testdata/full-valid-example.yaml
-:link-eib-building-images: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/building-images.md
-:link-eib-building-images-k8s: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/building-images.md#kubernetes
-:link-eib-installing-packages: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/installing-packages.md
-:link-eib-debugging: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/debugging.md
-:link-eib-testing: https://github.com/suse-edge/edge-image-builder/blob/{eib-release-tag}/docs/testing-guide.md
+:link-eib-docs: https://github.com/suse-edge/edge-image-builder/tree/{release-tag-eib}/docs
+:link-eib-full-example: https://github.com/suse-edge/edge-image-builder/blob/{release-tag-eib}/pkg/image/testdata/full-valid-example.yaml
+:link-eib-building-images: https://github.com/suse-edge/edge-image-builder/blob/{release-tag-eib}/docs/building-images.md
+:link-eib-building-images-k8s: https://github.com/suse-edge/edge-image-builder/blob/{release-tag-eib}/docs/building-images.md#kubernetes
+:link-eib-installing-packages: https://github.com/suse-edge/edge-image-builder/blob/{release-tag-eib}/docs/installing-packages.md
+:link-eib-debugging: https://github.com/suse-edge/edge-image-builder/blob/{release-tag-eib}/docs/debugging.md
+:link-eib-testing: https://github.com/suse-edge/edge-image-builder/blob/{release-tag-eib}/docs/testing-guide.md
 
-// == Rancher ==
+// ============================================================================
+// Rancher
+
 :rancher-docs-version: v2.9
-:rancher-release-tag: v2.9.3
 
 :link-rancher-extensions: https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/rancher-extensions
 :link-rancher-logging: https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/logging
 
-:link-rancher-upstream-release: https://github.com/rancher/rancher/releases/tag/{rancher-release-tag}
+:link-rancher-upstream-release: https://github.com/rancher/rancher/releases/tag/{release-tag-rancher}
 
 :link-cert-manager-installation: https://cert-manager.io/v1.14-docs/installation/helm/#installing-with-helm
 
-// == Longhorn ==
+// ============================================================================
+// Longhorn
+
 :link-longhorn-iscsi: https://longhorn.io/docs/{version-longhorn}/deploy/install/#installing-open-iscsi
 :link-longhorn-installation: https://longhorn.io/docs/{version-longhorn}/deploy/install/
 :link-longhorn-terminology: https://longhorn.io/docs/{version-longhorn}/terminology/
 
-// == Virtualization ==
+// ============================================================================
+// Virtualization
+
 :link-virtualization-sles: https://documentation.suse.com/sles/15-SP6/html/SLES-all/cha-virt-support.html#sec-kvm-requires-hardware
 :link-virtualization-virtctl: https://github.com/kubevirt/kubevirt/releases/download/v1.3.1/virtctl-v1.3.1-linux-amd64
 
-// == Lifecycle ==
-:fleet-examples-release-tag: release-3.1
+// ============================================================================
+// Lifecycle
 
 :link-lifecycle-example: https://github.com/suse-edge/upgrade-controller/blob/main/config/samples/lifecycle_v1alpha1_releasemanifest.yaml 
-:link-lifecycle-rke2-images: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-release-rke2-images.txt
-:link-lifecycle-save-oci-artifacts: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-save-oci-artefacts.sh
-:link-lifecycle-load-oci-artifacts: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-load-oci-artefacts.sh
-:link-lifecycle-save-images: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-save-images.sh
-:link-lifecycle-load-images: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-load-images.sh
 
-// == Nvidia ==
+:link-lifecycle-rke2-images: https://github.com/suse-edge/fleet-examples/blob/{release-tag-fleet-examples}/scripts/day2/edge-release-rke2-images.txt
+:link-lifecycle-save-oci-artifacts: https://github.com/suse-edge/fleet-examples/blob/{release-tag-fleet-examples}/scripts/day2/edge-save-oci-artefacts.sh
+:link-lifecycle-load-oci-artifacts: https://github.com/suse-edge/fleet-examples/blob/{release-tag-fleet-examples}/scripts/day2/edge-load-oci-artefacts.sh
+:link-lifecycle-save-images: https://github.com/suse-edge/fleet-examples/blob/{release-tag-fleet-examples}/scripts/day2/edge-save-images.sh
+:link-lifecycle-load-images: https://github.com/suse-edge/fleet-examples/blob/{release-tag-fleet-examples}/scripts/day2/edge-load-images.sh
+
+// ============================================================================
+// Nvidia
 // jdob, Nov 21, 2024 :: It may make sense to remove these in the future as the
 //   NVIDIA guide likely needs more hands on reviews instead of simple substitutions.
+
 :link-nvidia-driver: https://download.nvidia.com/suse/sle15sp6/x86_64/
 :link-nvidia-open-driver: https://scc.suse.com/packages?name=SUSE%20Linux%20Micro&version={version-operatingsystem}&arch=x86_64
 :link-nvidia-package-repo: https://download.nvidia.com/suse/sle15sp6/
 :link-nvidia-cuda-package-repo: https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/
 
-// == ATIP ==
-:atip-release-tag: release-3.1
+// ============================================================================
+// ATIP
 
-:link-atip-examples: https://github.com/suse-edge/atip/tree/{atip-release-tag}/telco-examples/edge-clusters
-:link-atip-performance-settings: https://github.com/suse-edge/atip/blob/{atip-release-tag}/telco-examples/edge-clusters/dhcp/eib/custom/files/performance-settings.sh
-:link-atip-sriov-auto-filler: https://github.com/suse-edge/atip/blob/{atip-release-tag}/telco-examples/edge-clusters/dhcp/eib/custom/files/sriov-auto-filler.sh
-:link-atip-sriov-operator-values: https://github.com/suse-edge/charts/blob/{release-tag-edge-charts}/charts/sriov-network-operator/{version-sriov-network-operator-chart}/values.yaml
+:link-atip-examples: https://github.com/suse-edge/atip/tree/{release-tag-atip}/telco-examples/edge-clusters
+:link-atip-performance-settings: https://github.com/suse-edge/atip/blob/{release-tag-atip}/telco-examples/edge-clusters/dhcp/eib/custom/files/performance-settings.sh
+:link-atip-sriov-auto-filler: https://github.com/suse-edge/atip/blob/{release-tag-atip}/telco-examples/edge-clusters/dhcp/eib/custom/files/sriov-auto-filler.sh
+:link-atip-sriov-operator-values: https://github.com/suse-edge/charts/blob/{release-tag-atip}/charts/sriov-network-operator/{version-sriov-network-operator-chart}/values.yaml
 
 :link-atip-micro-download-url: https://download.opensuse.org/repositories/isv:/SUSE:/Edge:/Telco/SL-Micro_6.0_images/

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -23,9 +23,12 @@
 
 // == Rancher ==
 :rancher-docs-version: v2.9
+:rancher-release-tag: v2.9.3
 
 :link-rancher-extensions: https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/rancher-extensions
 :link-rancher-logging: https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/logging
+
+:link-rancher-upstream-release: https://github.com/rancher/rancher/releases/tag/{rancher-release-tag}
 
 :link-cert-manager-installation: https://cert-manager.io/v1.14-docs/installation/helm/#installing-with-helm
 

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -7,8 +7,11 @@
 // ============================================================================
 
 // == SL Micro ==
-:link-micro-official-docs: https://documentation.suse.com/sle-micro/6.0/
-:link-micro-networkmanager: https://documentation.suse.com/sle-micro/6.0/html/Micro-network-configuration/index.html
+:link-micro-official-docs: https://documentation.suse.com/sle-micro/{version-operatingsystem}/
+:link-micro-networkmanager: https://documentation.suse.com/sle-micro/{version-operatingsystem}/html/Micro-network-configuration/index.html
+:link-micro-transactional-updates: https://documentation.suse.com/sle-micro/{version-operatingsystem}/html/Micro-transactional-updates/transactional-updates.html
+
+:link-bci: https://registry.suse.com/repositories/bci-bci-base-15sp6
 
 // == Edge Image Builder ==
 :eib-release-tag: release-1.1
@@ -43,3 +46,11 @@
 
 // == Lifecycle ==
 :link-lifecycle-example: https://github.com/suse-edge/upgrade-controller/blob/main/config/samples/lifecycle_v1alpha1_releasemanifest.yaml 
+
+// == Nvidia ==
+// jdob, Nov 21, 2024 :: It may make sense to remove these in the future as the
+//   NVIDIA guide likely needs more hands on reviews instead of simple substitutions.
+:link-nvidia-driver: https://download.nvidia.com/suse/sle15sp6/x86_64/
+:link-nvidia-open-driver: https://scc.suse.com/packages?name=SUSE%20Linux%20Micro&version={version-operatingsystem}&arch=x86_64
+:link-nvidia-package-repo: https://download.nvidia.com/suse/sle15sp6/
+:link-nvidia-cuda-package-repo: https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -45,7 +45,14 @@
 :link-virtualization-virtctl: https://github.com/kubevirt/kubevirt/releases/download/v1.3.1/virtctl-v1.3.1-linux-amd64
 
 // == Lifecycle ==
+:fleet-examples-release-tag: release-3.1
+
 :link-lifecycle-example: https://github.com/suse-edge/upgrade-controller/blob/main/config/samples/lifecycle_v1alpha1_releasemanifest.yaml 
+:link-lifecycle-rke2-images: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-release-rke2-images.txt
+:link-lifecycle-save-oci-artifacts: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-save-oci-artefacts.sh
+:link-lifecycle-load-oci-artifacts: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-load-oci-artefacts.sh
+:link-lifecycle-save-images: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-save-images.sh
+:link-lifecycle-load-images: https://github.com/suse-edge/fleet-examples/blob/{fleet-examples-release-tag}/scripts/day2/edge-load-images.sh
 
 // == Nvidia ==
 // jdob, Nov 21, 2024 :: It may make sense to remove these in the future as the
@@ -54,3 +61,13 @@
 :link-nvidia-open-driver: https://scc.suse.com/packages?name=SUSE%20Linux%20Micro&version={version-operatingsystem}&arch=x86_64
 :link-nvidia-package-repo: https://download.nvidia.com/suse/sle15sp6/
 :link-nvidia-cuda-package-repo: https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/
+
+// == ATIP ==
+:atip-release-tag: release-3.1
+
+:link-atip-examples: https://github.com/suse-edge/atip/tree/{atip-release-tag}/telco-examples/edge-clusters
+:link-atip-performance-settings: https://github.com/suse-edge/atip/blob/{atip-release-tag}/telco-examples/edge-clusters/dhcp/eib/custom/files/performance-settings.sh
+:link-atip-sriov-auto-filler: https://github.com/suse-edge/atip/blob/{atip-release-tag}/telco-examples/edge-clusters/dhcp/eib/custom/files/sriov-auto-filler.sh
+:link-atip-sriov-operator-values: https://github.com/suse-edge/charts/blob/{release-tag-edge-charts}/charts/sriov-network-operator/{version-sriov-network-operator-chart}/values.yaml
+
+:link-atip-micro-download-url: https://download.opensuse.org/repositories/isv:/SUSE:/Edge:/Telco/SL-Micro_6.0_images/

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -57,25 +57,25 @@
 
 :version-operatingsystem: 6.0
 
-:version-rancher-chart: v2.9.3
-:version-longhorn-chart: 104.2.0+up1.7.1
-:version-longhorn-crd-chart: 104.2.0+up1.7.1
-:version-metallb-chart: 0.14.9
+:version-akri-chart: 0.12.20
+:version-akri-dashboard-extension-chart: 1.1.0
 :version-cdi-chart: 0.4.0
+:version-elemental-operator-chart: 1.6.4
+:version-elemental-operator-crds-chart: 1.6.4
+:version-endpoint-copier-operator-chart: 0.2.1
 :version-kubevirt-chart: 0.4.0
 :version-kubevirt-dashboard-extension-chart: 1.1.0
+:version-longhorn-chart: 104.2.0+up1.7.1
+:version-longhorn-crd-chart: 104.2.0+up1.7.1
+:version-metal3-chart: 0.8.3
+:version-metallb-chart: 0.14.9
 :version-neuvector-chart: 104.0.2+up2.8.0
 :version-neuvector-crd-chart: 104.0.2+up2.8.0
 :version-neuvector-dashboard-extension-chart: 2.0.0
-:version-endpoint-copier-operator-chart: 0.2.1
-:version-elemental-operator-chart: 1.6.4
-:version-elemental-operator-crds-chart: 1.6.4
-:version-sriov-network-operator-chart: 1.3.0
-:version-sriov-crd-chart: 1.3.0
-:version-akri-chart: 0.12.20
-:version-akri-dashboard-extension-chart: 1.1.0
-:version-metal3-chart: 0.8.3
+:version-rancher-chart: v2.9.3
 :version-rancher-turtles-chart: 0.3.3
+:version-sriov-crd-chart: 1.3.0
+:version-sriov-network-operator-chart: 1.3.0
 
 
 // ============================================================================

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -17,6 +17,7 @@
 
 // == Component Versions ==
 :version-rancher-prime: 2.9.3
+:version-cert-manager: 1.15.3
 :version-longhorn: 1.7.1
 :version-suc: 0.13.4
 

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -20,10 +20,12 @@
 :version-cert-manager: 1.15.3
 :version-longhorn: 1.7.1
 :version-suc: 0.13.4
+:version-nvidia-device-plugin: 0.14.5
 
 // == Misc Charts ==
 :version-suc-chart: 104.0.0+up0.7.0
 :version-upgrade-controller-chart: 0.1.0
+:version-nvidia-device-plugin-chart: v0.14.5
 
 // ============================================================================
 // Release Manifest Versions

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -75,7 +75,7 @@
 :version-akri-chart: 0.12.20
 :version-akri-dashboard-extension-chart: 1.1.0
 :version-metal3-chart: 0.8.3
-:version-rancher-turtles: 0.3.3
+:version-rancher-turtles-chart: 0.3.3
 
 
 // ============================================================================

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -32,13 +32,18 @@
 :version-suc: 0.13.4
 :version-nvidia-device-plugin: 0.14.5
 
-// == Misc Charts ==
+// == Non-Release Manifest Charts ==
 :version-suc-chart: 104.0.0+up0.7.0
 :version-upgrade-controller-chart: 0.1.0
 :version-nvidia-device-plugin-chart: v0.14.5
 
 // == Release Tags ==
+:release-tag-eib: release-1.1
 :release-tag-edge-charts: release-3.1
+:release-tag-atip: release-3.1
+:release-tag-fleet-examples: release-3.1
+:release-tag-rancher: v2.9.3
+
 
 // ============================================================================
 // Release Manifest Versions
@@ -71,6 +76,7 @@
 :version-akri-dashboard-extension-chart: 1.1.0
 :version-metal3-chart: 0.8.3
 :version-rancher-turtles: 0.3.3
+
 
 // ============================================================================
 // Manual Version Entries

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -12,7 +12,7 @@
 :version-edge-registry: 3.1
 
 // == SL Micro ==
-:micro-base-image: SL-Micro.x86_64-6.0-Base-GM2.raw
+:micro-base-image-raw: SL-Micro.x86_64-6.0-Base-GM2.raw
 :micro-base-image-iso: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
 
 // == Edge Image Builder ==

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -1,9 +1,19 @@
+// ============================================================================
+// Automatic Version Substitutions
+// 
+// The values in here are used throughout the documentation. Updating them here
+// will propagate throughout the rest of the documentation. See the section at
+// the bottom for details on versioning instances that cannot be handled in this
+// fashion.
+// ============================================================================
+
 // == General Edge ==
 :version-edge: 3.1.0
 :version-edge-registry: 3.1
 
 // == SL Micro ==
 :micro-base-image: SL-Micro.x86_64-6.0-Base-GM2.raw
+:micro-base-image-iso: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
 
 // == Edge Image Builder ==
 :version-eib: 1.1.0
@@ -58,3 +68,15 @@
 :version-akri-dashboard-extension-chart: 1.1.0
 :version-metal3-chart: 0.8.3
 :version-rancher-turtles: 0.3.3
+
+// ============================================================================
+// Manual Version Entries
+//
+// The following files mention versions that cannot be handled through
+// substitution. For example, EIB definitions that contain a list of 
+// images to embed. These files should be manually reviewed on a per-release
+// basis to ensure accuracy.
+// ============================================================================
+
+// asciidoc/guides/air-gapped-eib-deployments.adoc
+// asciidoc/product/atip-management-cluster.adoc

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -37,6 +37,9 @@
 :version-upgrade-controller-chart: 0.1.0
 :version-nvidia-device-plugin-chart: v0.14.5
 
+// == Release Tags ==
+:release-tag-edge-charts: release-3.1
+
 // ============================================================================
 // Release Manifest Versions
 //
@@ -80,3 +83,4 @@
 
 // asciidoc/guides/air-gapped-eib-deployments.adoc
 // asciidoc/product/atip-management-cluster.adoc
+// asciidoc/product/atip-automated-provision.adoc

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -90,3 +90,4 @@
 // asciidoc/guides/air-gapped-eib-deployments.adoc
 // asciidoc/product/atip-management-cluster.adoc
 // asciidoc/product/atip-automated-provision.adoc
+// asciidoc/edge-book/releasenotes.adoc

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 == Intro
 
-This guide will show how to deploy several of the SUSE Edge components completely air-gapped on SLE Micro 6.0 utilizing <<components-eib,Edge Image Builder(EIB)>>. With this, you'll be able to boot into a customized, ready to boot (CRB) image created by EIB and have the specified components deployed on either a RKE2 or K3s cluster without an Internet connection or any manual steps. This configuration is highly desirable for customers that want to pre-bake all artifacts required for deployment into their OS image, so they are immediately available on boot.
+This guide will show how to deploy several of the SUSE Edge components completely air-gapped on SLE Micro {version-operatingsystem} utilizing <<components-eib,Edge Image Builder(EIB)>>. With this, you'll be able to boot into a customized, ready to boot (CRB) image created by EIB and have the specified components deployed on either a RKE2 or K3s cluster without an Internet connection or any manual steps. This configuration is highly desirable for customers that want to pre-bake all artifacts required for deployment into their OS image, so they are immediately available on boot.
 
 We will cover an air-gapped installation of:
 
@@ -82,9 +82,9 @@ Make sure to add whichever base image you plan to use into the `base-images` dir
 
 Let's copy the downloaded image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-cp SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso $CONFIG_DIR/base-images/slemicro.iso
+cp {micro-base-image} $CONFIG_DIR/base-images/slemicro.iso
 ----
 
 [NOTE]
@@ -161,7 +161,7 @@ Full list of customization options in the definition file can be found in the ht
 
 We will take a look at the following fields which will be present in all definition files:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
@@ -174,7 +174,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.30.5+rke2r1
+  version: {version-kubernetes-rke2}
 embeddedArtifactRegistry:
   images:
     - ...
@@ -184,8 +184,7 @@ The `image` section is required, and it specifies the input image, its architect
 
 The `operatingSystem` section is optional, and contains configuration to enable login on the provisioned systems with the `root/eib` username/password.
 
-The `kubernetes` section is optional, and it defines the Kubernetes type and version. We are going to use Kubernetes 1.30.5 and RKE2 by default.
-Use `kubernetes.version: v1.30.5+k3s1` if K3s is desired instead. Unless explicitly configured via the `kubernetes.nodes` field, all clusters we bootstrap in this guide will be single-node ones.
+The `kubernetes` section is optional, and it defines the Kubernetes type and version. We are going to use the RKE2 distribution. Use `kubernetes.version: {version-kubernetes-k3s}` if K3s is desired instead. Unless explicitly configured via the `kubernetes.nodes` field, all clusters we bootstrap in this guide will be single-node ones.
 
 The `embeddedArtifactRegistry` section will include all images which are only referenced and pulled at runtime for the specific component.
 
@@ -196,13 +195,13 @@ The `embeddedArtifactRegistry` section will include all images which are only re
 The <<components-rancher,Rancher>> deployment that will be demonstrated will be highly slimmed down for demonstration purposes. For your actual deployments, additional artifacts may be necessary depending on your configuration.
 ====
 
-The https://github.com/rancher/rancher/releases/tag/v2.9.3[Rancher v2.9.3] release assets contain a `rancher-images.txt` file which lists all the images required for an air-gapped installation.
+The {link-rancher-upstream-release}[Rancher {version-rancher-prime}] release assets contain a `rancher-images.txt` file which lists all the images required for an air-gapped installation.
 
 There are over 600 container images in total which means that the resulting CRB image would be roughly 30GB. For our Rancher installation, we will strip down that list to the smallest working configuration. From there, you can add back any images you may need for your deployments.
 
 We will create the definition file and include the stripped down image list:
 
-[,console]
+[,console,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
@@ -215,7 +214,7 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.30.5+rke2r1
+  version: {version-kubernetes-rke2}
   network:
     apiVIP: 192.168.100.151
   manifests:
@@ -224,7 +223,7 @@ kubernetes:
   helm:
     charts:
       - name: rancher
-        version: 2.9.3
+        version: {version-rancher-prime}
         repositoryName: rancher-prime
         valuesFile: rancher-values.yaml
         targetNamespace: cattle-system
@@ -235,7 +234,7 @@ kubernetes:
         createNamespace: true
         repositoryName: jetstack
         targetNamespace: cert-manager
-        version: 1.15.3
+        version: {version-cert-manager}
     repositories:
       - name: jetstack
         url: https://charts.jetstack.io
@@ -320,10 +319,10 @@ Setting the `systemDefaultRegistry` to `registry.rancher.com` allows Rancher to 
 ====
 
 Let's build the image:
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm -it --privileged -v $CONFIG_DIR:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
 build --definition-file eib-iso-definition.yaml
 ----
 
@@ -407,7 +406,7 @@ image::air-gapped-rancher.png[]
 Unlike the Rancher installation, the NeuVector installation does not require any special handling in EIB. EIB will automatically air-gap every image required by NeuVector.
 
 We will create the definition file:
-[,console]
+[,console,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
@@ -420,18 +419,18 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.30.5+rke2r1
+  version: {version-kubernetes-rke2}
   helm:
     charts:
       - name: neuvector-crd
-        version: 104.0.1+up2.7.9
+        version: {version-neuvector-crd-chart}
         repositoryName: rancher-charts
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector-values.yaml
       - name: neuvector
-        version: 104.0.1+up2.7.9
+        version: {version-neuvector-chart}
         repositoryName: rancher-charts
         targetNamespace: neuvector
         createNamespace: true
@@ -462,10 +461,10 @@ EOF
 ----
 
 Let's build the image:
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm -it --privileged -v $CONFIG_DIR:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
 build --definition-file eib-iso-definition.yaml
 ----
 
@@ -535,7 +534,7 @@ The https://longhorn.io/docs/1.7.1/deploy/install/airgap/[official documentation
 We will be including their mirrored counterparts from the Rancher container registry in our definition file.
 Let's create it:
 
-[,console]
+[,console,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
@@ -548,24 +547,24 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
   packages:
-    sccRegistrationCode: <reg-code>
+    sccRegistrationCode: [reg-code]
     packageList:
       - open-iscsi
 kubernetes:
-  version: v1.30.5+rke2r1
+  version: {version-kubernetes-rke2}
   helm:
     charts:
       - name: longhorn
         repositoryName: longhorn
         targetNamespace: longhorn-system
         createNamespace: true
-        version: 104.2.0+up1.7.1
+        version: {version-longhorn-chart}
       - name: longhorn-crd
         repositoryName: longhorn
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
-        version: 104.2.0+up1.7.1
+        version: {version-longhorn-crd-chart}
     repositories:
       - name: longhorn
         url: https://charts.rancher.io
@@ -596,10 +595,10 @@ relies on a `iscsiadm` daemon running on the different nodes to provide persiste
 
 Let's build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm -it --privileged -v $CONFIG_DIR:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
 build --definition-file eib-iso-definition.yaml
 ----
 
@@ -707,7 +706,7 @@ The Helm charts for both KubeVirt and CDI are only installing their respective o
 It is up to the operators to deploy the rest of the systems which means we will have to include all
 necessary container images in our definition file. Let's create it:
 
-[,console]
+[,console,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
@@ -720,24 +719,24 @@ operatingSystem:
     - username: root
       encryptedPassword: $6$jHugJNNd3HElGsUZ$eodjVe4te5ps44SVcWshdfWizrP.xAyd71CVEXazBJ/.v799/WRCBXxfYmunlBO2yp1hm/zb4r8EmnrrNCF.P/
 kubernetes:
-  version: v1.30.5+rke2r1
+  version: {version-kubernetes-rke2}
   helm:
     charts:
       - name: kubevirt-chart
         repositoryName: suse-edge
-        version: 0.4.0
+        version: {version-kubevirt-chart}
         targetNamespace: kubevirt-system
         createNamespace: true
         installationNamespace: kube-system
       - name: cdi-chart
         repositoryName: suse-edge
-        version: 0.4.0
+        version: {version-cdi-chart}
         targetNamespace: cdi-system
         createNamespace: true
         installationNamespace: kube-system
     repositories:
       - name: suse-edge
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/{version-edge-registry}
 embeddedArtifactRegistry:
   images:
     - name: registry.suse.com/suse/sles/15.6/cdi-uploadproxy:1.60.1-150600.3.9.1
@@ -756,10 +755,10 @@ embeddedArtifactRegistry:
 
 Let's build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm -it --privileged -v $CONFIG_DIR:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
 build --definition-file eib-iso-definition.yaml
 ----
 

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -84,7 +84,7 @@ Let's copy the downloaded image:
 
 [,shell,subs="attributes"]
 ----
-cp {micro-base-image} $CONFIG_DIR/base-images/slemicro.iso
+cp {micro-base-image-iso} $CONFIG_DIR/base-images/slemicro.iso
 ----
 
 [NOTE]

--- a/asciidoc/guides/metallb-k3s.adoc
+++ b/asciidoc/guides/metallb-k3s.adoc
@@ -51,10 +51,10 @@ K3S comes with its own service load balancer named Klipper. You https://metallb.
 
 MetalLB leverages Helm (and other methods as well), so:
 
-[,bash]
+[,bash,subs="attributes"]
 ----
 helm install \
-  metallb oci://registry.suse.com/edge/3.1/metallb-chart \
+  metallb oci://registry.suse.com/edge/{version-edge-registry}/metallb-chart \
   --namespace metallb-system \
   --create-namespace
 

--- a/asciidoc/guides/metallb-kube-api.adoc
+++ b/asciidoc/guides/metallb-kube-api.adoc
@@ -14,7 +14,7 @@ endif::[]
 This guide demonstrates using a MetalLB service to expose the RKE2/K3s API externally on an HA cluster with three control-plane nodes.
 To achieve this, a Kubernetes Service of type `LoadBalancer` and Endpoints will be manually created. The Endpoints keep the IPs of all control plane nodes available in the cluster.
 For the Endpoint to be continuously synchronized with the events occurring in the cluster (adding/removing a node or a node goes offline), the https://github.com/suse-edge/endpoint-copier-operator[Endpoint Copier Operator] will be deployed. The operator monitors the events happening in the default `kubernetes` Endpoint and updates the managed one automatically to keep them in sync.
-Since the managed Service is of type `LoadBalancer`, `MetalLB` assigns it a static `ExternalIP`. This `ExternalIP` will be used to communicate with the API Server.
+Since the managed Service is of type `LoadBalancer`, MetalLB assigns it a static `ExternalIP`. This `ExternalIP` will be used to communicate with the API Server.
 
 == Prerequisites
 
@@ -94,7 +94,7 @@ scp ${NODE_IP}:/etc/rancher/${KUBE_DISTRIBUTION}/${KUBE_DISTRIBUTION}.yaml ~/.ku
 This step is valid only if you intend to use an existing RKE2/K3s cluster.
 ====
 
-To use an existing cluster the `tls-san` flags should be modified and also, `servicelb` LB should be disabled for K3s.
+To use an existing cluster the `tls-san` flags should be modified. Additionally, the `servicelb` LB should be disabled for K3s.
 
 To change the flags for RKE2 or K3s servers, you need to modify either the `/etc/systemd/system/rke2.service` or `/etc/systemd/system/k3s.service` file on all the VMs in the cluster, depending on the distribution.
 
@@ -179,10 +179,10 @@ EOF
 
 == Installing the Endpoint Copier Operator
 
-[,bash]
+[,bash,subs="attributes"]
 ----
 helm install \
-endpoint-copier-operator oci://registry.suse.com/edge/3.1/endpoint-copier-operator-chart \
+endpoint-copier-operator oci://registry.suse.com/edge/{version-edge-registry}/endpoint-copier-operator-chart \
 --namespace endpoint-copier-operator \
 --create-namespace
 ----

--- a/asciidoc/integrations/nvidia-slemicro.adoc
+++ b/asciidoc/integrations/nvidia-slemicro.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 == Intro
 
-This guide demonstrates how to implement host-level NVIDIA GPU support via the pre-built https://github.com/NVIDIA/open-gpu-kernel-modules[open-source drivers] on SLE Micro 6.0. These are drivers that are baked into the operating system rather than dynamically loaded by NVIDIA's https://github.com/NVIDIA/gpu-operator[GPU Operator]. This configuration is highly desirable for customers that want to pre-bake all artifacts required for deployment into the image, and where the dynamic selection of the driver version, that is, the user selecting the version of the driver via Kubernetes, is not a requirement. This guide initially explains how to deploy the additional components onto a system that has already been pre-deployed, but follows with a section that describes how to embed this configuration into the initial deployment via Edge Image Builder. If you do not want to run through the basics and set things up manually, skip right ahead to that section.
+This guide demonstrates how to implement host-level NVIDIA GPU support via the pre-built https://github.com/NVIDIA/open-gpu-kernel-modules[open-source drivers] on SLE Micro {version-operatingsystem}. These are drivers that are baked into the operating system rather than dynamically loaded by NVIDIA's https://github.com/NVIDIA/gpu-operator[GPU Operator]. This configuration is highly desirable for customers that want to pre-bake all artifacts required for deployment into the image, and where the dynamic selection of the driver version, that is, the user selecting the version of the driver via Kubernetes, is not a requirement. This guide initially explains how to deploy the additional components onto a system that has already been pre-deployed, but follows with a section that describes how to embed this configuration into the initial deployment via Edge Image Builder. If you do not want to run through the basics and set things up manually, skip right ahead to that section.
 
 It is important to call out that the support for these drivers is provided by both SUSE and NVIDIA in tight collaboration, where the driver is built and shipped by SUSE as part of the package repositories. However, if you have any concerns or questions about the combination in which you use the drivers, ask your SUSE or NVIDIA account managers for further assistance. If you plan to use https://www.nvidia.com/en-gb/data-center/products/ai-enterprise/[NVIDIA AI Enterprise] (NVAIE), ensure that you are using an https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#supported-nvidia-gpus-and-systems[NVAIE certified GPU], which _may_ require the use of proprietary NVIDIA drivers. If you are unsure, speak with your NVIDIA representative.
 
@@ -22,7 +22,7 @@ Further information about NVIDIA GPU operator integration is _not_ covered in th
 
 If you are following this guide, it assumes that you have the following already available:
 
-* At least one host with SLE Micro 6.0 installed; this can be physical or virtual.
+* At least one host with SLE Micro {version-operatingsystem} installed; this can be physical or virtual.
 * Your hosts are attached to a subscription as this is required for package access — an evaluation is available https://www.suse.com/download/sle-micro/[here].
 * A https://github.com/NVIDIA/open-gpu-kernel-modules#compatible-gpus[compatible NVIDIA GPU] installed (or _fully_ passed through to the virtual machine in which SLE Micro is running).
 * Access to the root user — these instructions assume you are the root user, and _not_ escalating your privileges via `sudo`.
@@ -36,19 +36,16 @@ Before we begin, it is important to recognize that besides the NVIDIA open-drive
 We recommend that you ensure that the driver version that you are selecting is compatible with your GPU and meets any CUDA requirements that you may have by checking:
 
 * The https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/[CUDA release notes]
-* The driver version that you plan on deploying has a matching version in the https://download.nvidia.com/suse/sle15sp6/x86_64/[NVIDIA SLE15-SP6 repository] and ensuring that you have equivalent package versions for the supporting components available
+* The driver version that you plan on deploying has a matching version in the {link-nvidia-driver}[NVIDIA repository] and ensuring that you have equivalent package versions for the supporting components available
 
 [TIP] 
 ====
-To find the NVIDIA open-driver versions, either run `zypper se -s nvidia-open-driver` on the target machine _or_ search the SUSE Customer Center for the "nvidia-open-driver" in https://scc.suse.com/packages?name=SUSE%20Linux%20Micro&version=6.0&arch=x86_64[SLE Micro 6.0 for x86_64].
-
-At the time of writing, you will see a single version available (_550.54.14_):
+To find the NVIDIA open-driver versions, either run `zypper se -s nvidia-open-driver` on the target machine _or_ search the SUSE Customer Center for the "nvidia-open-driver" in {link-nvidia-open-driver}[SLE Micro {version-operatingsystem} for x86_64].
 
 image::scc-packages-nvidia.png[SUSE Customer Centre]
 ====
 
-
-When you have confirmed that an equivalent version is available in the NVIDIA repos, you are ready to install the packages on the host operating system. For this, we need to open up a `transactional-update` session, which creates a new read/write snapshot of the underlying operating system so we can make changes to the immutable platform (for further instructions on `transactional-update`, see https://documentation.suse.com/sle-micro/6.0/html/Micro-transactional-updates/transactional-updates.html[here]):
+When you have confirmed that an equivalent version is available in the NVIDIA repos, you are ready to install the packages on the host operating system. For this, we need to open up a `transactional-update` session, which creates a new read/write snapshot of the underlying operating system so we can make changes to the immutable platform (for further instructions on `transactional-update`, see {link-micro-transactional-updates}[here]):
 
 [,shell]
 ----
@@ -57,9 +54,9 @@ transactional-update shell
 
 When you are in your `transactional-update` shell, add an additional package repository from NVIDIA. This allows us to pull in additional utilities, for example, `nvidia-smi`:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-zypper ar https://download.nvidia.com/suse/sle15sp6/ nvidia-sle15sp6-main
+zypper ar {link-nvidia-package-repo} nvidia-suse-main
 zypper --gpg-auto-import-keys refresh
 ----
 
@@ -105,7 +102,6 @@ The output of this command should show you something similar to the following ou
 
 [,shell]
 ----
-Wed Feb 28 12:31:06 2024
 +---------------------------------------------------------------------------------------+
 | NVIDIA-SMI 545.29.06              Driver Version: 545.29.06    CUDA Version: 12.3     |
 |-----------------------------------------+----------------------+----------------------+
@@ -174,7 +170,7 @@ With the machine rebooted, you can verify that the system can successfully enume
 nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 ----
 
-This ensures that any container started on the machine can employ NVIDIA GPU devices that have been discovered. When ready, you can then run a podman-based container. Doing this via `podman` gives us a good way of validating access to the NVIDIA device from within a container, which should give confidence for doing the same with Kubernetes at a later stage. Give `podman` access to the labeled NVIDIA devices that were taken care of by the previous command, based on https://registry.suse.com/repositories/bci-bci-base-15sp6[SLE BCI], and simply run the Bash command:
+This ensures that any container started on the machine can employ NVIDIA GPU devices that have been discovered. When ready, you can then run a podman-based container. Doing this via `podman` gives us a good way of validating access to the NVIDIA device from within a container, which should give confidence for doing the same with Kubernetes at a later stage. Give `podman` access to the labeled NVIDIA devices that were taken care of by the previous command, based on {link-bci}[SLE BCI], and simply run the Bash command:
 
 [,shell]
 ----
@@ -183,9 +179,9 @@ podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable -it reg
 
 You will now execute commands from within a temporary podman container. It does not have access to your underlying system and is ephemeral, so whatever we do here will not persist, and you should not be able to break anything on the underlying host. As we are now in a container, we can install the required CUDA libraries, again checking the correct CUDA version for your driver https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/[here], although the previous output of `nvidia-smi` should show the required CUDA version. In the example below, we are installing _CUDA 12.3_ and pulling many examples, demos and development kits so you can fully validate the GPU:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-zypper ar https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/ cuda-sles15
+zypper ar {link-nvidia-cuda-package-repo} cuda-suse
 zypper in -y cuda-libraries-devel-12-3 cuda-minimal-build-12-3 cuda-demo-suite-12-3
 ----
 
@@ -269,10 +265,10 @@ kubectl get nodes
 
 This should show something similar to the following:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 NAME       STATUS   ROLES                       AGE   VERSION
-node0001   Ready    control-plane,etcd,master   13d   v1.30.5+rke2r1
+node0001   Ready    control-plane,etcd,master   13d   {version-kubernetes-rke2}
 ----
 
 What you should find is that your k3s/rke2 installation has detected the NVIDIA Container Toolkit on the host and auto-configured the NVIDIA runtime integration into `containerd` (the Container Runtime Interface that k3s/rke2 use). Confirm this by checking the containerd `config.toml` file:
@@ -319,9 +315,9 @@ helm repo update
 
 Now you can install the NVIDIA Device Plugin:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
-helm upgrade -i nvdp nvdp/nvidia-device-plugin --namespace nvidia-device-plugin --create-namespace --version 0.14.5 --set runtimeClassName=nvidia
+helm upgrade -i nvdp nvdp/nvidia-device-plugin --namespace nvidia-device-plugin --create-namespace --version {version-nvidia-device-plugin} --set runtimeClassName=nvidia
 ----
 
 After a few minutes, you see a new pod running that will complete the detection on your available nodes and tag them with the number of GPUs that have been detected:
@@ -416,11 +412,11 @@ NOTE: You need to reboot to make this package available to your applications. Th
 
 Okay, so you have demonstrated full functionality of your applications and GPUs on SLE Micro and you now want to use <<components-eib>> to provide it all together via a deployable/consumable ISO or RAW disk image. This guide does not explain how to use Edge Image Builder, but it provides the necessary configurations to build such image. Below you can find an example of an image definition, along with the necessary Kubernetes configuration files, to ensure that all the required components are deployed out of the box. Here is the directory structure of the Edge Image Builder directory for the example shown below:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 .
 ├── base-images
-│   └── SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
+│   └── {micro-base-image}
 ├── eib-config-iso.yaml
 ├── kubernetes
 │   ├── config
@@ -437,13 +433,13 @@ Okay, so you have demonstrated full functionality of your applications and GPUs 
 
 Let us explore those files. First, here is a sample image definition for a single-node cluster running K3s that deploys the utilities and OpenGL packages, too (`eib-config-iso.yaml`):
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
   arch: x86_64
   imageType: iso
-  baseImage: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
+  baseImage: {micro-base-image}
   outputImageName: deployimage.iso
 operatingSystem:
   time:
@@ -465,13 +461,13 @@ operatingSystem:
     additionalRepos:
       - url: https://download.nvidia.com/suse/sle15sp6/
       - url: https://nvidia.github.io/libnvidia-container/stable/rpm/x86_64
-    sccRegistrationCode: <snip>
+    sccRegistrationCode: [snip]
 kubernetes:
-  version: v1.30.5+k3s1
+  version: {version-kubernetes-k3s}
   helm:
     charts:
       - name: nvidia-device-plugin
-        version: v0.14.5
+        version: {version-nvidia-device-plugin-chart}
         installationNamespace: kube-system
         targetNamespace: nvidia-device-plugin
         createNamespace: true
@@ -534,14 +530,14 @@ curl -o rpms/gpg-keys/nvidia-container-toolkit.key https://nvidia.github.io/libn
 
 All the required artifacts, including Kubernetes binary, container images, Helm charts (and any referenced images), will be automatically air-gapped, meaning that the systems at deploy time should require no Internet connectivity by default. Now you need only to grab the SLE Micro ISO from the https://www.suse.com/download/sle-micro/[SUSE Downloads Page] (and place it in the `base-images` directory), and you can call the Edge Image Builder tool to generate the ISO for you. To complete the example, here is the command that was used to build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm --privileged -it -v /path/to/eib-files/:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
 build --definition-file eib-config-iso.yaml
 ----
 
-For further instructions, please see the https://github.com/suse-edge/edge-image-builder/blob/release-1.1/docs/building-images.md[documentation] for Edge Image Builder.
+For further instructions, please see the {link-eib-building-images}[documentation] for Edge Image Builder.
 
 == Resolving issues
 

--- a/asciidoc/integrations/nvidia-slemicro.adoc
+++ b/asciidoc/integrations/nvidia-slemicro.adoc
@@ -416,7 +416,7 @@ Okay, so you have demonstrated full functionality of your applications and GPUs 
 ----
 .
 ├── base-images
-│   └── {micro-base-image}
+│   └── {micro-base-image-iso}
 ├── eib-config-iso.yaml
 ├── kubernetes
 │   ├── config
@@ -439,7 +439,7 @@ apiVersion: 1.0
 image:
   arch: x86_64
   imageType: iso
-  baseImage: {micro-base-image}
+  baseImage: {micro-base-image-iso}
   outputImageName: deployimage.iso
 operatingSystem:
   time:

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -49,10 +49,10 @@ The following sections describe the different directed network provisioning work
 * xref:airgap-deployment[]
 
 
-[IMPORTANT NOTE]
+[NOTE]
 ====
 The following sections show how to prepare the different scenarios for the directed network provisioning workflow using ATIP.
-For examples of the different configurations options for deployment (incl. air-gapped environments, DHCP and DHCP-less networks, private container registries, etc.), see the https://github.com/suse-edge/atip/tree/release-3.1/telco-examples/edge-clusters[SUSE ATIP repository].
+For examples of the different configurations options for deployment (incl. air-gapped environments, DHCP and DHCP-less networks, private container registries, etc.), see the {link-atip-examples}[SUSE ATIP repository].
 ====
 
 [#single-node]
@@ -67,7 +67,7 @@ Much of the configuration via Edge Image Builder is possible, but in this guide,
 ==== Prerequisites for connected scenarios
 
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop] is required to run Edge Image Builder.
-* The base image `SL-Micro.x86_64-6.0-Base-RT-GM2.raw` must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
+* The base image `{micro-base-image-raw}` must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
 
 ==== Image configuration for connected scenarios
 
@@ -82,11 +82,11 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
     3. `03-sriov.sh` script is optional and can be used to configure the system for SR-IOV.
 * The `custom/files` directory contains the `performance-settings.sh` and `sriov-auto-filler.sh` files to be copied to the image during the image creation process.
 
-[,console]
+[,console,subs="attributes"]
 ----
 ├── downstream-cluster-config.yaml
 ├── base-images/
-│   └ SL-Micro.x86_64-6.0-Base-RT-GM2.raw
+│   └ {micro-base-image-raw}
 ├── network/
 |   └ configure-network.sh
 └── custom/
@@ -103,13 +103,13 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
 
 The `downstream-cluster-config.yaml` file is the main configuration file for the downstream cluster image. The following is a minimal example for deployment via Metal^3^:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
-  imageType: RAW
+  imageType: raw
   arch: x86_64
-  baseImage: SL-Micro.x86_64-6.0-Base-RT-GM2.raw
+  baseImage: {micro-base-image-raw}
   outputImageName: eibimage-slmicro60rt-telco.raw
 operatingSystem:
   kernelArgs:
@@ -124,14 +124,14 @@ operatingSystem:
       - time-sync.target
   users:
     - username: root
-      encryptedPassword: ${ROOT_PASSWORD}
+      encryptedPassword: $ROOT_PASSWORD
       sshKeys:
-      - ${USERKEY1}
+      - $USERKEY1
 ----
 
-`$\{ROOT_PASSWORD\}` is the encrypted password for the root user, which can be useful for test/debugging.  It can be generated with the `openssl passwd -6 PASSWORD` command
+`$ROOT_PASSWORD` is the encrypted password for the root user, which can be useful for test/debugging.  It can be generated with the `openssl passwd -6 PASSWORD` command
 
-For the production environments, it is recommended to use the SSH keys that can be added to the users block replacing the `$\{USERKEY1\}` with the real SSH keys.
+For the production environments, it is recommended to use the SSH keys that can be added to the users block replacing the `$USERKEY1` with the real SSH keys.
 
 [NOTE]
 ====
@@ -181,7 +181,7 @@ mkdir -p /opt/performance-settings
 cp performance-settings.sh /opt/performance-settings/
 ----
 
-The content of `custom/files/performance-settings.sh` is a script that can be used to configure the system for performance tuning and can be downloaded from the following https://github.com/suse-edge/atip/blob/release-3.1/telco-examples/edge-clusters/dhcp/eib/custom/files/performance-settings.sh[link].
+The content of `custom/files/performance-settings.sh` is a script that can be used to configure the system for performance tuning and can be downloaded from the following {link-atip-performance-settings}[link].
 
 [#add-custom-script-sriov]
 ===== SR-IOV script
@@ -198,7 +198,7 @@ mkdir -p /opt/sriov
 cp sriov-auto-filler.sh /opt/sriov/sriov-auto-filler.sh
 ----
 
-The content of `custom/files/sriov-auto-filler.sh` is a script that can be used to configure the system for SR-IOV and can be downloaded from the following https://github.com/suse-edge/atip/blob/release-3.1/telco-examples/edge-clusters/dhcp/eib/custom/files/sriov-auto-filler.sh[link].
+The content of `custom/files/sriov-auto-filler.sh` is a script that can be used to configure the system for SR-IOV and can be downloaded from the following {link-atip-sriov-auto-filler}[link].
 
 [NOTE]
 ====
@@ -212,13 +212,13 @@ For more information, see <<quickstart-eib>>.
 
 To enable Telco features like `dpdk`, `sr-iov` or `FEC`, additional packages may be required as shown in the following example.
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
-  imageType: RAW
+  imageType: raw
   arch: x86_64
-  baseImage: SL-Micro.x86_64-6.0-Base-RT-GM2.raw
+  baseImage: {micro-base-image-raw}
   outputImageName: eibimage-slmicro60rt-telco.raw
 operatingSystem:
   kernelArgs:
@@ -233,9 +233,9 @@ operatingSystem:
       - time-sync.target
   users:
     - username: root
-      encryptedPassword: ${ROOT_PASSWORD}
+      encryptedPassword: $ROOT_PASSWORD
       sshKeys:
-      - ${user1Key1}
+      - $user1Key1
   packages:
     packageList:
       - jq
@@ -244,11 +244,11 @@ operatingSystem:
       - libdpdk-23
       - pf-bb-config
     additionalRepos:
-      - url: https://download.opensuse.org/repositories/isv:/SUSE:/Edge:/Telco/SL-Micro_6.0_images/
-    sccRegistrationCode: ${SCC_REGISTRATION_CODE}
+      - url: {link-atip-micro-download-url}
+    sccRegistrationCode: $SCC_REGISTRATION_CODE
 ----
 
-Where `$\{SCC_REGISTRATION_CODE\}` is the registration code copied from https://scc.suse.com/[SUSE Customer Center], and the package list contains the minimum packages to be used for the Telco profiles.
+Where `$SCC_REGISTRATION_CODE` is the registration code copied from https://scc.suse.com/[SUSE Customer Center], and the package list contains the minimum packages to be used for the Telco profiles.
 To use the `pf-bb-config` package (to enable the `FEC` feature and binding with drivers), the `additionalRepos` block must be included to add the `SUSE Edge Telco` repository.
 
 [#add-network-eib]
@@ -299,10 +299,10 @@ umount /mnt
 
 Once the directory structure is prepared following the previous sections, run the following command to build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm --privileged -it -v $PWD:/eib \
- registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+ registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
  build --definition-file downstream-cluster-config.yaml
 ----
 
@@ -321,7 +321,7 @@ Much of the configuration is possible with Edge Image Builder, but in this guide
 ==== Prerequisites for air-gap scenarios
 
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop] is required to run Edge Image Builder.
-* The base image `SL-Micro.x86_64-6.0-Base-RT-GM2.raw` must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
+* The base image `{micro-base-image-raw}` must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
 * If you want to use SR-IOV or any other workload which require a container image, a local private registry must be deployed and already configured (with/without TLS and/or authentication). This registry will be used to store the images and the helm chart OCI images.
 
 ==== Image configuration for air-gap scenarios
@@ -338,11 +338,11 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
     4. `04-sriov.sh` script is optional and can be used to configure the system for SR-IOV.
 * The `custom/files` directory contains the `rke2` and the `cni` images to be copied to the image during the image creation process. Also, the optional `performance-settings.sh` and `sriov-auto-filler.sh` files can be included.
 
-[,console]
+[,console,subs="attributes"]
 ----
 ├── downstream-cluster-airgap-config.yaml
 ├── base-images/
-│   └ SL-Micro.x86_64-6.0-Base-RT-GM2.raw
+│   └ {micro-base-image-raw}
 ├── network/
 |   └ configure-network.sh
 └── custom/
@@ -422,7 +422,7 @@ mkdir -p /opt/performance-settings
 cp performance-settings.sh /opt/performance-settings/
 ----
 
-The content of `custom/files/performance-settings.sh` is a script that can be used to configure the system for performance tuning and can be downloaded from the following https://github.com/suse-edge/atip/blob/release-3.1/telco-examples/edge-clusters/dhcp/eib/custom/files/performance-settings.sh[link].
+The content of `custom/files/performance-settings.sh` is a script that can be used to configure the system for performance tuning and can be downloaded from the following {link-atip-performance-settings}[link].
 
 [#add-custom-script-sriov2]
 ===== SR-IOV script
@@ -444,7 +444,7 @@ The content of `custom/files/sriov-auto-filler.sh` is a script that can be used 
 ===== Custom files for air-gap scenarios
 
 The `custom/files` directory contains the `rke2` and the `cni` images to be copied to the image during the image creation process.
-To easily generate the images, prepare them locally using following https://github.com/suse-edge/fleet-examples/blob/release-3.0/scripts/day2/edge-save-rke2-images.sh[script] and the list of images https://github.com/suse-edge/fleet-examples/blob/release-3.0/scripts/day2/edge-release-rke2-images.txt[here] to generate the artifacts required to be included in `custom/files`.
+To easily generate the images, prepare them locally using following {link-lifecycle-save-images}[script] and the list of images {link-lifecycle-rke2-images}[here] to generate the artifacts required to be included in `custom/files`.
 Also, you can download the latest `rke2-install` script from https://get.rke2.io/[here].
 
 [,shell]
@@ -481,27 +481,27 @@ The following scripts can be used to download, extract, and push the images to t
 +
 .. You must create a list with the helm-chart OCI images required:
 +
-[,shell]
+[,shell,subs="attributes,specialchars"]
 ----
 $ cat > edge-release-helm-oci-artifacts.txt <<EOF
-edge/sriov-network-operator-chart:1.3.0
-edge/sriov-crd-chart:1.3.0
+edge/sriov-network-operator-chart:{version-sriov-network-operator-chart}
+edge/sriov-crd-chart:{version-sriov-crd-chart}
 EOF
 ----
 +
-.. Generate a local tarball file using the following https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-save-oci-artefacts.sh[script] and the list created above:
+.. Generate a local tarball file using the following {link-lifecycle-save-oci-artifacts}[script] and the list created above:
 +
-[,shell]
+[,shell,subs="attributes"]
 ----
 $ ./edge-save-oci-artefacts.sh -al ./edge-release-helm-oci-artifacts.txt -s registry.suse.com
-Pulled: registry.suse.com/edge/3.1/sriov-network-operator-chart:1.3.0
-Pulled: registry.suse.com/edge/3.1/sriov-crd-chart:1.3.0
+Pulled: registry.suse.com/edge/{version-edge-registry}/sriov-network-operator-chart:{version-sriov-network-operator-chart}
+Pulled: registry.suse.com/edge/{version-edge-registry}/sriov-crd-chart:{version-sriov-crd-chart}
 a edge-release-oci-tgz-20240705
-a edge-release-oci-tgz-20240705/sriov-network-operator-chart-1.3.0.tgz
-a edge-release-oci-tgz-20240705/sriov-crd-chart-1.3.0.tgz
+a edge-release-oci-tgz-20240705/sriov-network-operator-chart-{version-sriov-network-operator-chart}.tgz
+a edge-release-oci-tgz-20240705/sriov-crd-chart-{version-sriov-crd-chart}.tgz
 ----
 +
-.. Upload your tarball file to your private registry (e.g. `myregistry:5000`) using the following https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-load-oci-artefacts.sh[script] to preload your registry with the helm chart OCI images downloaded in the previous step:
+.. Upload your tarball file to your private registry (e.g. `myregistry:5000`) using the following {link-lifecycle-load-oci-artifacts}[script] to preload your registry with the helm chart OCI images downloaded in the previous step:
 +
 [,shell]
 ----
@@ -511,7 +511,7 @@ $ ./edge-load-oci-artefacts.sh -ad edge-release-oci-tgz-20240705 -r myregistry:5
 
 . Preload with the rest of the images required for SR-IOV:
 +
-.. In this case, we must include the `sr-iov container images for telco workloads (e.g. as a reference, you could get them from https://github.com/suse-edge/charts/blob/release-3.1/charts/sriov-network-operator/1.3.0%2Bup0.1.0/values.yaml[helm-chart values])
+.. In this case, we must include the `sr-iov container images for telco workloads (e.g. as a reference, you could get them from {link-atip-sriov-operator-values}[helm-chart values])
 +
 [,shell]
 ----
@@ -526,7 +526,7 @@ rancher/hardened-sriov-network-webhook:v1.3.0-build20240816
 EOF
 ----
 +
-.. Using the following https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-save-images.sh[script] and the list created above, you must generate locally the tarball file with the images required:
+.. Using the following {link-lifecycle-save-images}[script] and the list created above, you must generate locally the tarball file with the images required:
 +
 [,shell]
 ----
@@ -541,7 +541,7 @@ Image pull success: registry.suse.com/rancher/hardened-sriov-network-webhook:v1.
 Creating edge-images.tar.gz with 7 images
 ----
 +
-.. Upload your tarball file to your private registry (e.g. `myregistry:5000`) using the following https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-load-images.sh[script] to preload your private registry with the images downloaded in the previous step:
+.. Upload your tarball file to your private registry (e.g. `myregistry:5000`) using the following {link-lifecycle-load-images}[script] to preload your private registry with the images downloaded in the previous step:
 +
 [,shell]
 ----
@@ -554,10 +554,10 @@ $ ./edge-load-images.sh -ad edge-release-images-tgz-20240705 -r myregistry:5000
 
 Once the directory structure is prepared following the previous sections, run the following command to build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm --privileged -it -v $PWD:/eib \
- registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+ registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
  build --definition-file downstream-cluster-airgap-config.yaml
 ----
 

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -706,7 +706,7 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
 Also, it contains the information about the number of replicas to be used (in this case, one) and the `CNI` plug-in to be used (in this case, `Cilium`).
 The agentConfig block contains the `Ignition` format to be used and the `additionalUserData` to be used to configure the `RKE2` node with information like a systemd named `rke2-preinstall.service` to replace automatically the `BAREMETALHOST_UUID` and `node-name` during the provisioning process using the Ironic information.
 To enable multus with cilium a file is created in the `rke2` server manifests directory named `rke2-cilium-config.yaml` with the configuration to be used.
-The last block of information contains the Kubernetes version to be used. `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.30.5+rke2r1`).
+The last block of information contains the Kubernetes version to be used. `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `{version-kubernetes-rke2}`).
 
 [,yaml]
 ----
@@ -983,7 +983,7 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
     ** The `storage` block which contains the Helm charts to be used to install the `MetalLB` and the `endpoint-copier-operator`.
     ** The `metalLB` custom resource file with the `IPaddressPool` and the `L2Advertisement` to be used (replacing `$\{EDGE_VIP_ADDRESS\}` with the `VIP` address).
     ** The `endpoint-svc.yaml` file to be used to configure the `kubernetes-vip` service to be used by the `MetalLB` to manage the `VIP` address.
-* The last block of information contains the Kubernetes version to be used. The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.30.5+rke2r1`).
+* The last block of information contains the Kubernetes version to be used. The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `{version-kubernetes-rke2}`).
 
 [,yaml]
 ----
@@ -1063,7 +1063,7 @@ spec:
                   spec:
                     chart: oci://registry.suse.com/edge/3.1/endpoint-copier-operator-chart
                     targetNamespace: endpoint-copier-operator
-                    version: 0.2.1
+                    version: {version-endpoint-copier-operator-chart}
                     createNamespace: true
             - path: /var/lib/rancher/rke2/server/manifests/metallb.yaml
               overwrite: true
@@ -1077,7 +1077,7 @@ spec:
                   spec:
                     chart: oci://registry.suse.com/edge/3.1/metallb-chart
                     targetNamespace: metallb-system
-                    version: 0.14.9
+                    version: {version-metallb-chart}
                     createNamespace: true
 
             - path: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml
@@ -1398,7 +1398,7 @@ To make the process clear, the changes required on that block (`RKE2ControlPlane
     ** `performance-settings.service` to enable the CPU performance tuning.
     ** `sriov-custom-auto-vfs.service` to install the `sriov` Helm chart, wait until custom resources are created and run the `/var/sriov-auto-filler.sh` to replace the values in the config map `sriov-custom-auto-config` and create the `sriovnetworknodepolicy` to be used by the workloads.
 
-* The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `v1.30.5+rke2r1`).
+* The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `{version-kubernetes-rke2}`).
 
 With all these changes mentioned, the `RKE2ControlPlane` block in the `capi-provisioning-example.yaml` will look like the following:
 

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1111,7 +1111,7 @@ To enable `MetalLB` in the `RKE2` cluster, the following steps are required:
 
 * Install `MetalLB` using the following command:
 
-[,shell]
+[,shell,subs="attributes,specialchars"]
 ----
 $ kubectl apply <<EOF -f
 apiVersion: helm.cattle.io/v1
@@ -1120,9 +1120,9 @@ metadata:
   name: metallb
   namespace: kube-system
 spec:
-  chart: oci://registry.suse.com/edge/3.1/metallb-chart
+  chart: oci://registry.suse.com/edge/{version-edge-registry}/metallb-chart
   targetNamespace: metallb-system
-  version: 0.14.9
+  version: {version-metallb-chart}
   createNamespace: true
 ---
 apiVersion: helm.cattle.io/v1
@@ -1131,9 +1131,9 @@ metadata:
   name: endpoint-copier-operator
   namespace: kube-system
 spec:
-  chart: oci://registry.suse.com/edge/3.1/endpoint-copier-operator-chart
+  chart: oci://registry.suse.com/edge/{version-edge-registry}/endpoint-copier-operator-chart
   targetNamespace: endpoint-copier-operator
-  version: 0.2.1
+  version: {version-endpoint-copier-operator-chart}
   createNamespace: true
 EOF
 ----

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -32,13 +32,13 @@ helm fetch suse-edge/metal3
 After that, the easy way to upgrade is to export your current configurations to a file, and then upgrade the `Metal^3^` version using that previous file.
 If any change is required in the new version, the file can be edited before the upgrade.
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 helm get values metal3 -n metal3-system -o yaml > metal3-values.yaml
 helm upgrade metal3 suse-edge/metal3 \
   --namespace metal3-system \
   -f metal3-values.yaml \
-  --version=0.8.3
+  --version={version-metal3-chart}
 ----
 
 === Downstream cluster upgrades

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -127,7 +127,7 @@ eib
 
 [NOTE]
 ====
-The image `SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso` must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page], and it must be located under the `base-images` folder.
+The image `{micro-base-image-iso}` must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page], and it must be located under the `base-images` folder.
 
 You should check the SHA256 checksum of the image to ensure it has not been tampered with. The checksum can be found in the same location where the image was downloaded.
 
@@ -139,77 +139,77 @@ An example of the directory structure can be found in the https://github.com/sus
 
 The `mgmt-cluster.yaml` file is the main definition file for the management cluster. It contains the following information:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
   imageType: iso
   arch: x86_64
-  baseImage: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
+  baseImage: {micro-base-image-iso}
   outputImageName: eib-mgmt-cluster-image.iso
 operatingSystem:
   isoConfiguration:
     installDevice: /dev/sda
   users:
   - username: root
-    encryptedPassword: ${ROOT_PASSWORD}
+    encryptedPassword: $ROOT_PASSWORD
   packages:
     packageList:
     - git
     - jq
-    sccRegistrationCode: ${SCC_REGISTRATION_CODE}
+    sccRegistrationCode: $SCC_REGISTRATION_CODE
 kubernetes:
-  version: ${KUBERNETES_VERSION}
+  version: {version-kubernetes-rke2}
   helm:
     charts:
       - name: cert-manager
         repositoryName: jetstack
-        version: 1.15.3
+        version: {version-cert-manager}
         targetNamespace: cert-manager
         valuesFile: certmanager.yaml
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn-crd
-        version: 104.2.0+up1.7.1
+        version: {version-longhorn-crd-chart}
         repositoryName: rancher-charts
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn
-        version: 104.2.0+up1.7.1
+        version: {version-longhorn-chart}
         repositoryName: rancher-charts
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.8.3
+        version: {version-metal3-chart}
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: rancher-turtles-chart
-        version: 0.3.3
+        version: {version-rancher-turtles}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
         installationNamespace: kube-system
       - name: neuvector-crd
-        version: 104.0.1+up2.7.9
+        version: {version-neuvector-crd-chart}
         repositoryName: rancher-charts
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: neuvector
-        version: 104.0.1+up2.7.9
+        version: {version-neuvector-chart}
         repositoryName: rancher-charts
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.9.3
+        version: {version-rancher-prime}
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -221,12 +221,12 @@ kubernetes:
       - name: rancher-charts
         url: https://charts.rancher.io/
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/{version-edge-registry}
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
   network:
-    apiHost: ${API_HOST}
-    apiVIP: ${API_VIP}
+    apiHost: $API_HOST
+    apiVIP: $API_VIP
   nodes:
     - hostname: mgmt-cluster-node1
       initializer: true
@@ -241,12 +241,12 @@ To explain the fields and values in the `mgmt-cluster.yaml` definition file, we 
 
 - Image section (definition file):
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 image:
   imageType: iso
   arch: x86_64
-  baseImage: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
+  baseImage: {micro-base-image-iso}
   outputImageName: eib-mgmt-cluster-image.iso
 ----
 
@@ -261,11 +261,11 @@ operatingSystem:
     installDevice: /dev/sda
   users:
   - username: root
-    encryptedPassword: ${ROOT_PASSWORD}
+    encryptedPassword: $ROOT_PASSWORD
   packages:
     packageList:
     - jq
-    sccRegistrationCode: ${SCC_REGISTRATION_CODE}
+    sccRegistrationCode: $SCC_REGISTRATION_CODE
 ----
 
 where the `installDevice` is the device to be used to install the operating system, the `username` and `encryptedPassword` are the credentials to be used to access the system, the `packageList` is the list of packages to be installed (`jq` is required internally during the installation process), and the `sccRegistrationCode` is the registration code used to get the packages and dependencies at build time and can be obtained from the SUSE Customer Center.
@@ -285,60 +285,60 @@ $6$UrXB1sAGs46DOiSq$HSwi9GFJLCorm0J53nF2Sq8YEoyINhHcObHzX2R8h13mswUIsMwzx4eUzn/r
 
 - Kubernetes section (definition file):
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 kubernetes:
-  version: ${KUBERNETES_VERSION}
+  version: {version-kubernetes-rke2}
   helm:
     charts:
       - name: cert-manager
         repositoryName: jetstack
-        version: 1.15.3
+        version: {version-cert-manager}
         targetNamespace: cert-manager
         valuesFile: certmanager.yaml
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn-crd
-        version: 104.2.0+up1.7.1
+        version: {version-longhorn-crd-chart}
         repositoryName: rancher-charts
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn
-        version: 104.2.0+up1.7.1
+        version: {version-longhorn-chart}
         repositoryName: rancher-charts
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.8.3
+        version: {version-metal3-chart}
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: rancher-turtles-chart
-        version: 0.3.3
+        version: {version-rancher-turtles}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
         installationNamespace: kube-system
       - name: neuvector-crd
-        version: 104.0.1+up2.7.9
+        version: {version-neuvector-crd-chart}
         repositoryName: rancher-charts
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: neuvector
-        version: 104.0.1+up2.7.9
+        version: {version-neuvector-chart}
         repositoryName: rancher-charts
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.9.3
+        version: {version-rancher-prime}
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -350,12 +350,12 @@ kubernetes:
       - name: rancher-charts
         url: https://charts.rancher.io/
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/{version-edge-registry}
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
     network:
-      apiHost: ${API_HOST}
-      apiVIP: ${API_VIP}
+      apiHost: $API_HOST
+      apiVIP: $API_VIP
     nodes:
     - hostname: mgmt-cluster-node1
       initializer: true
@@ -365,8 +365,6 @@ kubernetes:
 #   - hostname: mgmt-cluster-node3
 #     type: server
 ----
-
-where `version` is the version of Kubernetes to be installed. In our case, we are using an RKE2 cluster, so the version must be minor less than 1.29 to be compatible with `Rancher` (for example, `v1.30.5+rke2r1`).
 
 The `helm` section contains the list of Helm charts to be installed, the repositories to be used, and the version configuration for all of them.
 
@@ -980,83 +978,83 @@ The `mgmt-cluster.yaml` file must be modified to include the `embeddedArtifactRe
 
 The `rancher-turtles-airgap-resources` helm chart must also be added, this creates resources as described in the https://turtles.docs.rancher.com/getting-started/air-gapped-environment[Rancher Turtles Airgap Documentation].  This also requires a turtles.yaml values file for the rancher-turtles chart to specify the necessary configuration.
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: 1.0
 image:
   imageType: iso
   arch: x86_64
-  baseImage: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
+  baseImage: {micro-base-image-iso}
   outputImageName: eib-mgmt-cluster-image.iso
 operatingSystem:
   isoConfiguration:
     installDevice: /dev/sda
   users:
   - username: root
-    encryptedPassword: ${ROOT_PASSWORD}
+    encryptedPassword: $ROOT_PASSWORD
   packages:
     packageList:
     - jq
-    sccRegistrationCode: ${SCC_REGISTRATION_CODE}
+    sccRegistrationCode: $SCC_REGISTRATION_CODE
 kubernetes:
-  version: ${KUBERNETES_VERSION}
+  version: {version-kubernetes-rke2}
   helm:
     charts:
       - name: cert-manager
         repositoryName: jetstack
-        version: 1.15.3
+        version: {version-cert-manager}
         targetNamespace: cert-manager
         valuesFile: certmanager.yaml
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn-crd
-        version: 104.2.0+up1.7.1
+        version: {version-longhorn-crd-chart}
         repositoryName: rancher-charts
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn
-        version: 104.2.0+up1.7.1
+        version: {version-longhorn-chart}
         repositoryName: rancher-charts
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.8.3
+        version: {version-metal3-chart}
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: rancher-turtles-chart
-        version: 0.3.3
+        version: {version-rancher-turtles}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: turtles.yaml
       - name: rancher-turtles-airgap-resources-chart
-        version: 0.3.3
+        version: {version-rancher-turtles}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
         installationNamespace: kube-system
       - name: neuvector-crd
-        version: 104.0.1+up2.7.9
+        version: {version-neuvector-crd-chart}
         repositoryName: rancher-charts
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: neuvector
-        version: 104.0.1+up2.7.9
+        version: {version-neuvector-chart}
         repositoryName: rancher-charts
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.9.3
+        version: {version-rancher-prime}
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -1068,12 +1066,12 @@ kubernetes:
       - name: rancher-charts
         url: https://charts.rancher.io/
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/{version-edge-registry}
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
     network:
-      apiHost: ${API_HOST}
-      apiVIP: ${API_VIP}
+      apiHost: $API_HOST
+      apiVIP: $API_VIP
     nodes:
     - hostname: mgmt-cluster-node1
       initializer: true
@@ -1198,10 +1196,10 @@ cluster-api-operator:
 
 Once the directory structure is prepared following the previous sections (for both, connected and air-gap scenarios), run the following command to build the image:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 podman run --rm --privileged -it -v $PWD:/eib \
- registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+ registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
  build --definition-file mgmt-cluster.yaml
 ----
 

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -189,7 +189,7 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: rancher-turtles-chart
-        version: {version-rancher-turtles}
+        version: {version-rancher-turtles-chart}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
@@ -318,7 +318,7 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: rancher-turtles-chart
-        version: {version-rancher-turtles}
+        version: {version-rancher-turtles-chart}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
@@ -1027,14 +1027,14 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: rancher-turtles-chart
-        version: {version-rancher-turtles}
+        version: {version-rancher-turtles-chart}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: turtles.yaml
       - name: rancher-turtles-airgap-resources-chart
-        version: {version-rancher-turtles}
+        version: {version-rancher-turtles-chart}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -48,11 +48,11 @@ export CONFIG_DIR=$HOME/eib
 mkdir -p $CONFIG_DIR/base-images
 ----
 
-In the previous step we created a "base-images" directory that will host the SLE Micro 6.0 input image, let's ensure that the downloaded image is copied over to the configuration directory:
+In the previous step we created a "base-images" directory that will host the SLE Micro {version-operatingsystem} input image, let's ensure that the downloaded image is copied over to the configuration directory:
 
 [,shell,subs="attributes"]
 ----
-cp /path/to/downloads/{micro-base-image} $CONFIG_DIR/base-images/slemicro.iso
+cp /path/to/downloads/{micro-base-image-iso} $CONFIG_DIR/base-images/slemicro.iso
 ----
 
 

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -250,7 +250,7 @@ apiVersion: 1.0
 image:
     imageType: iso
     arch: x86_64
-    baseImage: {micro-base-image}
+    baseImage: {micro-base-image-iso}
     outputImageName: elemental-image.iso
 operatingSystem:
   isoConfiguration:

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -50,7 +50,7 @@ Some tools are required, these can be installed either on the management cluster
 * https://kubernetes.io/docs/reference/kubectl/kubectl/[Kubectl], https://helm.sh[Helm] and https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl[Clusterctl]
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop]
 
-The `{micro-base-image}` OS image file must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
+The `{micro-base-image-raw}` OS image file must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
 
 === Setup Management Cluster
 
@@ -198,7 +198,7 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
 ----
 ├── downstream-cluster-config.yaml
 ├── base-images/
-│   └ {micro-base-image}
+│   └ {micro-base-image-raw}
 ├── network/
 |   └ configure-network.sh
 └── custom/
@@ -214,9 +214,9 @@ The `downstream-cluster-config.yaml` file is the main configuration file for the
 ----
 apiVersion: 1.0
 image:
-  imageType: RAW
+  imageType: raw
   arch: x86_64
-  baseImage: {micro-base-image}
+  baseImage: {micro-base-image-raw}
   outputImageName: SLE-Micro-eib-output.raw
 operatingSystem:
   kernelArgs:


### PR DESCRIPTION
See #495 for more context.

This PR includes the last of the sweeping changes to use attributes for versions. The bottom of the `versions.adoc` file shows the list of pages that need to be manually reviewed. I included `releasenotes.md` in that list rather than attempt to template it, though I may resurrect the old version matrix page and have it pull values from the variables. 

But this is the last of the major refactoring. Any further work on this should hopefully be less disruptive and not put a pause on others doing docs work.