### PR TITLE
Removing extra quotes in sed command

### DIFF
--- a/asciidoc/integrations/nats.adoc
+++ b/asciidoc/integrations/nats.adoc
@@ -140,7 +140,7 @@ The following command adds `nats` in the build tags to enable the NATS built-in 
 
 [,bash]
 ----
-sed -i '' 's/TAGS="ctrd/TAGS="nats ctrd/g' scripts/build
+sed -i 's/TAGS="ctrd/TAGS="nats ctrd/g' scripts/build
 make local
 ----
 


### PR DESCRIPTION
The command as written is broken. I believe this is what's intended?