### PR TITLE
[3.2] Add note to general "Day 2" docs that point to ATIP

### DIFF
--- a/asciidoc/day2/downstream-clusters.adoc
+++ b/asciidoc/day2/downstream-clusters.adoc
@@ -14,6 +14,11 @@ endif::[]
 :cluster-type: downstream
 :fleet-workspace: fleet-default
 
-This section covers the possible ways to perform "Day 2" operations for different parts of your downstream cluster.
+[IMPORTANT]
+====
+The following steps do not apply to `downstream` clusters managed by <<atip, ATIP>>. For guidance on upgrading ATIP-managed `downstream` clusters, refer to <<atip-lifecycle-downstream>>.
+====
+
+This section covers the possible ways to perform "Day 2" operations for different parts of your `downstream` cluster.
 
 include::fleet.adoc[]

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -41,6 +41,7 @@ helm upgrade metal3 suse-edge/metal3 \
   --version={version-metal3-chart}
 ----
 
+[#atip-lifecycle-downstream]
 === Downstream cluster upgrades
 
 Upgrading downstream clusters involves updating several components. The following sections cover the upgrade process for each of the components.


### PR DESCRIPTION
Add a note in the general `downstream` cluster documentation that points users looking to upgrade `downstream` clusters managed by ATIP.