### PR TITLE
releasenotes: clarify digest for multi-arch images

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -184,7 +184,7 @@ Verify the container image hash, for example using `crane`:
 sha256:d85c1bcd286dec81a3806a8fb8b66c0e0741797f23174f5f6f41281b1e27c52f
 ----
 
-NOTE: For multi-arch images it is also necessary to specify a platform when obtaining the digest, e.g `--platform linux/amd64` or `--platform linux/arm64`, failure to do this will result in an `Error: no matching attestations` error in the following step.
+NOTE: For multi-arch images it is also necessary to specify a platform when obtaining the digest, e.g `--platform linux/amd64` or `--platform linux/arm64`. Failure to do this will result in an error in the following step (`Error: no matching attestations`).
 
 Verify with `cosign`:
 

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -184,6 +184,8 @@ Verify the container image hash, for example using `crane`:
 sha256:d85c1bcd286dec81a3806a8fb8b66c0e0741797f23174f5f6f41281b1e27c52f
 ----
 
+NOTE: For multi-arch images it is also necessary to specify a platform when obtaining the digest, e.g `--platform linux/amd64` or `--platform linux/arm64`, failure to do this will result in an `Error: no matching attestations` error in the following step.
+
 Verify with `cosign`:
 
 [,bash]


### PR DESCRIPTION
The cosign verification must use the arch specific digest, otherwise the verification will fail.