### PR TITLE
atip-automated-provision: fix typo in metallb configuration

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1158,7 +1158,7 @@ spec:
                         - default
                       serviceSelectors:
                         - matchExpressions:
-                          - \{key: "serviceType", operator: In, values: [kubernetes-vip]}
+                          - {key: "serviceType", operator: In, values: [kubernetes-vip]}
                   ---
                   apiVersion: metallb.io/v1beta1
                   kind: L2Advertisement


### PR DESCRIPTION
There is a stray character which breaks this example with an error like: `/var/lib/rancher/rke2/server/manifests/metallb-cr.yaml: yaml: line 14: did not find expected key"`

Fixes: #581