### PR TITLE
[3.2] Update "Upgrade Controller" chart version

### DIFF
--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -43,7 +43,7 @@
 
 // == Non-Release Manifest Charts ==
 :version-suc-chart: 105.0.1
-:version-upgrade-controller-chart: 0.1.1
+:version-upgrade-controller-chart: 302.0.0+up0.1.1
 :version-nvidia-device-plugin-chart: v0.14.5
 
 // == Release Tags ==


### PR DESCRIPTION
According to our new chart version convention the `Upgrade Controller` chart version should be `302.0.0+up0.1.1`.