### PR TITLE
README/trivial: fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SUSE Edge website
 
-The latest version of our docs can be found at https://suse-edge.github.io/id-suse-edge-documentation.html
+The latest version of our docs can be found at https://suse-edge.github.io/
 
 
 


### PR DESCRIPTION
The latest suse-edge docs link contains the version (https://suse-edge.github.io/id-suse-edge-3-2-0-documentation.html) so the one present in the README is broken.
