### PR TITLE
Downstream cluster provisioning fix typos

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1231,10 +1231,10 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
-  name: multinode-node-cluster-controlplane-template
+  name: multinode-cluster-controlplane-template
   namespace: default
 spec:
-  clusterName: single-node-cluster
+  clusterName: multinode-cluster
   metaData:
     objectNames:
       - key: name


### PR DESCRIPTION
multinode-node-cluster-controlplane-template -> multinode-cluster-controlplane-template
clusterName: single-node-cluster -> clusterName: multinode-cluster

Fixes: #551
Fixes: #550