### PR TITLE
Use versioned Rancher docs links

### DIFF
--- a/asciidoc/components/fleet.adoc
+++ b/asciidoc/components/fleet.adoc
@@ -17,7 +17,7 @@ https://fleet.rancher.io[Fleet] is a container management and deployment engine 
 
 Fleet can manage deployments from Git of raw Kubernetes YAML, Helm charts, Kustomize, or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy all resources in the cluster. As a result, users can enjoy a high degree of control, consistency and auditability of their clusters.
 
-For information about how Fleet works, see https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/architecture[this page].
+For information about how Fleet works, see https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/fleet/architecture[this page].
 
 == Installing Fleet with Helm
 

--- a/asciidoc/components/rancher-dashboard-extensions.adoc
+++ b/asciidoc/components/rancher-dashboard-extensions.adoc
@@ -49,7 +49,7 @@ image::dashboard-extensions-available-extensions.png[]
 
 . On the extension card click `Install` and confirm the installation.
 +
-Once the extension is installed Rancher UI prompts to reload the page as described in the `https://ranchermanager.docs.rancher.com/integrations-in-rancher/rancher-extensions#installing-extensions[Installing Extensions Rancher documentation page]`.
+Once the extension is installed Rancher UI prompts to reload the page as described in the `https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/rancher-extensions#installing-extensions[Installing Extensions Rancher documentation page]`.
 
 
 

--- a/asciidoc/components/rancher.adoc
+++ b/asciidoc/components/rancher.adoc
@@ -12,7 +12,7 @@ ifdef::env-github[]
 endif::[]
 
 
-See Rancher upstream documentation at https://ranchermanager.docs.rancher.com.
+See Rancher documentation at https://ranchermanager.docs.rancher.com/{rancher-docs-version}.
 
 [quote]
 ____

--- a/asciidoc/components/system-upgrade-controller.adoc
+++ b/asciidoc/components/system-upgrade-controller.adoc
@@ -53,7 +53,7 @@ Using Fleet, there are two possible resources that can be used to deploy SUC:
 
 [NOTE]
 ====
-This process can also be done through the Rancher UI, if such is available. For more information, see link:https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Accessing Fleet in the Rancher UI].
+This process can also be done through the Rancher UI, if such is available. For more information, see link:https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Accessing Fleet in the Rancher UI].
 ====
 
 In your *management* cluster:

--- a/asciidoc/day2/downstream-cluster-helm.adoc
+++ b/asciidoc/day2/downstream-cluster-helm.adoc
@@ -324,7 +324,7 @@ While deploying your Fleet, if you get a `Modified` message, make sure to add a 
 
 Fleet's link:https://fleet.rancher.io/ref-gitrepo[GitRepo] resource holds information on how to access your chart's Fleet resources and to which clusters it needs to apply those resources.
 
-The `GitRepo` resource can be deployed through the link:https://ranchermanager.docs.rancher.com/v2.8/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI], or manually, by link:https://fleet.rancher.io/tut-deployment[deploying] the resource to the `management cluster`.
+The `GitRepo` resource can be deployed through the link:https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Rancher UI], or manually, by link:https://fleet.rancher.io/tut-deployment[deploying] the resource to the `management cluster`.
 
 _Example *Longhorn* `GitRepo` resource for *manual* deployment:_
 
@@ -560,7 +560,7 @@ The steps below depend on the environment that you are running:
 
 .. Configure a `GitRepo` resource that will be used to ship all the resources of the `eib-charts-upgrader` Fleet.
 
-... For `GitRepo` configuration and deployment through the Rancher UI, see link:https://ranchermanager.docs.rancher.com/v2.8/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Accessing Fleet in the Rancher UI].
+... For `GitRepo` configuration and deployment through the Rancher UI, see link:https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Accessing Fleet in the Rancher UI].
 
 ... For `GitRepo` manual configuration and deployment, see link:https://fleet.rancher.io/tut-deployment[Creating a Deployment].
 

--- a/asciidoc/day2/downstream-cluster-k8s.adoc
+++ b/asciidoc/day2/downstream-cluster-k8s.adoc
@@ -14,7 +14,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-This section covers Kubernetes upgrades for downstream clusters that have *NOT* been created through a <<components-rancher,Rancher>> instance. For information on how to upgrade the Kubernetes version of `Rancher` created clusters, see link:https://ranchermanager.docs.rancher.com/v2.8/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes#upgrading-the-kubernetes-version[Upgrading and Rolling Back Kubernetes].
+This section covers Kubernetes upgrades for downstream clusters that have *NOT* been created through a <<components-rancher,Rancher>> instance. For information on how to upgrade the Kubernetes version of `Rancher` created clusters, see link:https://ranchermanager.docs.rancher.com/{rancher-docs-version}/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes#upgrading-the-kubernetes-version[Upgrading and Rolling Back Kubernetes].
 ====
 
 === Components
@@ -200,7 +200,7 @@ Once deployed, to monitor the Kubernetes upgrade process of the nodes of your ta
 [#k8s-upgrade-suc-plan-deployment-git-repo-rancher]
 ===== GitRepo creation - Rancher UI
 
-To create a `GitRepo` resource through the Rancher UI, follow their official link:https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[documentation].
+To create a `GitRepo` resource through the Rancher UI, follow their official link:https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[documentation].
 
 The Edge team maintains ready to use fleets for both link:https://github.com/suse-edge/fleet-examples/tree/release-3.1.1/fleets/day2/system-upgrade-controller-plans/rke2-upgrade[rke2] and link:https://github.com/suse-edge/fleet-examples/tree/release-3.1.1/fleets/day2/system-upgrade-controller-plans/k3s-upgrade[k3s] Kubernetes distributions, that users can add as a `path` for their GitRepo resource.
 

--- a/asciidoc/day2/downstream-cluster-os.adoc
+++ b/asciidoc/day2/downstream-cluster-os.adoc
@@ -210,7 +210,7 @@ Once deployed, to monitor the OS upgrade process of the nodes of your targeted c
 [#os-upgrade-suc-plan-deployment-git-repo-rancher]
 ===== GitRepo creation - Rancher UI
 
-To create a `GitRepo` resource through the Rancher UI, follow their official link:https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[documentation].
+To create a `GitRepo` resource through the Rancher UI, follow their official link:https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[documentation].
 
 The Edge team maintains a ready to use link:https://github.com/suse-edge/fleet-examples/tree/release-3.1.1/fleets/day2/system-upgrade-controller-plans/os-upgrade[fleet] that users can add as a `path` for their GitRepo resource.
 

--- a/asciidoc/day2/migration.adoc
+++ b/asciidoc/day2/migration.adoc
@@ -896,7 +896,7 @@ spec:
 EOF
 ----
 +
-Alternatively, you can also create the resource through Ranchers' UI, if such is available. For more information, see link:https://ranchermanager.docs.rancher.com/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Accessing Fleet in the Rancher UI].
+Alternatively, you can also create the resource through Ranchers' UI, if such is available. For more information, see link:https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/fleet/overview#accessing-fleet-in-the-rancher-ui[Accessing Fleet in the Rancher UI].
 
 . By creating the above `GitRepo` on your `management` cluster, Fleet will deploy a `SUC Plan` (called `eib-chart-migration-prep`) on each downstream cluster that matches the `targets` specified in the `GitRepo`. To monitor the lifecycle of this plan, refer to <<components-system-upgrade-controller-monitor-plans, "Monitoring System Upgrade Controller Plans">>.
 

--- a/asciidoc/demo_setup/elemental-utm-aarch64.adoc
+++ b/asciidoc/demo_setup/elemental-utm-aarch64.adoc
@@ -46,13 +46,13 @@ The trick here is there is no ARM64 image yet, but just a Raspberry Pi one... so
 
 
 * A Kubernetes cluster where Elemental is deployed. Hint, you can use https://suse-edge.github.io/quickstart/k3s-on-slemicro[the K3s on SLE Micro guide].
-* Rancher server configured (server-url set). Hint: you can use https://ranchermanager.docs.rancher.com/v2.6/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli[the official Rancher] docs or the https://github.com/suse-edge/misc/blob/main/slemicro/create_vm.sh[create_vm.sh] script for inspiration.
+* Rancher server configured (server-url set). Hint: you can use https://ranchermanager.docs.rancher.com/{rancher-docs-version}/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli[the official Rancher] docs or the https://github.com/suse-edge/misc/blob/main/slemicro/create_vm.sh[create_vm.sh] script for inspiration.
 * Helm
 * jq
 
 == Elemental UI Rancher extension
 
-This is an optional step to enable the Elemental UI extension in Rancher (see https://ranchermanager.docs.rancher.com/v2.9/integrations-in-rancher/rancher-extensions[more about Rancher extensions]):
+This is an optional step to enable the Elemental UI extension in Rancher (see https://ranchermanager.docs.rancher.com/{rancher-docs-version}/integrations-in-rancher/rancher-extensions[more about Rancher extensions]):
 
 [,bash]
 ----

--- a/asciidoc/edge-book/welcome.adoc
+++ b/asciidoc/edge-book/welcome.adoc
@@ -65,7 +65,7 @@ It's important to recognize that there are distinct mechanisms in which this con
 2. The downstream clusters are configured to use the built-in onboarding mechanism (e.g. via <<components-elemental,Elemental>>), and they automatically register into the management cluster at first-boot, allowing for late-binding of the cluster configuration.
 3. The downstream clusters have been provisioned with the baremetal management capabilities (CAPI + Metal^3), and they're automatically imported into the management cluster once the cluster has been deployed and configured (via the Rancher Turtles operator).
 
-NOTE: It's recommended that multiple management clusters are implemented to accommodate the scale of large deployments, optimize for bandwidth and latency concerns in geographically dispersed environments, and to minimize the disruption in the event of an outage or management cluster upgrade. You can find the current management cluster scalability limits and system requirements https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements[here].
+NOTE: It's recommended that multiple management clusters are implemented to accommodate the scale of large deployments, optimize for bandwidth and latency concerns in geographically dispersed environments, and to minimize the disruption in the event of an outage or management cluster upgrade. You can find the current management cluster scalability limits and system requirements https://ranchermanager.docs.rancher.com/{rancher-docs-version}/getting-started/installation-and-upgrade/installation-requirements[here].
 
 == Common Edge Deployment Patterns
 

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -24,7 +24,7 @@ image::quickstart-elemental-architecture.png[]
 The following describes the minimum system and environmental requirements to run through this quickstart:
 
 * A host for the centralized management cluster (the one hosting Rancher and Elemental):
- ** Minimum 8 GB RAM and 20 GB disk space for development or testing (see https://ranchermanager.docs.rancher.com/pages-for-subheaders/installation-requirements#hardware-requirements[here] for production use)
+ ** Minimum 8 GB RAM and 20 GB disk space for development or testing (see https://ranchermanager.docs.rancher.com/{rancher-docs-version}/pages-for-subheaders/installation-requirements#hardware-requirements[here] for production use)
 * A target node to be provisioned, i.e. the edge device (a virtual machine can be used for demoing or testing purposes)
  ** Minimum 4GB RAM, 2 CPU cores, and 20 GB disk
 * A resolvable host name for the management cluster or a static IP address to use with a service like sslip.io
@@ -65,7 +65,7 @@ For RKE2, the kubeconfig file will have been written to `/etc/rancher/rke2/rke2.
 Save this file as `~/.kube/config` on your local system.
 You may need to edit the file to include the correct externally routable IP address or host name.
 
-Install Rancher easily with the commands from the https://ranchermanager.docs.rancher.com/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster[Rancher Documentation]:
+Install Rancher easily with the commands from the https://ranchermanager.docs.rancher.com/{rancher-docs-version}/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster[Rancher Documentation]:
 
 Install https://cert-manager.io[cert-manager]:
 [,bash]


### PR DESCRIPTION
Follow-up to #497 where rancher-docs-version was introduced but not applied to all existing links