### PR TITLE
[3.2] Fix Upgrade Controller examples

### DIFF
--- a/asciidoc/components/upgrade-controller.adoc
+++ b/asciidoc/components/upgrade-controller.adoc
@@ -260,7 +260,7 @@ kubectl get upgradeplan <upgradeplan_name> -n upgrade-controller-system -o yaml
 apiVersion: lifecycle.suse.com/v1alpha1
 kind: UpgradePlan
 metadata:
-  name: upgrade-plan-mgmt-3-1-0
+  name: upgrade-plan-mgmt
   namespace: upgrade-controller-system
 spec:
   releaseVersion: {version-edge}
@@ -381,7 +381,7 @@ An Upgrade Plan scheduled by the Upgrade Controller can be marked as `successful
 apiVersion: lifecycle.suse.com/v1alpha1
 kind: UpgradePlan
 metadata:
-  name: upgrade-plan-mgmt-3-1-0
+  name: upgrade-plan-mgmt
   namespace: upgrade-controller-system
 spec:
   releaseVersion: {version-edge}
@@ -457,7 +457,7 @@ status:
     reason: Skipped
     status: "False"
     type: RancherTurtlesUpgraded
-  lastSuccessfulReleaseVersion: 3.1.0
+  lastSuccessfulReleaseVersion: {version-edge}
   observedGeneration: 1
   sucNameSuffix: 90315a2b6d
 ----


### PR DESCRIPTION
- Remove hardcoded version from example `UpgradePlan` name
- Template the `lastSuccessfulReleaseVersion` property from the "Successful `UpgradePlan` example" section.