### PR TITLE
[3.2] SUC fixes and changes

### DIFF
--- a/asciidoc/components/system-upgrade-controller.adoc
+++ b/asciidoc/components/system-upgrade-controller.adoc
@@ -78,7 +78,7 @@ kind: GitRepo
 metadata:
   name: system-upgrade-controller
 spec:
-  revision: release-{version-edge}
+  revision: {release-tag-fleet-examples}
   paths:
   - fleets/day2/system-upgrade-controller
   repo: https://github.com/suse-edge/fleet-examples.git
@@ -100,7 +100,7 @@ kind: GitRepo
 metadata:
   name: system-upgrade-controller
 spec:
-  revision: release-{version-edge}
+  revision: {release-tag-fleet-examples}
   paths:
   - fleets/day2/system-upgrade-controller
   repo: https://github.com/suse-edge/fleet-examples.git
@@ -120,7 +120,7 @@ EOF
 kubectl get gitrepo system-upgrade-controller -n <fleet-local/fleet-default>
 
 NAME                        REPO                                              COMMIT          BUNDLEDEPLOYMENTS-READY   STATUS
-system-upgrade-controller   https://github.com/suse-edge/fleet-examples.git   release-{version-edge}   1/1                       
+system-upgrade-controller   https://github.com/suse-edge/fleet-examples.git   {release-tag-fleet-examples}   1/1                       
 ----
 
 . Validate the System Upgrade Controller deployment:
@@ -150,16 +150,16 @@ Make sure that the version of the fleet-cli you download matches the version of 
 
 *** Linux AMD:
 +
-[,bash]
+[,bash,subs="attributes"]
 ----
-curl -L -o fleet-cli https://github.com/rancher/fleet/releases/download/<FLEET_VERSION>/fleet-linux-amd64
+curl -L -o fleet-cli https://github.com/rancher/fleet/releases/download/v{version-fleet}/fleet-linux-amd64
 ----
 
 *** Linux ARM:
 +
-[,bash]
+[,bash,subs="attributes"]
 ----
-curl -L -o fleet-cli https://github.com/rancher/fleet/releases/download/<FLEET_VERSION>/fleet-linux-arm64
+curl -L -o fleet-cli https://github.com/rancher/fleet/releases/download/v{version-fleet}/fleet-linux-arm64
 ----
 
 . Make `fleet-cli` executable:
@@ -173,7 +173,7 @@ chmod +x fleet-cli
 +
 [,bash,subs="attributes"]
 ----
-git clone -b release-{version-edge} https://github.com/suse-edge/fleet-examples.git
+git clone -b {release-tag-fleet-examples} https://github.com/suse-edge/fleet-examples.git
 ----
 
 . Navigate to the SUC fleet, located in the `fleet-examples` repo:
@@ -284,7 +284,7 @@ helm repo add rancher-charts https://charts.rancher.io/
 helm install system-upgrade-controller rancher-charts/system-upgrade-controller --version {version-suc-chart} --set global.cattle.psp.enabled=false -n cattle-system --create-namespace
 ----
 +
-This will install SUC version {version-suc} which is needed by the Edge 3.1 platform.
+This will install SUC version {version-suc} which is needed by the Edge {version-edge} platform.
 
 . Validate the SUC deployment:
 +

--- a/asciidoc/components/system-upgrade-controller.adoc
+++ b/asciidoc/components/system-upgrade-controller.adoc
@@ -24,6 +24,13 @@ ____
 [#components-system-upgrade-controller-install]
 == Installing the System Upgrade Controller
 
+[IMPORTANT]
+====
+Starting with Rancher link:https://github.com/rancher/rancher/releases/tag/v2.10.0[v2.10.0], the `System Upgrade Controller` is installed automatically.
+
+Follow the steps below *only* if your environment is *not* managed by Rancher, or if your Rancher version is lesser than `v2.10.0`. 
+====
+
 We recommend that you install SUC through <<components-fleet, Fleet>> located in the link:https://github.com/suse-edge/fleet-examples[suse-edge/fleet-examples] repository.
 
 [NOTE]

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -42,7 +42,7 @@
 :version-kiwi-builder: 10.1.16.0
 
 // == Non-Release Manifest Charts ==
-:version-suc-chart: 105.0.0
+:version-suc-chart: 105.0.1
 :version-upgrade-controller-chart: 0.1.1
 :version-nvidia-device-plugin-chart: v0.14.5
 


### PR DESCRIPTION
- Use the correct attributes references for the `fleet-example` oriented examples.
- Use the `version-fleet` attribute reference for `fleet-cli` download examples.
- Fix leftover non-templated versions.
- Add installation note for environments running Rancher `>= v2.10.0`.
- Update the SUC chart version reference to the correct one used by Rancher `v2.10.1`.