### PR TITLE
change v1alpha1 from capi controlplane and minor changes

### DIFF
--- a/asciidoc/components/rke2.adoc
+++ b/asciidoc/components/rke2.adoc
@@ -51,7 +51,7 @@ In those cases, the RKE2 configuration must be applied on the different CRDs inv
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -110,7 +110,7 @@ image:
   imageType: raw
   arch: x86_64
   baseImage: {micro-base-image-raw}
-  outputImageName: eibimage-slmicro60rt-telco.raw
+  outputImageName: eibimage-output-telco.raw
 operatingSystem:
   kernelArgs:
     - ignition.platform.id=openstack
@@ -219,7 +219,7 @@ image:
   imageType: raw
   arch: x86_64
   baseImage: {micro-base-image-raw}
-  outputImageName: eibimage-slmicro60rt-telco.raw
+  outputImageName: eibimage-output-telco.raw
 operatingSystem:
   kernelArgs:
     - ignition.platform.id=openstack
@@ -306,7 +306,7 @@ podman run --rm --privileged -it -v $PWD:/eib \
  build --definition-file downstream-cluster-config.yaml
 ----
 
-This creates the output ISO image file named `eibimage-slmicro60rt-telco.raw`, based on the definition described above.
+This creates the output ISO image file named `eibimage-output-telco.raw`, based on the definition described above.
 
 The output image must then be made available via a webserver, either the media-server container enabled via the <<metal3-media-server,Management Cluster Documentation>>
 or some other locally accessible server.  In the examples below, we refer to this server as `imagecache.local:8080`
@@ -561,7 +561,7 @@ podman run --rm --privileged -it -v $PWD:/eib \
  build --definition-file downstream-cluster-airgap-config.yaml
 ----
 
-This creates the output ISO image file named `eibimage-slmicro60rt-telco.raw`, based on the definition described above.
+This creates the output ISO image file named `eibimage-output-telco.raw`, based on the definition described above.
 
 The output image must then be made available via a webserver, either the media-server container enabled via the <<metal3-media-server,Management Cluster Documentation>>
 or some other locally accessible server.  In the examples below, we refer to this server as `imagecache.local:8080`.
@@ -677,7 +677,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
@@ -710,7 +710,7 @@ The last block of information contains the Kubernetes version to be used. `$\{RK
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -721,6 +721,7 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
   serverConfig:
     cni: cilium
   agentConfig:
@@ -772,7 +773,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ----
 
@@ -798,10 +798,10 @@ spec:
         matchLabels:
           cluster-role: control-plane
       image:
-        checksum: http://imagecache.local:8080/eibimage-slmicro60rt-telco.raw.sha256
+        checksum: http://imagecache.local:8080/eibimage-output-telco.raw.sha256
         checksumType: sha256
         format: raw
-        url: http://imagecache.local:8080/eibimage-slmicro60rt-telco.raw
+        url: http://imagecache.local:8080/eibimage-output-telco.raw
 ----
 
 The `Metal3DataTemplate` object specifies the `metaData` for the downstream cluster.
@@ -949,7 +949,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
@@ -987,7 +987,7 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
@@ -998,6 +998,7 @@ spec:
     kind: Metal3MachineTemplate
     name: multinode-cluster-controlplane
   replicas: 3
+  version: ${RKE2_VERSION}
   registrationMethod: "address"
   registrationAddress: ${EDGE_VIP_ADDRESS}
   serverConfig:
@@ -1133,7 +1134,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "Node-multinode-cluster"
 ----
 
@@ -1159,10 +1159,10 @@ spec:
         matchLabels:
           cluster-role: control-plane
       image:
-        checksum: http://imagecache.local:8080/eibimage-slmicro60rt-telco.raw.sha256
+        checksum: http://imagecache.local:8080/eibimage-output-telco.raw.sha256
         checksumType: sha256
         format: raw
-        url: http://imagecache.local:8080/eibimage-slmicro60rt-telco.raw
+        url: http://imagecache.local:8080/eibimage-output-telco.raw
 ----
 
 The `Metal3DataTemplate` object specifies the `metaData` for the downstream cluster.
@@ -1230,6 +1230,7 @@ stringData:
       type: ethernet
       state: up
       mtu: 1500
+      identifier: mac-address
       mac-address: "${CONTROLPLANE_MAC}"
       ipv4:
         address:
@@ -1258,7 +1259,7 @@ This file contains the `networkData` in a `nmstate` format to be used to configu
 As you can see, the example shows the configuration to enable the interface with static IPs, as well as the configuration to enable the VLAN using the base interface.
 Any other `nmstate` example could be defined to be used to configure the network for the downstream cluster to adapt to the specific requirements, where the following variables have to be replaced with real values:
 
-- `$\{CONTROLPLANE1_INTERFACE\}` — The control-plane interface to be used for the edge cluster (for example, `eth0`).
+- `$\{CONTROLPLANE1_INTERFACE\}` — The control-plane interface to be used for the edge cluster (for example, `eth0`). Including `identifier: mac-address` the naming is inspected automatically by the MAC address so any interface name can be used.
 - `$\{CONTROLPLANE1_IP\}` — The IP address to be used as an endpoint for the edge cluster (must match with the kubeapi-server endpoint).
 - `$\{CONTROLPLANE1_PREFIX\}` — The CIDR to be used for the edge cluster (for example, `24` if you want `/24` or `255.255.255.0`).
 - `$\{CONTROLPLANE1_GATEWAY\}` — The gateway to be used for the edge cluster (for example, `192.168.100.1`).
@@ -1404,7 +1405,7 @@ With all these changes mentioned, the `RKE2ControlPlane` block in the `capi-prov
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -1415,6 +1416,7 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
   serverConfig:
     cni: calico
     cniMultusEnable: true
@@ -1576,7 +1578,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ----
 
@@ -1628,7 +1629,7 @@ With all these changes mentioned, the `RKE2ControlPlane` block in the `capi-prov
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -1639,6 +1640,7 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
   privateRegistriesConfig:
     mirrors:
       "registry.example.com":
@@ -1688,7 +1690,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ----
 
@@ -1749,7 +1750,7 @@ data:
   username: ${REGISTRY_USERNAME}
   password: ${REGISTRY_PASSWORD}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -1760,6 +1761,7 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
   privateRegistriesConfig:       # Private registry configuration to add your own mirror and credentials
     mirrors:
       docker.io:
@@ -1985,7 +1987,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ----
 

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -62,7 +62,7 @@ The changes required to upgrade the `RKE2` cluster using the automated workflow 
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -72,12 +72,14 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
+  version: ${RKE2_NEW_VERSION}
   replicas: 1
   serverConfig:
     cni: cilium
   rolloutStrategy:
     rollingUpdate:
       maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   agentConfig:
     format: ignition
     additionalUserData:
@@ -106,7 +108,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_NEW_VERSION}
     nodeName: "localhost.localdomain"
 ----
 

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -974,7 +974,14 @@ This section describes how to prepare the image for air-gap environments showing
 [#mgmt-cluster-image-definition-file-airgap]
 ==== Modifications in the definition file
 
-The `mgmt-cluster.yaml` file must be modified to include the `embeddedArtifactRegistry` section with the `images` field set to all container images to be included into the EIB output image. The `images` field must contain the list of all container images to be included in the output image. The following is an example of the `mgmt-cluster.yaml` file with the `embeddedArtifactRegistry` section included:
+The `mgmt-cluster.yaml` file must be modified to include the `embeddedArtifactRegistry` section.
+In this section the `images` field must contain the list of all container images to be included in the output image.
+
+[NOTE]
+====
+The following is an example of the `mgmt-cluster.yaml` file with the `embeddedArtifactRegistry` section included.
+Make sure to the listed images contain the component versions you need.
+====
 
 The `rancher-turtles-airgap-resources` helm chart must also be added, this creates resources as described in the https://turtles.docs.rancher.com/getting-started/air-gapped-environment[Rancher Turtles Airgap Documentation].  This also requires a turtles.yaml values file for the rancher-turtles chart to specify the necessary configuration.
 

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -466,7 +466,7 @@ To deploy the controlplane we define a yaml manifest similar to the one below, w
 Note for simplicity this example assumes a single-node controlplane, where the BareMetalHost is configured with an IP of `192.168.125.200` - for more
 advanced multi-node examples please see the <<atip-automated-provisioning, ATIP documentation>>
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -482,7 +482,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: sample-cluster
   infrastructureRef:
@@ -501,7 +501,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: sample-cluster
@@ -512,6 +512,7 @@ spec:
     kind: Metal3MachineTemplate
     name: sample-cluster-controlplane
   replicas: 1
+  version: {version-kubernetes-rke2}
   agentConfig:
     format: ignition
     kubelet:
@@ -540,7 +541,6 @@ spec:
                 ExecStartPost=/bin/sh -c "umount /mnt"
                 [Install]
                 WantedBy=multi-user.target
-    version: v1.30.5+rke2r1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
@@ -602,7 +602,7 @@ Similar to the controlplane we define a yaml manifest, which contains the follow
 * Metal3MachineTemplate defines the OS Image to be applied to the BareMetalHost resources, and the hostSelector defines which BareMetalHosts to consume
 * Metal3DataTemplate defines additional metaData to be passed to the BareMetalHost (note networkData is not currently supported in the Edge solution)
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -633,7 +633,7 @@ spec:
         kind: Metal3MachineTemplate
         name: sample-cluster-workers
       nodeDrainTimeout: 0s
-      version: v1.30.5+rke2r1
+      version: {version-kubernetes-rke2}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: RKE2ConfigTemplate
@@ -645,7 +645,7 @@ spec:
     spec:
       agentConfig:
         format: ignition
-        version: v1.30.5+rke2r1
+        version: {version-kubernetes-rke2}
         kubelet:
           extraArgs:
             - provider-id=metal3://BAREMETALHOST_UUID


### PR DESCRIPTION
- Change to move from v1alpha1 to v1beta1 in rke2controlplane 
- version in spec out of the agentConfig
2nd EDIT:
- Add the identifier mac to the bmh spec file
- remove OS version from the images to make it easy to be updated