### PR TITLE
atip-management-cluster: Fix typo in comment

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -620,7 +620,7 @@ Type=forking
 TimeoutStartSec=1800
 
 ExecStartPre=/bin/sh -c "echo 'Setting up Management components...'"
-# Scripts are executed in StartPre because Start can only run a single on
+# Scripts are executed in StartPre because Start can only run a single one
 ExecStartPre=/opt/mgmt/bin/rancher.sh
 ExecStartPre=/opt/mgmt/bin/metal3.sh
 ExecStart=/bin/sh -c "echo 'Finished setting up Management components'"


### PR DESCRIPTION
Fix a typo which makes the comment less clear

Fixes: #473