### PR TITLE
[release-3.2] management-cluster: clarify basic-setup.sh contents (#566)

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -409,7 +409,7 @@ The `custom` folder contains the following subfolders:
 
 The `custom/files` folder contains the following files:
 
-* `basic-setup.sh`: contains the configuration parameters about the `Metal^3^` version to be used, as well as the `Rancher` and `MetalLB` basic parameters. Only modify this file if you want to change the versions of the components or the namespaces to be used.
+* `basic-setup.sh`: contains configuration parameters for `Metal^3^`, `Rancher` and `MetalLB`. Only modify this file if you want to change the namespaces to be used.
 +
 [,shell]
 ----


### PR DESCRIPTION
Backport #566

Since migrating deployment of CAPI dependencies to Rancher Turtles we no longer specify versions in this file, see
https://github.com/suse-edge/atip/pull/7 for more details.

Fixes: #554
(cherry picked from commit eb981628e3ad45717a290f0afdcfc267b6db09ff)