### PR TITLE
release-notes: further updates to support phases

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -218,7 +218,7 @@ SUSE Edge is backed by award-winning support from SUSE, an established technolog
 SUSE Edge "3.2" is supported for 18-months of production support, with an initial 6-months of "full support", followed by 12-months of "maintenance support".  After these support phases the product reaches "end of life" (EOL) and is no longer supported. More info about the lifecycle phases can be found in the table below:
 
 |======
-| *Full Support (6 months)* | Urgent and selected high-priority bug fixes will be released during the full support window, and all other patches (non-urgent, enhancements, new capabilities) will be released via the regular release schedule
+| *Full Support (6 months)* | Urgent and selected high-priority bug fixes will be released during the full support window, and all other patches (non-urgent, enhancements, new capabilities) will be released via the regular release schedule.
 | *Maintenance Support (12 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected
 | *End of Life (EOL)*  | Once a product release reaches its End of Life date, the customer may continue to use the product within the terms of product licensing agreement.
 Support Plans from SUSE do not apply to product releases past their EOL date.

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -215,7 +215,14 @@ It is recommended to create a non-root user or use key based authentication, but
 
 SUSE Edge is backed by award-winning support from SUSE, an established technology leader with a proven history of delivering enterprise-quality support services. For more information, see https://www.suse.com/lifecycle[https://www.suse.com/lifecycle] and the Support Policy page at https://www.suse.com/support/policy.html[https://www.suse.com/support/policy.html]. If you have any questions about raising a support case, how SUSE classifies severity levels, or the scope of support, please see the Technical Support Handbook at https://www.suse.com/support/handbook/[https://www.suse.com/support/handbook/].
 
-SUSE Edge "3.2" is supported for 18-months of production support, with an initial 6-months from GA\* to EOM\**, followed by 12-months from EOM\** to EOL\***. More info about the lifecycle phases can be found <<lifecycle-phases, here>>
+SUSE Edge "3.2" is supported for 18-months of production support, with an initial 6-months of "full support", followed by 12-months of "maintenance support".  After these support phases the product reaches "end of life" (EOL) and is no longer supported. More info about the lifecycle phases can be found in the table below:
+
+|======
+| *Full Support (6 months)* | Urgent and selected high-priority bug fixes will be released during the full support window, and all other patches (non-urgent, enhancements, new capabilities) will be released via the regular release schedule
+| *Maintenance Support (12 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected
+| *End of Life (EOL)*  | Once a product release reaches its End of Life date, the customer may continue to use the product within the terms of product licensing agreement.
+Support Plans from SUSE do not apply to product releases past their EOL date.
+|======
 
 Unless explicitly stated, all components listed are considered Generally Available (GA), and are covered by SUSE's standard scope of support. Some components may be listed as "Technology Preview", where SUSE is providing customers with access to early pre-GA features and functionality for evaluation, but are not subject to the standard support policies and are not recommended for production use-cases. SUSE very much welcomes feedback and suggestions on the improvements that can be made to Technology Preview components, but SUSE reserves the right to deprecate a Technology Preview feature before it becomes Generally Available if it doesn't meet the needs of our customers or doesn't reach a state of maturity that we require.
 
@@ -242,28 +249,3 @@ This release notes document is licensed under a Creative Commons Attribution-NoD
 SUSE has intellectual property rights relating to technology embodied in the product that is described in this document. In particular, and without limitation, these intellectual property rights may include one or more of the U.S. patents listed at https://www.suse.com/company/legal/[https://www.suse.com/company/legal/] and one or more additional patents or pending patent applications in the U.S. and other countries.
 
 For SUSE trademarks, see the SUSE Trademark and Service Mark list (https://www.suse.com/company/legal/[https://www.suse.com/company/legal/]). All third-party trademarks are the property of their respective owners. For SUSE brand information and usage requirements, please see the guidelines published at https://brand.suse.com/[https://brand.suse.com/].
-
-[[lifecycle-phases]]
-[options="header"]
-|======
-| Phases | Description
-| *GA to EOM | Upon the General Availability date, products are supported and maintained until the End of Maintenance date.
-
-* Applying configuration changes
-
-* Upgrade recommendation to an existing newer version of product
-
-* Code-level maintenance in the form of Software updates; typically, results in a maintenance release, which is a newer version of product that was not existing at the time the issue was encountered
-| **EOM to EOL | After a product release reaches its End of Maintenance date, no further code-level maintenance will be provided, except for critical security- related fixes on a per-request basis.
-
-After the EOM date, Software will continue to be supported until it reaches its End of Life date, in the form of:
-
-* General troubleshooting of a specific issue to isolate potential causes
-
-* Upgrade recommendation to an existing newer version of product
-
-* Issue resolution limited to applying configuration changes and/or an upgrade recommendation to an existing newer version of product
-| ***EOL  | Once a product release reaches its End of Life date, the customer may continue to use the product within the terms of product licensing agreement.
-
-Support Plans from SUSE Rancher do not apply to product releases past their EOL date.
-|======

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -219,7 +219,7 @@ SUSE Edge "3.2" is supported for 18-months of production support, with an initia
 
 |======
 | *Full Support (6 months)* | Urgent and selected high-priority bug fixes will be released during the full support window, and all other patches (non-urgent, enhancements, new capabilities) will be released via the regular release schedule.
-| *Maintenance Support (12 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected
+| *Maintenance Support (12 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
 | *End of Life (EOL)*  | Once a product release reaches its End of Life date, the customer may continue to use the product within the terms of product licensing agreement.
 Support Plans from SUSE do not apply to product releases past their EOL date.
 |======


### PR DESCRIPTION
Follow-up to #529 - on further discussion it seems we should align with the phases described in https://www.suse.com/support/kb/doc/?id=000021405

This also moves the table and fixes some formatting issues to improve readability.

@dprodanov4 apologies, I know we previously discussed alignment with [https://www.suse.com/lifecycle](https://www.suse.com/lifecycle/#suse-rancher-prime) but after discussion with @timirnich it seems this is the preferred approach. 