### PR TITLE
Add missing RKE2ControlPlane rolloutStrategy

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -767,6 +767,10 @@ spec:
     name: single-node-cluster-controlplane
   replicas: 1
   version: $\{RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
   serverConfig:
     cni: cilium
   agentConfig:
@@ -1050,6 +1054,10 @@ spec:
     name: multinode-cluster-controlplane
   replicas: 3
   version: $\{RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
   registrationMethod: "address"
   registrationAddress: $\{EDGE_VIP_ADDRESS}
   serverConfig:
@@ -1504,6 +1512,10 @@ spec:
     name: single-node-cluster-controlplane
   replicas: 1
   version: $\{RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
   serverConfig:
     cni: calico
     cniMultusEnable: true
@@ -1728,6 +1740,10 @@ spec:
     name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
   privateRegistriesConfig:
     mirrors:
       "registry.example.com":
@@ -1849,6 +1865,10 @@ spec:
     name: single-node-cluster-controlplane
   replicas: 1
   version: $\{RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
   privateRegistriesConfig:       # Private registry configuration to add your own mirror and credentials
     mirrors:
       docker.io:

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -58,7 +58,7 @@ The changes required to upgrade the `RKE2` cluster using the automated workflow 
 
 * Change the block `RKE2ControlPlane` in the `capi-provisioning-example.yaml` shown in the following <<single-node-provision,section>>:
 
-  ** Add the rollout strategy in the spec file.
+  ** Specify the desired `rolloutStrategy`.
   ** Change the version of the `RKE2` cluster to the new version replacing `$\{RKE2_NEW_VERSION\}`.
 
 [,yaml]
@@ -75,6 +75,10 @@ spec:
     name: single-node-cluster-controlplane
   version: ${RKE2_NEW_VERSION}
   replicas: 1
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
   serverConfig:
     cni: cilium
   rolloutStrategy:

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -520,6 +520,10 @@ spec:
     name: sample-cluster-controlplane
   replicas: 1
   version: {version-kubernetes-rke2}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
   agentConfig:
     format: ignition
     kubelet:


### PR DESCRIPTION
This is required since moving to the v1beta1 API in #504

In future we should add more details describing the options but for now this ensures the examples are functional, and aligned with the ATIP repo examples.

Fixes: #557