### PR TITLE
[3.2] Fix some missed 3.1 references (#560)

### DIFF
--- a/asciidoc/components/fleet.adoc
+++ b/asciidoc/components/fleet.adoc
@@ -61,12 +61,12 @@ The "Advanced" section allows to manage workspaces and other related Fleet resou
 
 1. Create a Git repository containing the `fleet.yaml` file:
 +
-[, yaml]
+[,yaml,subs="attributes"]
 ----
 defaultNamespace: kubevirt
 helm:
-  chart: "oci://registry.suse.com/edge/3.1/kubevirt-chart"
-  version: "0.4.0"
+  chart: "oci://registry.suse.com/edge/{version-edge-registry}/kubevirt-chart"
+  version: "{version-kubevirt-chart}"
   # kubevirt namespace is created by kubevirt as well, we need to take ownership of it
   takeOwnership: true
 ----

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -753,7 +753,7 @@ The agentConfig block contains the `Ignition` format to be used and the `additio
 To enable multus with cilium a file is created in the `rke2` server manifests directory named `rke2-cilium-config.yaml` with the configuration to be used.
 The last block of information contains the Kubernetes version to be used. `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `{version-kubernetes-rke2}`).
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
@@ -766,7 +766,7 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
-  version: ${RKE2_VERSION}
+  version: $\{RKE2_VERSION}
   serverConfig:
     cni: cilium
   agentConfig:
@@ -1036,7 +1036,7 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
     ** The `endpoint-svc.yaml` file to be used to configure the `kubernetes-vip` service to be used by the `MetalLB` to manage the `VIP` address.
 * The last block of information contains the Kubernetes version to be used. The `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `{version-kubernetes-rke2}`).
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
@@ -1049,14 +1049,14 @@ spec:
     kind: Metal3MachineTemplate
     name: multinode-cluster-controlplane
   replicas: 3
-  version: ${RKE2_VERSION}
+  version: $\{RKE2_VERSION}
   registrationMethod: "address"
-  registrationAddress: ${EDGE_VIP_ADDRESS}
+  registrationAddress: $\{EDGE_VIP_ADDRESS}
   serverConfig:
     cni: cilium
     tlsSan:
-      - ${EDGE_VIP_ADDRESS}
-      - https://${EDGE_VIP_ADDRESS}.sslip.io
+      - $\{EDGE_VIP_ADDRESS}
+      - https://$\{EDGE_VIP_ADDRESS}.sslip.io
   agentConfig:
     format: ignition
     additionalUserData:
@@ -1113,7 +1113,7 @@ spec:
                     name: endpoint-copier-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/endpoint-copier-operator-chart
+                    chart: oci://registry.suse.com/edge/{version-edge-registry}/endpoint-copier-operator-chart
                     targetNamespace: endpoint-copier-operator
                     version: {version-endpoint-copier-operator-chart}
                     createNamespace: true
@@ -1127,7 +1127,7 @@ spec:
                     name: metallb
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/metallb-chart
+                    chart: oci://registry.suse.com/edge/{version-edge-registry}/metallb-chart
                     targetNamespace: metallb-system
                     version: {version-metallb-chart}
                     createNamespace: true
@@ -1143,14 +1143,14 @@ spec:
                     namespace: metallb-system
                   spec:
                     addresses:
-                      - ${EDGE_VIP_ADDRESS}/32
+                      - $\{EDGE_VIP_ADDRESS}/32
                     serviceAllocation:
                       priority: 100
                       namespaces:
                         - default
                       serviceSelectors:
                         - matchExpressions:
-                          - {key: "serviceType", operator: In, values: [kubernetes-vip]}
+                          - \{key: "serviceType", operator: In, values: [kubernetes-vip]}
                   ---
                   apiVersion: metallb.io/v1beta1
                   kind: L2Advertisement
@@ -1490,7 +1490,7 @@ To make the process clear, the changes required on that block (`RKE2ControlPlane
 
 With all these changes mentioned, the `RKE2ControlPlane` block in the `capi-provisioning-example.yaml` will look like the following:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
@@ -1503,7 +1503,7 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
-  version: ${RKE2_VERSION}
+  version: $\{RKE2_VERSION}
   serverConfig:
     cni: calico
     cniMultusEnable: true
@@ -1530,18 +1530,18 @@ spec:
                     config.json: |
                       [
                          {
-                           "resourceName": "${RESOURCE_NAME1}",
-                           "interface": "${SRIOV-NIC-NAME1}",
-                           "pfname": "${PF_NAME1}",
-                           "driver": "${DRIVER_NAME1}",
-                           "numVFsToCreate": ${NUM_VFS1}
+                           "resourceName": "$\{RESOURCE_NAME1}",
+                           "interface": "$\{SRIOV-NIC-NAME1}",
+                           "pfname": "$\{PF_NAME1}",
+                           "driver": "$\{DRIVER_NAME1}",
+                           "numVFsToCreate": $\{NUM_VFS1}
                          },
                          {
-                           "resourceName": "${RESOURCE_NAME2}",
-                           "interface": "${SRIOV-NIC-NAME2}",
-                           "pfname": "${PF_NAME2}",
-                           "driver": "${DRIVER_NAME2}",
-                           "numVFsToCreate": ${NUM_VFS2}
+                           "resourceName": "$\{RESOURCE_NAME2}",
+                           "interface": "$\{SRIOV-NIC-NAME2}",
+                           "pfname": "$\{PF_NAME2}",
+                           "driver": "$\{DRIVER_NAME2}",
+                           "numVFsToCreate": $\{NUM_VFS2}
                          }
                       ]
               mode: 0644
@@ -1559,9 +1559,9 @@ spec:
                     name: sriov-crd
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/sriov-crd-chart
+                    chart: oci://registry.suse.com/edge/{version-edge-registry}/sriov-crd-chart
                     targetNamespace: sriov-network-operator
-                    version: 1.3.0
+                    version: {version-sriov-crd-chart}
                     createNamespace: true
             - path: /var/lib/rancher/rke2/server/manifests/sriov-network-operator.yaml
               overwrite: true
@@ -1573,9 +1573,9 @@ spec:
                     name: sriov-network-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/sriov-network-operator-chart
+                    chart: oci://registry.suse.com/edge/{version-edge-registry}/sriov-network-operator-chart
                     targetNamespace: sriov-network-operator
-                    version: 1.3.0
+                    version: {version-sriov-network-operator-chart}
                     createNamespace: true
         kernel_arguments:
           should_exist:
@@ -1586,10 +1586,10 @@ spec:
             - hugepagesz=1G hugepages=40
             - hugepagesz=2M hugepages=0
             - default_hugepagesz=1G
-            - irqaffinity=${NON-ISOLATED_CPU_CORES}
-            - isolcpus=domain,nohz,managed_irq,${ISOLATED_CPU_CORES}
-            - nohz_full=${ISOLATED_CPU_CORES}
-            - rcu_nocbs=${ISOLATED_CPU_CORES}
+            - irqaffinity=$\{NON-ISOLATED_CPU_CORES}
+            - isolcpus=domain,nohz,managed_irq,$\{ISOLATED_CPU_CORES}
+            - nohz_full=$\{ISOLATED_CPU_CORES}
+            - rcu_nocbs=$\{ISOLATED_CPU_CORES}
             - rcu_nocb_poll
             - nosoftlockup
             - nowatchdog
@@ -1626,7 +1626,7 @@ spec:
                 [Service]
                 Type=oneshot
                 User=root
-                ExecStart=/bin/sh -c "echo isolated_cores=${ISOLATED_CPU_CORES} > /etc/tuned/cpu-partitioning-variables.conf"
+                ExecStart=/bin/sh -c "echo isolated_cores=$\{ISOLATED_CPU_CORES} > /etc/tuned/cpu-partitioning-variables.conf"
                 ExecStartPost=/bin/sh -c "tuned-adm profile cpu-partitioning"
                 ExecStartPost=/bin/sh -c "systemctl enable tuned.service"
                 [Install]
@@ -1813,7 +1813,7 @@ The following example shows the SR-IOV configuration in the `AdditionalUserData`
 - Private Registry secrets references
 - Helm-Chart definition using the private registry instead of the public OCI images.
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
 # secret to include the private registry certificates
 apiVersion: v1
@@ -1822,9 +1822,9 @@ metadata:
   name: private-registry-cert
   namespace: default
 data:
-  tls.crt: ${TLS_BASE64_CERT}
-  tls.key: ${TLS_BASE64_KEY}
-  ca.crt: ${CA_BASE64_CERT}
+  tls.crt: $\{TLS_BASE64_CERT}
+  tls.key: $\{TLS_BASE64_KEY}
+  ca.crt: $\{CA_BASE64_CERT}
 type: kubernetes.io/tls
 ---
 # secret to include the private registry auth credentials
@@ -1834,8 +1834,8 @@ metadata:
   name: private-registry-auth
   namespace: default
 data:
-  username: ${REGISTRY_USERNAME}
-  password: ${REGISTRY_PASSWORD}
+  username: $\{REGISTRY_USERNAME}
+  password: $\{REGISTRY_PASSWORD}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
@@ -1848,7 +1848,7 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
-  version: ${RKE2_VERSION}
+  version: $\{RKE2_VERSION}
   privateRegistriesConfig:       # Private registry configuration to add your own mirror and credentials
     mirrors:
       docker.io:
@@ -1895,18 +1895,18 @@ spec:
                     config.json: |
                       [
                          {
-                           "resourceName": "${RESOURCE_NAME1}",
-                           "interface": "${SRIOV-NIC-NAME1}",
-                           "pfname": "${PF_NAME1}",
-                           "driver": "${DRIVER_NAME1}",
-                           "numVFsToCreate": ${NUM_VFS1}
+                           "resourceName": "$\{RESOURCE_NAME1}",
+                           "interface": "$\{SRIOV-NIC-NAME1}",
+                           "pfname": "$\{PF_NAME1}",
+                           "driver": "$\{DRIVER_NAME1}",
+                           "numVFsToCreate": $\{NUM_VFS1}
                          },
                          {
-                           "resourceName": "${RESOURCE_NAME2}",
-                           "interface": "${SRIOV-NIC-NAME2}",
-                           "pfname": "${PF_NAME2}",
-                           "driver": "${DRIVER_NAME2}",
-                           "numVFsToCreate": ${NUM_VFS2}
+                           "resourceName": "$\{RESOURCE_NAME2}",
+                           "interface": "$\{SRIOV-NIC-NAME2}",
+                           "pfname": "$\{PF_NAME2}",
+                           "driver": "$\{DRIVER_NAME2}",
+                           "numVFsToCreate": $\{NUM_VFS2}
                          }
                       ]
               mode: 0644
@@ -1920,7 +1920,7 @@ spec:
                 inline: |
                   apiVersion: v1
                   data:
-                    .dockerconfigjson: ${REGISTRY_AUTH_DOCKERCONFIGJSON}
+                    .dockerconfigjson: $\{REGISTRY_AUTH_DOCKERCONFIGJSON}
                   kind: Secret
                   metadata:
                     name: privregauth
@@ -1935,7 +1935,7 @@ spec:
                   data:
                     ca.crt: |-
                       -----BEGIN CERTIFICATE-----
-                      ${CA_BASE64_CERT}
+                      $\{CA_BASE64_CERT}
                       -----END CERTIFICATE-----
                   ---
                   apiVersion: helm.cattle.io/v1
@@ -1944,7 +1944,7 @@ spec:
                     name: sriov-crd
                     namespace: kube-system
                   spec:
-                    chart: oci://${PRIVATE_REGISTRY_URL}/sriov-crd
+                    chart: oci://$\{PRIVATE_REGISTRY_URL}/sriov-crd
                     dockerRegistrySecret:
                       name: privregauth
                     repoCAConfigMap:
@@ -1958,7 +1958,7 @@ spec:
                       global.rke2DataDir: /var/lib/rancher/rke2
                       global.serviceCIDR: 10.96.0.0/12
                     targetNamespace: sriov-network-operator
-                    version: ${SRIOV_CRD_VERSION}
+                    version: {version-sriov-crd-chart}
                   ---
                   apiVersion: helm.cattle.io/v1
                   kind: HelmChart
@@ -1966,7 +1966,7 @@ spec:
                     name: sriov-network-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://${PRIVATE_REGISTRY_URL}/sriov-network-operator
+                    chart: oci://$\{PRIVATE_REGISTRY_URL\}/sriov-network-operator
                     dockerRegistrySecret:
                       name: privregauth
                     repoCAConfigMap:
@@ -1980,7 +1980,7 @@ spec:
                       global.rke2DataDir: /var/lib/rancher/rke2
                       global.serviceCIDR: 10.96.0.0/12
                     targetNamespace: sriov-network-operator
-                    version: ${SRIOV_OPERATOR_VERSION}
+                    version: {version-sriov-network-operator-chart}
               mode: 0644
               user:
                 name: root
@@ -1995,10 +1995,10 @@ spec:
             - hugepagesz=1G hugepages=40
             - hugepagesz=2M hugepages=0
             - default_hugepagesz=1G
-            - irqaffinity=${NON-ISOLATED_CPU_CORES}
-            - isolcpus=domain,nohz,managed_irq,${ISOLATED_CPU_CORES}
-            - nohz_full=${ISOLATED_CPU_CORES}
-            - rcu_nocbs=${ISOLATED_CPU_CORES}
+            - irqaffinity=$\{NON-ISOLATED_CPU_CORES}
+            - isolcpus=domain,nohz,managed_irq,$\{ISOLATED_CPU_CORES}
+            - nohz_full=$\{ISOLATED_CPU_CORES}
+            - rcu_nocbs=$\{ISOLATED_CPU_CORES}
             - rcu_nocb_poll
             - nosoftlockup
             - nowatchdog
@@ -2035,7 +2035,7 @@ spec:
                 [Service]
                 Type=oneshot
                 User=root
-                ExecStart=/bin/sh -c "echo isolated_cores=${ISOLATED_CPU_CORES} > /etc/tuned/cpu-partitioning-variables.conf"
+                ExecStart=/bin/sh -c "echo isolated_cores=$\{ISOLATED_CPU_CORES} > /etc/tuned/cpu-partitioning-variables.conf"
                 ExecStartPost=/bin/sh -c "tuned-adm profile cpu-partitioning"
                 ExecStartPost=/bin/sh -c "systemctl enable tuned.service"
                 [Install]

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -449,7 +449,7 @@ If there are no interfaces here, it makes little sense to continue because the i
 
 * Get Helm if not present:
 
-[,shell]
+[,shell,subs="attributes"]
 ----
 $ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 ----
@@ -461,8 +461,8 @@ This part could be done in two ways, using the `CLI` or using the `Rancher UI`.
 Install Operator from CLI::
 +
 ----
-helm install sriov-crd oci://registry.suse.com/edge/3.1/sriov-crd-chart -n sriov-network-operator
-helm install sriov-network-operator oci://registry.suse.com/edge/3.1/sriov-network-operator-chart -n sriov-network-operator
+helm install sriov-crd oci://registry.suse.com/edge/{version-edge-registry}/sriov-crd-chart -n sriov-network-operator
+helm install sriov-network-operator oci://registry.suse.com/edge/{version-edge-registry}/sriov-network-operator-chart -n sriov-network-operator
 ----
 +
 Install Operator from Rancher UI::

--- a/asciidoc/tips/eib.adoc
+++ b/asciidoc/tips/eib.adoc
@@ -17,4 +17,4 @@
 To learn more about this configuration, please refer to the https://github.com/suse-edge/edge-image-builder/blob/main/docs/building-images.md#kubernetes[Kubernetes section docs].
 
 
-- `Edge Image Builder` relies on the hostnames of the different nodes to determine their Kubernetes type (`server` or `agent`). While this configuration is managed in the definition file, for the general networking setup of the machines we can utilize either DHCP or the https://documentation.suse.com/suse-edge/3.1/html/edge/components-nmc.html[Edge Networking page].
+- `Edge Image Builder` relies on the hostnames of the different nodes to determine their Kubernetes type (`server` or `agent`). While this configuration is managed in the definition file, for the general networking setup of the machines we can utilize either DHCP configuration as described in <<components-nmc>>.


### PR DESCRIPTION
There are a few places where we missed replacing hard-coded references with attributes

Fixes: #556
(cherry picked from commit 742efdbadc79ec2d4e2ab91ac4ba24b774f67d35)

Backport of #560 to release-3.2