### PR TITLE
[release-3.2] Downstream cluster provisioning fix typos (#567)

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1231,10 +1231,10 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
-  name: multinode-node-cluster-controlplane-template
+  name: multinode-cluster-controlplane-template
   namespace: default
 spec:
-  clusterName: single-node-cluster
+  clusterName: multinode-cluster
   metaData:
     objectNames:
       - key: name


### PR DESCRIPTION
Backport #567 

multinode-node-cluster-controlplane-template -> multinode-cluster-controlplane-template

clusterName: single-node-cluster -> clusterName: multinode-cluster

Fixes: #551
Fixes: #550
(cherry picked from commit 3a7cf9873d58d1b5da838cd902d66a52904c71e8)