### PR TITLE
UpgradeController and SystemUpgradeController

### DIFF
--- a/asciidoc/components/system-upgrade-controller.adoc
+++ b/asciidoc/components/system-upgrade-controller.adoc
@@ -19,7 +19,11 @@ ____
 
 == How does SUSE Edge use System Upgrade Controller?
 
-*SUC* is used to assist in the various "Day 2" operations that need to be executed in order to upgrade management/downstream clusters from one Edge platform version to another. Day 2 operations are defined in the form of *SUC Plans*. Based on the these plans, SUC deploys workloads on each node that executes the respective Day 2 operations.
+The SUC facilitates various "day 2" operations, including SUSE Edge version upgrades. SUSE Edge uses it to identifie and upgrade all existing components (OS, Kubernetes, etc.) within a cluster.
+
+While SUC is used to upgrade downstream clusters directly, it also operates behind the scenes when the Upgrade Controller updates management clusters.
+
+Day 2 operations are defined in the form of *SUC Plans*. Based on the these plans, SUC deploys workloads on each node that executes the respective Day 2 operations.
 
 [#components-system-upgrade-controller-install]
 == Installing the System Upgrade Controller

--- a/asciidoc/components/upgrade-controller.adoc
+++ b/asciidoc/components/upgrade-controller.adoc
@@ -21,6 +21,15 @@ A Kubernetes controller capable of performing infrastructure platform upgrades c
 * Additional components (Rancher, Elemental, SUSE Security, etc.)
 ____
 
+The Upgrade Controller intelligently upgrades a SUSE Edge *management cluster* to a new version. It identifies and upgrades all existing components, including the OS, Kubernetes, and others. If a component's version remains unchanged in the new SUSE Edge release, it will not be upgraded. Also, any components not found in the cluster are skipped during the upgrade process. It uses System Upgrade Controller (SUC) under the hood.
+
+
+== Upgrade Controller vs System Upgrade Controller
+
+While the System Upgrade Controller (SUC) is a general-purpose tool for Kubernetes node upgrades, it isn't tailored for SUSE Edge. Therefore, the Upgrade Controller (UC) was created to provide a streamlined upgrade experience specifically for SUSE Edge clusters.  UC manages upgrades between SUSE Edge versions (e.g., 3.1.2 to 3.2.0 or 3.1.1 to 3.2.2), simplifying management by treating the entire platform as a single unit.
+
+However, the current design of Cluster API prevents Upgrade Controller functioning correctly for downstream clusters. Cluster API separates OS provisioning from Kubernetes deployment and requires complete node replacement. Therefore, in current release, SUSE Edge utilizes SUC and Fleet for downstream cluster upgrades. Management clusters can be upgraded with the UC.
+
 == How does SUSE Edge use Upgrade Controller?
 
 The *Upgrade Controller* is essential in automating the (formerly manual) "Day 2" operations required to upgrade management clusters from one SUSE Edge release version to the next.

--- a/asciidoc/day2/migration.adoc
+++ b/asciidoc/day2/migration.adoc
@@ -24,6 +24,24 @@ Always perform cluster migrations from the `latest Z-stream` release of `Edge {p
 Always migrate to the `Edge {static-edge-version}` release. For subsequent post-migration upgrades, refer to the <<day2-mgmt-cluster, management>> and <<day2-downstream-clusters, downstream>> cluster sections.
 ====
 
+== Upgrade Prerequisites
+We understand you may not use all SUSE Edge components. The following components are required for a successful upgrade:
+
+* SUSE Linux Micro
+* k3s or RKE2 as Kubernetes platform
+* If downstream cluster is upgraded: System Upgrade Controller on each downstream cluster. Fleet on management cluster is necessary to trigger the upgrade
+* If management cluster is upgraded:
+** If cluster is not air-gapped, Upgrade Controller
+** If cluster is air-gapped, Fleet
+
+
+[NOTE]
+====
+Question. Are both UC and SUC necessary?
+
+Due to the current Cluster API design, the Upgrade Controller (UC) cannot upgrade downstream clusters. Cluster API's separation of OS provisioning from Kubernetes deployment, coupled with its requirement for complete node replacement, prevents UC from functioning correctly in this context. Therefore, this release utilizes SUC and Fleet for downstream cluster upgrades. Management clusters can be upgraded with the UC.
+====
+
 [#day2-migration-mgmt]
 == Management Cluster
 :cluster-type: management


### PR DESCRIPTION
I am hoping this PR clarifies the purpose of two-similarly-named-controllers and answer the basic questions from the users, such as "why both controllers are needed" and their individual roles.

* Adds "UC vs SUC" to explain when to use which controller
* Explains the use of SUC and Fleet (instead of UC) for managing downstream clusters, despite UC's original development for SUSE Edge
* Specifies the minimum required components for the upgrade. This considers that many customers don't install the full suite of SUSE Edge