### PR TITLE
Use correct Fleet version for Rancher 2.10.1

### DIFF
--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -36,7 +36,7 @@
 :version-endpoint-copier-operator: 0.2.0
 :version-suc: 0.14.2
 :version-nm-configurator: 0.3.1
-:version-fleet: 0.11.1
+:version-fleet: 0.11.2
 :version-cdi: 1.60.1
 :version-nvidia-device-plugin: 0.14.5
 :version-kiwi-builder: 10.1.16.0
@@ -72,7 +72,7 @@
 :version-elemental-operator-chart: 105.0.1+up1.6.5
 :version-elemental-operator-crds-chart: 105.0.1+up1.6.5
 :version-endpoint-copier-operator-chart: 0.2.1
-:version-fleet-chart: 105.0.1+up0.11.1
+:version-fleet-chart: 105.0.2+up0.11.2
 :version-kubevirt-chart: 0.4.0
 :version-kubevirt-dashboard-extension-chart: 1.2.1
 :version-longhorn-chart: 105.1.0+up1.7.2


### PR DESCRIPTION
According to Rancher's [build.yaml](https://github.com/rancher/rancher/blob/v2.10.1/build.yaml), for `2.10.1` Rancher uses the `105.0.2+up0.11.2` Fleet chart and the `0.11.2` Fleet version.