### PR TITLE
[3.2] Fix fleet-examples tag reference

### DIFF
--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -50,7 +50,7 @@
 :release-tag-eib: release-1.1
 :release-tag-edge-charts: release-3.2
 :release-tag-atip: release-3.2
-:release-tag-fleet-examples: release-3.2
+:release-tag-fleet-examples: release-3.2.0
 :release-tag-rancher: v2.10.1
 
 


### PR DESCRIPTION
The correct tag reference for the `fleet-examples` repository is `release-3.X.Y`.