### PR TITLE
metal3-quickstart: update known issues

### DIFF
--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -761,13 +761,9 @@ worker-0         available              false            15m
 * The upstream https://github.com/metal3-io/ip-address-manager[IP Address Management controller] is currently not supported, because it's not yet compatible with our choice of network configuration tooling and first-boot toolchain in SLEMicro.
 * Relatedly, the IPAM resources and Metal3DataTemplate networkData fields are not currently supported.
 * Only deployment via redfish-virtualmedia is currently supported.
-* Deployed clusters are not currently imported into Rancher
-* Due to disabling the Rancher embedded CAPI controller, a management cluster configured for Metal^3^ as described above cannot also be used for other cluster provisioning methods such as <<components-elemental, Elemental>>
 
 == Planned changes
 
-* Deployed clusters imported into Rancher, this is planned via https://turtles.docs.rancher.com/[Rancher Turtles] in future
-* Aligning with Rancher Turtles is also expected to remove the requirement to disable the Rancher embedded CAPI, so other cluster methods should be possible via the management cluster.
 * Enable support of the IPAM resources and configuration via networkData fields
 
 == Additional resources


### PR DESCRIPTION
The issues mentioned are no longer relevant since 3.1, when we aligned with Rancher Turtles.

Additional information regarding the Turtles integration will be added via a follow-up PR