### PR TITLE
release-notes: Add note regarding toolbox image

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -49,6 +49,7 @@ Summary: SUSE Edge 3.2.0 is the first release in the SUSE Edge 3.2 release strea
 == Known issues
 
 * When deploying via the directed network provisioning flow, a bug affects clusters with static IPs in networks with DHCP servers and/or RAs: static network configurations only apply to the provisioned host and will not be in effect during the host discovery and enrollment. Please refer to the https://github.com/suse-edge/atip/tree/main/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node#readme[SUSE Edge for Telco examples repository] for more details and updates.
+* When using `toolbox` in SUSE Linux Micro 6.0, the default container image does not contain some tools which were included in the previous 5.5 version.  The workaround is to configure toolbox to use the previous `suse/sle-micro/5.5/toolbox` container image, see `toolbox --help` for options to configure the image.
 
 == Components Versions
 


### PR DESCRIPTION
Make a note that the suse/sle-micro/5.5/toolbox image may be required

In future we can add more comprehensive troubleshooting docs, but this at least points in the right direction for any users who encounter issues trying to use the 6.0 toolbox image

Fixes: #528