### PR TITLE
Rename ATIP to SUSE Edge for Telco

### DIFF
--- a/asciidoc/components/turtles.adoc
+++ b/asciidoc/components/turtles.adoc
@@ -37,7 +37,7 @@ Only the default providers installed via the wrapper chart are supported - alter
 
 == Installing Rancher Turtles
 
-Rancher Turtles may be installed by following the <<quickstart-metal3,Metal3 Quickstart>> guide, or the <<atip-management-cluster,ATIP Management Cluster>> documentation.
+Rancher Turtles may be installed by following the <<quickstart-metal3,Metal3 Quickstart>> guide, or the <<atip-management-cluster,Management Cluster>> documentation.
 
 == Additional Resources
 

--- a/asciidoc/day2/downstream-clusters.adoc
+++ b/asciidoc/day2/downstream-clusters.adoc
@@ -16,7 +16,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-The following steps do not apply to `downstream` clusters managed by <<atip, ATIP>>. For guidance on upgrading ATIP-managed `downstream` clusters, refer to <<atip-lifecycle-downstream>>.
+The following steps do not apply to `downstream` clusters managed by <<atip, SUSE Edge for Telco>>. For guidance on upgrading these clusters, refer to <<atip-lifecycle-downstream>>.
 ====
 
 This section covers the possible ways to perform "Day 2" operations for different parts of your `downstream` cluster.

--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -152,7 +152,7 @@ include::../day2/downstream-clusters.adoc[leveloffset=+1]
 = Product Documentation
 
 [partintro]
-Find the ATIP documentation here
+Find the SUSE Edge for Telco documentation here
 
 include::../product/atip.adoc[leveloffset=+1]
 

--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -78,7 +78,7 @@
 :link-nvidia-cuda-package-repo: https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/
 
 // ============================================================================
-// ATIP
+// SUSE Edge for Telco (ATIP)
 
 :link-atip-examples: https://github.com/suse-edge/atip/tree/{release-tag-atip}/telco-examples/edge-clusters
 :link-atip-performance-settings: https://github.com/suse-edge/atip/blob/{release-tag-atip}/telco-examples/edge-clusters/dhcp/eib/custom/files/performance-settings.sh

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -16,7 +16,7 @@ The solution is designed with the notion that there is no "one-size-fits-all" ed
 
 SUSE Edge is built on best-of-breed open source software from the ground up, consistent with both our 30-year history in delivering secure, stable, and certified SUSE Linux platforms and our experience in providing highly scalable and feature-rich Kubernetes management with our Rancher portfolio. SUSE Edge builds on-top of these capabilities to deliver functionality that can address a wide number of market segments, including retail, medical, transportation, logistics, telecommunications, smart manufacturing, and Industrial IoT.
 
-NOTE: SUSE Adaptive Telco Infrastructure Platform (ATIP) is a derivative (or downstream product) of SUSE Edge, with additional optimizations and components that enable the platform to address the requirements found in telecommunications use-cases. Unless explicitly stated, all the release notes are applicable for both SUSE Edge 3.2, and SUSE ATIP 3.2.
+NOTE: SUSE Edge for Telco (formerly known as Adaptive Telco Infrastructure Platform/ATIP) is a derivative (or downstream product) of SUSE Edge, with additional optimizations and components that enable the platform to address the requirements found in telecommunications use-cases. Unless explicitly stated, all the release notes are applicable for both SUSE Edge 3.2, and SUSE Edge for Telco 3.2.
 
 = About
 
@@ -45,7 +45,7 @@ TBC
 
 == Known issues
 
-* When deploying via the directed network provisioning flow, a bug affects clusters with static IPs in networks with DHCP servers and/or RAs: static network configurations only apply to the provisioned host and will not be in effect during the host discovery and enrollment. Please refer to the https://github.com/suse-edge/atip/tree/main/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node#readme[ATIP repository] for more details and updates.
+* When deploying via the directed network provisioning flow, a bug affects clusters with static IPs in networks with DHCP servers and/or RAs: static network configurations only apply to the provisioned host and will not be in effect during the host discovery and enrollment. Please refer to the https://github.com/suse-edge/atip/tree/main/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node#readme[SUSE Edge for Telco examples repository] for more details and updates.
 
 == Components Versions
 

--- a/asciidoc/product/atip-architecture.adoc
+++ b/asciidoc/product/atip-architecture.adoc
@@ -11,14 +11,14 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-SUSE ATIP is a platform designed for hosting modern, cloud native, Telco applications at scale from core to edge.
+SUSE Edge for Telco is a platform designed for hosting modern, cloud native, Telco applications at scale from core to edge.
 
-This page explains the architecture and components used in ATIP. Knowledge of this helps deploy and use ATIP.
+This page explains the architecture and components used in SUSE Edge for Telco.
 
 
-=== ATIP Architecture
+=== SUSE Edge for Telco Architecture
 
-The following diagram shows the high-level architecture of ATIP:
+The following diagram shows the high-level architecture of SUSE Edge for Telco:
 
 image::product-atip-architecture1.svg[]
 
@@ -27,7 +27,7 @@ image::product-atip-architecture1.svg[]
 
 There are two different blocks, the management stack and the runtime stack:
 
-* *Management stack*: This is the part of ATIP that is used to manage the provision and lifecycle of the runtime stacks. It includes the following components:
+* *Management stack*: This is the part of SUSE Edge for Telco that is used to manage the provision and lifecycle of the runtime stacks. It includes the following components:
   ** Multi-cluster management in public and private cloud environments with <<components-rancher,Rancher>>
   ** Bare-metal support with <<components-metal3,Metal^3^>>, <<components-metallb,MetalLB>> and `CAPI` (Cluster API) infrastructure providers
   ** Comprehensive tenant isolation and `IDP` (Identity Provider) integrations
@@ -36,7 +36,7 @@ There are two different blocks, the management stack and the runtime stack:
   ** Control the SUSE Linux Micro transactional updates
   ** GitOps Engine for managing the lifecycle of the clusters using Git repositories with <<components-fleet,Fleet>>
 
-* *Runtime stack*: This is the part of ATIP that is used to run the workloads.
+* *Runtime stack*: This is the part of SUSE Edge for Telco that is used to run the workloads.
   ** Kubernetes with secure and lightweight distributions like <<components-k3s,K3s>> and <<components-rke2,RKE2>> (`RKE2` is hardened, certified and optimized for government use and regulated industries).
   ** <<components-suse-security,SUSE Security>> to enable security features like image vulnerability scanning, deep packet inspection and automatic intra-cluster traffic control.
   ** Block Storage with <<components-suse-storage,SUSE Storage>> to enable a simple and easy way to use a cloud native storage solution.
@@ -54,7 +54,7 @@ Using the <<components-eib,Edge Image Builder>> to create a new `ISO` image with
 
 image::product-atip-architecture2.png[]
 
-NOTE: For more information about how to deploy a new management cluster, see the <<atip-management-cluster,ATIP Management Cluster guide>>.
+NOTE: For more information about how to deploy a new management cluster, see the <<atip-management-cluster,SUSE Edge for Telco Management Cluster guide>>.
 
 NOTE: For more information about how to use the Edge Image Builder, see the <<quickstart-eib,Edge Image Builder guide>>.
 
@@ -67,9 +67,9 @@ The following diagram shows the high-level workflow to deploy it:
 
 image::product-atip-architecture3.png[]
 
-NOTE: For more information about how to deploy a downstream cluster, see the <<atip-automated-provisioning,ATIP Automated Provisioning guide.>>
+NOTE: For more information about how to deploy a downstream cluster, see the <<atip-automated-provisioning,SUSE Edge for Telco Automated Provisioning guide.>>
 
-NOTE: For more information about Telco features, see the <<atip-features,ATIP Telco Features guide.>>
+NOTE: For more information about Telco features, see the <<atip-features,SUSE Edge for Telco Telco Features guide.>>
 
 ==== Example 3: Deploying a high availability downstream cluster using MetalLB as a Load Balancer
 
@@ -79,6 +79,6 @@ The following diagram shows the high-level workflow to deploy it:
 
 image::product-atip-architecture4.png[]
 
-NOTE: For more information about how to deploy a downstream cluster, see the <<atip-automated-provisioning,ATIP Automated Provisioning guide.>>
+NOTE: For more information about how to deploy a downstream cluster, see the <<atip-automated-provisioning,SUSE Edge for Telco Automated Provisioning guide.>>
 
 NOTE: For more information about `MetalLB`, see <<components-metallb,here:>>

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -51,8 +51,8 @@ The following sections describe the different directed network provisioning work
 
 [NOTE]
 ====
-The following sections show how to prepare the different scenarios for the directed network provisioning workflow using ATIP.
-For examples of the different configurations options for deployment (incl. air-gapped environments, DHCP and DHCP-less networks, private container registries, etc.), see the {link-atip-examples}[SUSE ATIP repository].
+The following sections show how to prepare the different scenarios for the directed network provisioning workflow using SUSE Edge for Telco.
+For examples of the different configurations options for deployment (incl. air-gapped environments, DHCP and DHCP-less networks, private container registries, etc.), see the {link-atip-examples}[SUSE SUSE Edge for Telco repository].
 ====
 
 [#single-node]
@@ -1376,7 +1376,7 @@ IPv6 and dual-stack deployments are in tech preview status and are not officiall
 
 [NOTE]
 ====
-You can refer to https://github.com/suse-edge/atip/tree/main/telco-examples/edge-clusters[the ATIP repo] for more complex examples, including IPv6 only and dual-stack configurations.
+You can refer to https://github.com/suse-edge/atip/tree/main/telco-examples/edge-clusters[the SUSE Edge for Telco examples repo] for more complex examples, including IPv6 only and dual-stack configurations.
 ====
 
 Lastly, regardless of the network configuration details, ensure that the secret is referenced by appending `preprovisioningNetworkDataName` to the `BaremetalHost` object to successfully enroll the host in the management cluster.

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -10,9 +10,9 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-This section documents and explains the configuration of Telco-specific features on ATIP-deployed clusters.
+This section documents and explains the configuration of Telco-specific features on clusters deployed via SUSE Edge for Telco.
 
-The directed network provisioning deployment method is used, as described in the <<atip-automated-provisioning,ATIP Automated Provision>> section.
+The directed network provisioning deployment method is used, as described in the <<atip-automated-provisioning,Automated Provisioning>> section.
 
 The following topics are covered in this section:
 
@@ -188,13 +188,13 @@ There is another script that can be used to tune the CPU configuration, which ba
 * Set the isolated CPUs latency to the lowest possible value.
 * Delay the vmstat updates to 300 seconds.
 
-The script is available at https://raw.githubusercontent.com/suse-edge/atip/refs/heads/release-3.1/telco-examples/edge-clusters/dhcp-less/eib/custom/files/performance-settings.sh[SUSE ATIP Github repository - performance-settings.sh].
+The script is available at https://raw.githubusercontent.com/suse-edge/atip/refs/heads/release-3.1/telco-examples/edge-clusters/dhcp-less/eib/custom/files/performance-settings.sh[SUSE Edge for Telco Examples repository].
 
 [#cni-configuration]
 === CNI Configuration
 
 ==== Cilium
-`Cilium` is the default CNI plug-in for ATIP.
+`Cilium` is the default CNI plug-in for SUSE Edge for Telco.
 To enable Cilium on RKE2 cluster as the default plug-in, the following configurations are required in the `/etc/rancher/rke2/config.yaml` file:
 
 [,yaml]

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -11,7 +11,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-This section covers the lifecycle management actions of deployed ATIP clusters.
+This section covers the lifecycle management actions for clusters deployed via SUSE Edge for Telco.
 
 === Management cluster upgrades
 

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -12,14 +12,14 @@ ifdef::env-github[]
 endif::[]
 
 === Introduction
-The management cluster is the part of ATIP that is used to manage the provision and lifecycle of the runtime stacks.
+The management cluster is the part of SUSE Edge for Telco that is used to manage the provision and lifecycle of the runtime stacks.
 From a technical point of view, the management cluster contains the following components:
 
 * `SUSE Linux Micro` as the OS. Depending on the use case, some configurations like networking, storage, users and kernel arguments can be customized.
 * `RKE2` as the Kubernetes cluster. Depending on the use case, it can be configured to use specific CNI plugins, such as `Multus`, `Cilium`, etc.
 * `Rancher` as the management platform to manage the lifecycle of the clusters.
 * `Metal^3^` as the component to manage the lifecycle of the bare-metal nodes.
-* `CAPI` as the component to manage the lifecycle of the Kubernetes clusters (downstream clusters). With ATIP, also the `RKE2 CAPI Provider` is used to manage the lifecycle of the RKE2 clusters (downstream clusters).
+* `CAPI` as the component to manage the lifecycle of the Kubernetes clusters (downstream clusters). The `RKE2 CAPI Provider` is used to manage the lifecycle of the RKE2 clusters.
 
 With all components mentioned above, the management cluster can manage the lifecycle of downstream clusters, using a declarative approach to manage the infrastructure and applications.
 

--- a/asciidoc/product/atip-requirements.adoc
+++ b/asciidoc/product/atip-requirements.adoc
@@ -13,14 +13,14 @@ endif::[]
 
 === Hardware
 
-The hardware requirements for the ATIP nodes are based on the following components:
+The hardware requirements SUSE Edge for telco are as follows:
 
 * **Management cluster**: The management cluster contains components like `SUSE Linux Micro`, `RKE2`, `SUSE Rancher Prime`, `Metal^3^`, and it is used to manage several downstream clusters. Depending on the number of downstream clusters to be managed, the hardware requirements for the server could vary.
   ** Minimum requirements for the server (`VM` or `bare-metal`) are:
      *** RAM: 8 GB Minimum (we recommend at least 16 GB)
      *** CPU: 2 Minimum (we recommend at least 4 CPU)
 
-* **Downstream clusters**: The downstream clusters are the clusters deployed on the ATIP nodes to run Telco workloads. Specific requirements are needed to enable certain Telco capabilities like `SR-IOV`, `CPU Performance Optimization`, etc.
+* **Downstream clusters**: The downstream clusters are the clusters deployed to run Telco workloads. Specific requirements are needed to enable certain Telco capabilities like `SR-IOV`, `CPU Performance Optimization`, etc.
   ** SR-IOV: to attach VFs (Virtual Functions) in pass-through mode to CNFs/VNFs, the NIC must support SR-IOV and VT-d/AMD-Vi be enabled in the BIOS.
   ** CPU Processors: To run specific Telco workloads, the CPU Processor model should be adapted to enable most of the features available in this reference <<atip-features,table>>.
   ** Firmware requirements for installing with virtual media:
@@ -49,9 +49,9 @@ image::product-atip-requirements1.svg[]
 
 The network architecture is based on the following components:
 
-* **Management network**: This network is used for the management of the ATIP nodes. It is used for the out-of-band management. Usually, this network is also connected to a separate management switch, but it can be connected to the same service switch using VLANs to isolate the traffic.
-* **Control-plane network**: This network is used for the communication between the ATIP nodes and the services that are running on them. This network is also used for the communication between the ATIP nodes and the external services, like the `DHCP` or `DNS` servers. In some cases, for connected environments, the switch/router can handle traffic through the Internet.
-* **Other networks**: In some cases, the ATIP nodes could be connected to other networks for specific customer purposes.
+* **Management network**: This network is used for the management of downstream cluster nodes. It is used for the out-of-band management. Usually, this network is also connected to a separate management switch, but it can be connected to the same service switch using VLANs to isolate the traffic.
+* **Control-plane network**: This network is used for the communication between the downstream cluster nodes and the services that are running on them. This network is also used for the communication between the nodes and the external services, like the `DHCP` or `DNS` servers. In some cases, for connected environments, the switch/router can handle traffic through the Internet.
+* **Other networks**: In some cases, nodes could be connected to other networks for specific purposes.
 
 [NOTE]
 ====
@@ -62,9 +62,9 @@ To use the directed network provisioning workflow, the management cluster must h
 
 Some external services like `DHCP`, `DNS`, etc. could be required depending on the kind of environment where they are deployed:
 
-* **Connected environment**: In this case, the ATIP nodes will be connected to the Internet (via routing L3 protocols) and the external services will be provided by the customer.
-* **Disconnected / air-gap environment**: In this case, the ATIP nodes will not have Internet IP connectivity and additional services will be required to locally mirror content required by the ATIP directed network provisioning workflow.
-* **File server**: A file server is used to store the OS images to be provisioned on the ATIP nodes during the directed network provisioning workflow. The `metal^3^` Helm chart can deploy a media server to store the OS images — check the following xref:metal3-media-server[section], but it is also possible to use an existing local webserver.
+* **Connected environment**: In this case, the nodes will be connected to the Internet (via routing L3 protocols) and the external services will be provided by the customer.
+* **Disconnected / air-gap environment**: In this case, the nodes will not have Internet IP connectivity and additional services will be required to locally mirror content required by the directed network provisioning workflow.
+* **File server**: A file server is used to store the OS images to be provisioned on the downstream cluster nodes during the directed network provisioning workflow. The `metal^3^` Helm chart can deploy a media server to store the OS images — check the following xref:metal3-media-server[section], but it is also possible to use an existing local webserver.
 
 === Disabling systemd services
 
@@ -106,7 +106,7 @@ rebootmgrctl strategy off
 
 [NOTE]
 ====
-This configuration to set the `rebootmgr` strategy can be automated using the directed network provisioning workflow. For more information, check the <<atip-automated-provisioning,ATIP Automated Provisioning documentation>>.
+This configuration to set the `rebootmgr` strategy can be automated using the directed network provisioning workflow. For more information, check the <<atip-automated-provisioning,Automated Provisioning documentation>>.
 ====
 
 * `transactional-update` is a service that allows automatic updates controlled by the system. For Telco workloads, it is important to disable the automatic updates to avoid any impact on the services running on the nodes.

--- a/asciidoc/product/atip-requirements.adoc
+++ b/asciidoc/product/atip-requirements.adoc
@@ -13,7 +13,7 @@ endif::[]
 
 === Hardware
 
-The hardware requirements SUSE Edge for telco are as follows:
+The hardware requirements SUSE Edge for Telco are as follows:
 
 * **Management cluster**: The management cluster contains components like `SUSE Linux Micro`, `RKE2`, `SUSE Rancher Prime`, `Metal^3^`, and it is used to manage several downstream clusters. Depending on the number of downstream clusters to be managed, the hardware requirements for the server could vary.
   ** Minimum requirements for the server (`VM` or `bare-metal`) are:

--- a/asciidoc/product/atip.adoc
+++ b/asciidoc/product/atip.adoc
@@ -1,5 +1,5 @@
 [#atip]
-= SUSE Adaptive Telco Infrastructure Platform (ATIP)
+= SUSE Edge for Telco
 :experimental:
 
 ifdef::env-github[]
@@ -12,9 +12,9 @@ ifdef::env-github[]
 endif::[]
 :toc: preamble
 
-SUSE Adaptive Telco Infrastructure Platform (`ATIP`) is a Telco-optimized edge computing platform that enables telecom companies to innovate and accelerate the modernization of their networks.
+SUSE Edge for Telco (formerly known as Adaptive Telco Infrastructure Platform/ATIP) is a Telco-optimized edge computing platform that enables telecom companies to innovate and accelerate the modernization of their networks.
 
-ATIP is a complete Telco cloud stack for hosting CNFs such as 5G Packet Core and Cloud RAN.
+SUSE Edge for Telco is a complete Telco cloud stack for hosting CNFs such as 5G Packet Core and Cloud RAN.
 
 - Automates zero-touch rollout and lifecycle management of complex edge stack configurations at Telco scale.
 - Continuously assures quality on Telco-grade hardware, using Telco-specific configurations and workloads.

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -67,7 +67,7 @@ The basic steps to install a management cluster and use Metal^3^ are:
 
 This guide assumes an existing RKE2 cluster and Rancher (including cert-manager) has been installed, for example by using <<components-eib, Edge Image Builder>>.
 
-TIP: The steps here can also be fully automated as described in the <<atip-management-cluster, ATIP management cluster documentation>>.
+TIP: The steps here can also be fully automated as described in the <<atip-management-cluster, Management Cluster Documentation>>.
 
 === Installing Metal^3^ dependencies
 
@@ -473,7 +473,7 @@ To deploy the controlplane we define a yaml manifest similar to the one below, w
 * Metal3DataTemplate defines additional metaData to be passed to the BareMetalHost (note networkData is not currently supported in the Edge solution)
 
 Note for simplicity this example assumes a single-node controlplane, where the BareMetalHost is configured with an IP of `192.168.125.200` - for more
-advanced multi-node examples please see the <<atip-automated-provisioning, ATIP documentation>>
+advanced multi-node examples please see the <<atip-automated-provisioning, SUSE Edge for Telco Documentation>>
 
 [,yaml,subs="attributes"]
 ----
@@ -777,7 +777,7 @@ worker-0         available              false            15m
 
 == Additional resources
 
-The <<atip, ATIP Documentation>> has examples of more advanced usage of Metal^3^ for telco use-cases.
+The <<atip, SUSE Edge for Telco Documentation>> has examples of more advanced usage of Metal^3^ for telco use-cases.
 
 === Single-node configuration
 


### PR DESCRIPTION
To align with recent branding changes update the ATIP naming

To reduce the risk of breakage this doesn't update any filenames or links, we'll have to adjust them via follow-up changes.