### PR TITLE
metal3: downstream cluster EIB example fixes

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -127,7 +127,13 @@ operatingSystem:
       encryptedPassword: $ROOT_PASSWORD
       sshKeys:
       - $USERKEY1
+  packages:
+    packageList:
+      - jq
+    sccRegistrationCode: $SCC_REGISTRATION_CODE
 ----
+
+Where `$SCC_REGISTRATION_CODE` is the registration code copied from https://scc.suse.com/[SUSE Customer Center], and the package list contains `jq` which is required.
 
 `$ROOT_PASSWORD` is the encrypted password for the root user, which can be useful for test/debugging.  It can be generated with the `openssl passwd -6 PASSWORD` command
 

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -225,12 +225,21 @@ operatingSystem:
   systemd:
     disable:
       - rebootmgr
+      - transactional-update.timer
+      - transactional-update-cleanup.timer
   users:
     - username: root
       encryptedPassword: $ROOT_PASSWORD
       sshKeys:
       - $USERKEY1
+  packages:
+    packageList:
+      - jq
+  sccRegistrationCode: $SCC_REGISTRATION_CODE
 ----
+
+Where `$SCC_REGISTRATION_CODE` is the registration code copied from https://scc.suse.com/[SUSE Customer Center], and the package list contains `jq` w
+hich is required.
 
 `$ROOT_PASSWORD` is the encrypted password for the root user, which can be useful for test/debugging.  It can be generated with the `openssl passwd -6 PASSWORD` command
 


### PR DESCRIPTION
Ensure jq is installed as it's needed for the manifest rke2-preinstall.service

Also ensure transactional-update timers are disabled since we won't be doing package based updates.

Fixes: #394
Fixes: #471