### PR TITLE
Initial SUSE Multilinux Manager component/quickstart

### DIFF
--- a/asciidoc/components/suse-multilinux-manager.adoc
+++ b/asciidoc/components/suse-multilinux-manager.adoc
@@ -1,0 +1,6 @@
+[#components-suma]
+= SUSE Multi-Linux Manager
+
+SUSE Multi-Linux Manager is included in SUSE Edge to provide automation and control for keeping SUSE Linux Micro as the underlying operating system consistently up-to-date on all nodes of your edge deployment.
+
+For more information please refer to the <<quickstart-suma>> and the https://documentation.suse.com/suma/5.0/en/suse-manager/index.html[SUSE Multi-Linux Manager Documentation].

--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -40,6 +40,8 @@ include::../quickstart/elemental.adoc[leveloffset=+1]
 
 include::../quickstart/eib.adoc[leveloffset=+1]
 
+include::../quickstart/suse-multilinux-manager.adoc[leveloffset=+1]
+
 //--------------------------------------------
 // Components
 //--------------------------------------------
@@ -84,6 +86,8 @@ include::../components/virtualization.adoc[leveloffset=+1]
 include::../components/system-upgrade-controller.adoc[leveloffset=+1]
 
 include::../components/upgrade-controller.adoc[leveloffset=+1]
+
+include::../components/suse-multilinux-manager.adoc[leveloffset=+1]
 
 //--------------------------------------------
 // How-To Guides

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -180,7 +180,7 @@ operatingSystem:
     activationKey: 1-edge-x86_64
 ----
 
-Edge Image Builder can also configure the network, automatically install Kubernetes on the node, and even deploy applications via helm charts. See <<quickstart-eib>> for more comprehensive examples.
+Edge Image Builder can also configure the network, automatically install Kubernetes on the node, and even deploy applications via Helm charts. See <<quickstart-eib>> for more comprehensive examples.
 
 For `baseImage`, specify the actual name of the ISO in the `base-images` directory that you want to use.
 

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -150,7 +150,7 @@ If you either want to preload the image directly to a physical node or directly 
 Download or copy the image
 `SL-Micro.x86_64-6.0-Default-SelfInstall-GM2.install.iso` to the `base-images` directoy and name it "slemicro.iso".
 
-Building aarch64 images on an Arm-based build host is a technology preview in SUSE Edge 3.1. It will most likely work, but isn't supported yet. If you want to try it out, you need to be running podman on a 64-bit Arm machine, and you need to replace "x86_64" in all the examples and code snippets by "aarch64".
+Building `aarch64` images on an Arm-based build host is a technology preview in SUSE Edge 3.1. It will most likely work, but isn't supported yet. If you want to try it out, you need to be running Podman on a 64-bit Arm machine, and you need to replace "x86_64" in all the examples and code snippets with "aarch64".
 
 In `/opt/eib`, create a file called `iso-definition.yaml`. This is your build definition for Edge Image Builder.
 

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -53,7 +53,7 @@ Register SUSE Linux Micro:
 Register SUSE Multi-Linux Manager:
 `transactional-update register -p SUSE-Manager-Server/5.0/x86_64 -r <REGCODE>`
 
-The product string depends on your hardware architecture! For example, if you are using SUSE Multi-Linux Manager on a 64-bit Arm system, the string is "SUSE-Manager-Server/5.0/aarch64"
+The product string depends on your hardware architecture! For example, if you are using SUSE Multi-Linux Manager on a 64-bit Arm system, the string is "SUSE-Manager-Server/5.0/aarch64".
 
 Reboot
 

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -62,7 +62,7 @@ Update the system:
 
 Unless there were no changes, reboot to apply the updates.
 
-SUSE Multi-Linux Manager is provided via a container that is managed by podman. The `mgradm` command handles the setup and configuration for you.
+SUSE Multi-Linux Manager is provided via a container that is managed by Podman. The `mgradm` command handles the setup and configuration for you.
 
 [WARNING]
 ====

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -19,7 +19,7 @@ If you already have an instance of the latest version of SUSE Multi-Linux Manage
 
 You can run SUSE Multi-Linux Manager Server on a dedicated physical server, as a virtual machine on your own hardware, or in the cloud. Pre-configured virtual machine images for SUSE Multi-Linux Server are provided for supported public clouds.
 
-In this quick start we're using the "qcow2" image "SUSE-Manager-Server.x86_64-5.0.2-Qcow-2024.12.qcow2" for x86-64 that you can find at https://www.suse.com/download/suse-manager/ or in the SUSE Customer Center. This image will work as a virtual machine on hypervisors like KVM. Please always check for the newest version of the image and use it for new installations.
+In this quick start we're using the "qcow2" image `SUSE-Manager-Server.x86_64-5.0.2-Qcow-2024.12.qcow2` for x86-64 that you can find at https://www.suse.com/download/suse-manager/ or in the SUSE Customer Center. This image will work as a virtual machine on hypervisors like KVM. Please always check for the newest version of the image and use it for new installations.
 
 You can also install SUSE Multi-Linux Manager Server on any of the other supported hardware architectures.
 

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -127,7 +127,7 @@ On the "Groups" tab, add the group you've created before. All nodes that are onb
 
 To use Edge Image Builder, you only need an environment where you can start a Linux-based container with podman.
 
-For a minimal lab setup, we can actually use the same virtual machine SUSE Multi-Linux Manager Server is running on. Please make sure that you have enough disk space in the virtual machine! This is not a recommended setup for production use. See <<id-prerequisites-2>> for host operating systems we have tested Edge Image builder with.
+For a minimal lab setup, we can actually use the same virtual machine SUSE Multi-Linux Manager Server is running on. Please make sure that you have enough disk space in the virtual machine! This is not a recommended setup for production use. See <<id-prerequisites-2>> for host operating systems we have tested Edge Image Builder with.
 
 Log into your SUSE Multi-Linux Manager Server host as root.
 

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -242,7 +242,7 @@ build --definition-file iso-definition.yaml
 
 If you have used a different name for your YAML definition file or want to use a different version of Edge Image Builder, you need to adapt the command accordingly.
 
-After the build is finished, you'll find the installation iso in the `/opt/eib` directory as `eib-image.iso`.
+After the build is finished, you'll find the installation ISO in the `/opt/eib` directory as `eib-image.iso`.
 
 
 

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -1,0 +1,250 @@
+[#quickstart-suma]
+= SUSE Multi-Linux Manager
+
+SUSE Multi-Linux Manager is included in SUSE Edge to provide automation and control for keeping SUSE Linux Micro as the underlying operating system consistently up-to-date on all nodes of your edge deployment.
+
+This quickstart guide is intended to get you up to speed with SUSE Multi-Linux Manager as quickly as possible, with the goal of providing operating system updates to your edge nodes. The quickstart guide doesn't discuss topics like sizing your storage, creating and managing additional software channels for staging purposes, or managing users, system groups, and organizations for larger deployments. For production use, we strongly recommend to get familiar with the comprehensive https://documentation.suse.com/suma/5.0/en/suse-manager/index.html[SUSE Multi-Linux Manager Documentation].
+
+The following steps are required to prepare SUSE Edge for using SUSE Multi-Linux Manager effectively:
+
+* Deploy and configure SUSE Multi-Linux Manager Server.
+* Sync the SUSE Linux Micro package repositories.
+* Create system groups.
+* Create activation keys.
+* Use Edge Image Builder to prepare installation media for SUSE Multi-Linux Manager registration
+
+== Deploy SUSE Multi-Linux Manager Server
+
+If you already have an instance of the latest version of SUSE Multi-Linux Manager 5.0 running, you can skip this step.
+
+You can run SUSE Multi-Linux Manager Server on a dedicated physical server, as a virtual machine on your own hardware, or in the cloud. Pre-configured virtual machine images for SUSE Multi-Linux Server are provided for supported public clouds.
+
+In this quick start we're using the "qcow2" image "SUSE-Manager-Server.x86_64-5.0.2-Qcow-2024.12.qcow2" for x86-64 that you can find at https://www.suse.com/download/suse-manager/ or in the SUSE Customer Center. This image will work as a virtual machine on hypervisors like KVM. Please always check for the newest version of the image and use it for new installations.
+
+You can also install SUSE Multi-Linux Manager Server on any of the other supported hardware architectures.
+
+Once you have downloaded the image, create a virtual machine that meets at least the following minimal hardware specifications:
+
+* 16 GB RAM
+* 4 physical or virtual cores
+* an additional block device that has at least 100 GB
+
+With the qcow2 image, there is no need to install the operating system. You can directly attach the image as your root partition.
+
+You need to set up the network so that your edge nodes can later access SUSE Multi-Linux Manager Server with a hostname that contains the fully qualified domain name ("FQDN")!
+
+When you boot SUSE Multi-Linux Manager for the first time you need to perform some initial configuration:
+
+* Select your keyboard layout
+* Accept the license agreement
+* Select your time zone
+* Enter the root password for the operating system
+
+The next steps need to be done as the "root" user:
+
+For the next step you need two registration codes that you can find in the SUSE Customer Center:
+
+* Your registration code for SLE Micro 5.5
+* Your registration code for the SUSE Multi-Linux Manager Extension
+
+Register SUSE Linux Micro:
+`transactional-update register -r <REGCODE> -e <your_email>`
+
+Register SUSE Multi-Linux Manager:
+`transactional-update register -p SUSE-Manager-Server/5.0/x86_64 -r <REGCODE>`
+
+The product string depends on your hardware architecture! For example, if you are using SUSE Multi-Linux Manager on a 64-bit Arm system, the string is "SUSE-Manager-Server/5.0/aarch64"
+
+Reboot
+
+Update the system:
+`transactional-update`
+
+Unless there were no changes, reboot to apply the updates.
+
+SUSE Multi-Linux Manager is provided via a container that is managed by podman. The `mgradm` command handles the setup and configuration for you.
+
+[WARNING]
+====
+It is very important that your SUSE Multi-Linux Manager Server has the hostname configured with a fully qualified domain name ("FQDN") that the edge nodes you want to manage can properly resolve in your network!
+====
+
+Before you install and configure the SUSE Multi-Linux Manager Server container, you need to prepare the additional block device that you've previously added. For that, you need to know the name the virtual machine has given to the device. For example, if the block device is `/dev/vdb`, you can configure to to be used for SUSE Multi-Linux Manager using the following command:
+
+[,shell]
+----
+mgr-storage-server /dev/vdb
+----
+
+Deploy SUSE Multi-Linux Manager:
+`mgradm install podman <FQDN>`
+
+Provide the password for the CA certificate. This password should be different from your login passwords. You usually don't need to enter it later, but you should note it down.
+
+Provide the password for the "admin" user. This is the initial user for logging into SUSE Multi-Linux Manager. You can create additional users with full or restricted rights later.
+
+== Configure SUSE Multi-Linux Manager
+
+Once the deployment has finished, you can log into the SUSE Multi-Linux Manager web UI using the host name you provided earlier.
+
+For the next step you need your Organization Credentials that you can find in SUSE Customer Center. With those credentials, SUSE Multi-Linux Manager can synchronize all the products that you have subscriptions for.
+
+Select "Admin > Setup Wizard"
+On the `Organization Credentials` tab create a new credential with your `Username` and `Password`.
+
+Go to the next tab `SUSE Products`. You need to wait until the first data synchronization with SUSE Customer Center has finished.
+
+Once the list is populated, you use the filter to only show "Micro 6".
+Check the box for SUSE Linux Micro 6.0 for the hardware architecture your edge nodes will run on (x86_64 or aarch64).
+
+Click `Add Products`. This will add the main package repository ("channel") for SUSE Linux Micro and automatically add the channel for the SUSE Manager client tools as a sub-channel.
+
+Depending on your Internet connection, the first synchronization will take a while. You can already start with the next steps:
+
+Under `System > System Groups`, create at least one group that your systems will automatically join when they are onboarded. Groups are an important way of categorizing systems, so you can apply configuration or actions to a whole set of systems at once. They are conceptionally similar to labels in Kubernetes.
+
+Click `+ Create Group`
+
+Provide a short name, e.g., "Edge Nodes", and long description.
+
+Under `Systems > Activation Keys`, create at least one activation key. Activation keys can be thought of as a configuration profile that is automatically applied to systems when they are onboarded to SUSE Multi-Linux Manager. If you want certain edge nodes to be added to different groups or use different configuration, you can create separate activation keys for them and use them later in Edge Image Builder to create customized installation media.
+
+A typical advanced use case for activation keys would be to assign your test clusters to the software channels with the latest updates and your production clusters to software channels that only get those latest updates once you've tested them in the test cluster.
+
+Click `+ Create Key`
+
+Choose a short description, e.g., "Edge Nodes".
+Provide a unique name that identifies the key, e.g., "edge-x86_64" for your edge nodes with x86_64 hardware architecture.
+A number prefix is automatically added to the key. For the default organization, the number is always "1". If you create additional organizations in SUSE Multi-Linux Manager and create keys for them, that number may differ.
+
+If you haven't created any cloned software channels, you can keep the setting for the Base Channel to "SUSE Manager Default". This will automatically assign the correct SUSE update repository for your edge nodes.
+
+As "Child Channel", select the "include recommended" slider for the hardware architecture your activation key is used for. This will add the "SUSE-Manager-Tools-For-SL-Micro-6.0" channel.
+
+On the "Groups" tab, add the group you've created before. All nodes that are onboarded using this activation key will automatically added to that group.
+
+== Create a customized installation image with Edge Image Builder
+
+To use Edge Image Builder, you only need an environment where you can start a Linux-based container with podman.
+
+For a minimal lab setup, we can actually use the same virtual machine SUSE Multi-Linux Manager Server is running on. Please make sure that you have enough disk space in the virtual machine! This is not a recommended setup for production use. See <<id-prerequisites-2>> for host operating systems we have tested Edge Image builder with.
+
+Log into your SUSE Multi-Linux Manager Server host as root.
+
+Pull the Edge Image Builder container:
+[,shell,subs="attributes"]
+----
+podman pull registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib}
+----
+
+Create the directory `/opt/eib` and a sub-directory `base-images`:
+[,shell]
+----
+mkdir -p /opt/eib/base-images
+----
+
+In this quickstart we're using the "self-install" flavor of the SUSE Linux Micro image. That image can later be written to a physical USB thumb drive that you can use to install on physical servers. If your server has the option of remote attachment of installation ISOs via a BMC (Baseboard Management Controller), you can also use that approach. Finally that image can also be used with most virtualization tools.
+
+If you either want to preload the image directly to a physical node or directly start it from a VM, you can also use the "raw" image flavor.
+
+Download or copy the image
+`SL-Micro.x86_64-6.0-Default-SelfInstall-GM2.install.iso` to the `base-images` directoy and name it "slemicro.iso".
+
+Building aarch64 images on an Arm-based build host is a technology preview in SUSE Edge 3.1. It will most likely work, but isn't supported yet. If you want to try it out, you need to be running podman on a 64-bit Arm machine, and you need to replace "x86_64" in all the examples and code snippets by "aarch64".
+
+In `/opt/eib`, create a file called `iso-definition.yaml`. This is your build definition for Edge Image Builder.
+
+Here is a simple example that installs SL Micro 6.0, sets a root password and the keymap, starts the Cockpit graphical UI and registers your node to SUSE Multi-Linux Manager:
+
+[,yaml]
+----
+apiVersion: 1.0
+image:
+  imageType: iso
+  arch: x64_64
+  baseImage: slemicro.iso
+  outputImageName: eib-image.iso
+operatingSystem:
+  users:
+  - username: root
+    createHomeDir: true
+    encryptedPassword: $6$aaBTHyqDRUMY1HAp$pmBY7.qLtoVlCGj32XR/Ogei4cngc3f4OX7fwBD/gw7HWyuNBOKYbBWnJ4pvrYwH2WUtJLKMbinVtBhMDHQIY0
+  keymap: de
+  systemd:
+    enable:
+      - cockpit.socket
+  packages:
+    noGPGCheck: true
+  suma:
+    host: ${fully qualified hostname of your SUSE Multi-Linux Manager Server}
+    activationKey: 1-edge-x86_64
+----
+
+Edge Image Builder can also configure the network, automatically install Kubernetes on the node, and even deploy applications via helm charts. See <<quickstart-eib>> for more comprehensive examples.
+
+For `baseImage`, specify the actual name of the ISO in the `base-images` directory that you want to use.
+
+In this example, the root password would be "root". See <<id-configuring-os-users>> for creating password hashes for the secure password you want to use.
+
+Set the keymap to the actual keyboard layout you want the system to have after installation.
+
+[NOTE]
+====
+We use the option `noGPGCheck: true` because we aren't going to provide a GPG key to check RPM packages. A comprehensive guide with a more secure setup that we recommend for production use can be found in the {link-eib-installing-packages}[upstream installing packages guide].
+====
+
+As mentioned several times, your SUSE Multi-Linux Manager host requires a fully qualified hostname that can be resolved in the network your edge nodes will boot into.
+
+The value for `activationKey` needs to match the key you've created in SUSE Multi-Linux Manager. 
+
+To build an installation image that automatically registers your edge nodes to SUSE Multi-Linux Manager after installation, you also need to prepare two artifacts:
+
+* the Salt minion package that installs the management agent for SUSE Multi-Linux Manager
+* the CA certificate of your SUSE Multi-Linux Manager server
+
+=== Download the venv-salt-minion package
+
+In `/opt/eib`, create a subdirectory `rpms`.
+
+Download the package `venv-salt-minion` from your SUSE Multi-Linux Manager server into that directory. You can either find it via the web UI by finding the package under `Software > Channel List` and download it from the SUSE-Manager-Tools ... channel or download it from the SUSE Multi-Linux Manager "bootstrap repo" with a tool like curl:
+
+[,shell]
+----
+curl http://${HOSTNAME_OF_SUSE_MANAGER}/pub/repositories/slmicro/6/0/bootstrap/x86_64/venv-salt-minion-3006.0-1.1.x64_64.rpm
+----
+The actual package name may differ if a newer release has already been released. If there are multiple packages to choose from, always pick the latest.
+
+== Download the SUSE Multi-Linux Manager CA certificate
+
+In `/opt/eib`, create a subdirectory `certificates`
+
+Download the CA certificate from SUSE Multi-Linux Manager into that directory:
+
+[,shell]
+----
+curl http://${HOSTNAME_OF_SUSE_MANAGER}/pub/RHN-ORG-TRUSTED-SSL-CERT
+----
+
+[WARNING]
+====
+You have to rename the certificate to `RHN-ORG-TRUSTED-SSL-CERT.crt`. Edge Image Builder will then make sure that the certificate is installed and activated on the edge node during installation.
+====
+
+Now you can run Edge Image Builder:
+
+[,bash,subs="attributes"]
+----
+cd /opt/eib
+podman run --rm -it --privileged -v $CONFIG_DIR:/eib \
+registry.suse.com/edge/{version-edge-registry}/edge-image-builder:{version-eib} \
+build --definition-file iso-definition.yaml
+----
+
+If you have used a different name for your YAML definition file or want to use a different version of Edge Image Builder, you need to adapt the command accordingly.
+
+After the build is finished, you'll find the installation iso in the `/opt/eib` directory as `eib-image.iso`.
+
+
+
+
+


### PR DESCRIPTION
Initial SUSE Multilinux Manager content including a quickstart guide

This is based on #462 - the commits there have been rebased on the latest main branch, and I split the content into a component and quickstart page (since most of the content in #462 is a quickstart guide)