### PR TITLE
EIB: Align API versions to version-eib-api-latest

### DIFF
--- a/asciidoc/components/longhorn.adoc
+++ b/asciidoc/components/longhorn.adoc
@@ -257,7 +257,7 @@ export CONFIG_DIR=$HOME/eib
 mkdir -p $CONFIG_DIR
 
 cat << EOF > $CONFIG_DIR/iso-definition.yaml
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   baseImage: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -163,7 +163,7 @@ We will take a look at the following fields which will be present in all definit
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -203,7 +203,7 @@ We will create the definition file and include the stripped down image list:
 
 [,console,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -408,7 +408,7 @@ Unlike the Rancher installation, the NeuVector installation does not require any
 We will create the definition file:
 [,console,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -536,7 +536,7 @@ Let's create it:
 
 [,console,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -708,7 +708,7 @@ necessary container images in our definition file. Let's create it:
 
 [,console,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64

--- a/asciidoc/integrations/nvidia-slemicro.adoc
+++ b/asciidoc/integrations/nvidia-slemicro.adoc
@@ -435,7 +435,7 @@ Let us explore those files. First, here is a sample image definition for a singl
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   arch: x86_64
   imageType: iso

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -105,7 +105,7 @@ The `downstream-cluster-config.yaml` file is the main configuration file for the
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: raw
   arch: x86_64
@@ -214,7 +214,7 @@ To enable Telco features like `dpdk`, `sr-iov` or `FEC`, additional packages may
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: raw
   arch: x86_64

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -141,7 +141,7 @@ The `mgmt-cluster.yaml` file is the main definition file for the management clus
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64
@@ -980,7 +980,7 @@ The `rancher-turtles-airgap-resources` helm chart must also be added, this creat
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: iso
   arch: x86_64

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -246,7 +246,7 @@ curl $REGISURL -o $ELEM/eib_quickstart/elemental/elemental_config.yaml
 [,bash,subs="attributes,specialchars"]
 ----
 cat << EOF > $ELEM/eib_quickstart/eib-config.yaml
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
     imageType: iso
     arch: x86_64

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -212,7 +212,7 @@ The `downstream-cluster-config.yaml` file is the main configuration file for the
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: raw
   arch: x86_64


### PR DESCRIPTION
Although not strictly required it's somewhat confusing having a mix of versions in the docs, so align all references with the version-eib-api-latest attribute for consistency.

Fixes: #470