### PR TITLE
ATIP wording and review fixes

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1213,7 +1213,7 @@ The following sections describe the additional steps required to enable provisio
 
 *Configuration*
 
-Use the following two sections as the base to enroll and provision the hosts:
+Before proceeding refer to one of the following sections for guidance on the steps required to enroll and provision the host(s):
 
 * xref:single-node[Downstream cluster provisioning with Directed network provisioning (single-node)]
 * xref:multi-node[Downstream cluster provisioning with Directed network provisioning (multi-node)]
@@ -1306,7 +1306,7 @@ spec:
 
 [NOTE]
 ====
-If you need to deploy a multi-node cluster, the same process must be done for the other nodes.
+If you need to deploy a multi-node cluster, the same process must be done for each node.
 ====
 
 * Provision step: The block of information related to the network data has to be removed because the platform includes the network data configuration into the secret `controlplane-0-networkdata`.

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1218,9 +1218,7 @@ Before proceeding refer to one of the following sections for guidance on the ste
 * xref:single-node[Downstream cluster provisioning with Directed network provisioning (single-node)]
 * xref:multi-node[Downstream cluster provisioning with Directed network provisioning (multi-node)]
 
-The changes required to enable the advanced network configuration are the following:
-
-* Enrollment step: The following new example file with a secret containing the information about the `networkData` to be used to configure, for example, the static `IPs` and `VLAN` for the downstream cluster
+Any advanced network configuration must be applied at enrollment time through the `BareMetalHost` host definition and an associated Secret containing an `nmstate` formatted `networkData` block. The following example file defines a secret containing the required `networkData` that requests a static `IP` and `VLAN` for the downstream cluster host:
 
 [,yaml]
 ----
@@ -1261,7 +1259,6 @@ stringData:
         next-hop-interface: ${CONTROLPLANE_INTERFACE}
 ----
 
-This file contains the `networkData` in a `nmstate` format to be used to configure the advance network configuration (for example, `static IPs` and `VLAN`) for the downstream cluster.
 As you can see, the example shows the configuration to enable the interface with static IPs, as well as the configuration to enable the VLAN using the base interface.
 Any other `nmstate` example could be defined to be used to configure the network for the downstream cluster to adapt to the specific requirements, where the following variables have to be replaced with real values:
 
@@ -1273,7 +1270,7 @@ Any other `nmstate` example could be defined to be used to configure the network
 - `$\{DNS_SERVER\}` — The DNS to be used for the edge cluster (for example, `192.168.100.2`).
 - `$\{VLAN_ID\}` — The VLAN ID to be used for the edge cluster (for example, `100`).
 
-Also, the reference to that secret using `preprovisioningNetworkDataName` is needed in the `BaremetalHost` object at the end of the file to be enrolled in the management cluster.
+Lastly, regardless of the specifics of the network configuration, do not forget to reference the secret by appending `preprovisioningNetworkDataName` at the end of the `BaremetalHost` object to be used to enroll the host in the management cluster:
 
 [,yaml]
 ----
@@ -1306,33 +1303,8 @@ spec:
 
 [NOTE]
 ====
-If you need to deploy a multi-node cluster, the same process must be done for each node.
-====
-
-* Provision step: The block of information related to the network data has to be removed because the platform includes the network data configuration into the secret `controlplane-0-networkdata`.
-
-[,yaml]
-----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Metal3DataTemplate
-metadata:
-  name: multinode-cluster-controlplane-template
-  namespace: default
-spec:
-  clusterName: multinode-cluster
-  metaData:
-    objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
-----
-
-[NOTE]
-====
-The `Metal3DataTemplate`, `networkData` and `Metal3 IPAM` are currently not supported; only the configuration via static secrets is fully supported.
+* If you need to deploy a multi-node cluster, the same process must be done for each node.
+* The `Metal3DataTemplate`, `networkData` and `Metal3 IPAM` are currently not supported; only the configuration via static secrets is fully supported.
 ====
 
 [#add-telco]

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -81,6 +81,7 @@ Edge Image Builder is used to create the image for the management cluster, in th
 Edge Image Builder runs inside a container, so a container runtime is required such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop]. For this guide, we assume podman is available.
 
 Also, as a prerequisite to deploy a highly available management cluster, you need to reserve three IPs in your network:
+
 - `apiVIP` for the API VIP Address (used to access the Kubernetes API server).
 - `ingressVIP` for the Ingress VIP Address (consumed, for example, by the Rancher UI).
 - `metal3VIP` for the Metal3 VIP Address.


### PR DESCRIPTION
Mostly wording fixes in preparation for IPv6/dual-stack changes, including the removal of a leftover from previous releases.