### PR TITLE
Updating the support duration for Edge 3.2

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -234,11 +234,11 @@ In Edge 3.2 the Metal^3^ chart changes some default behavior, chart configuratio
 
 SUSE Edge is backed by award-winning support from SUSE, an established technology leader with a proven history of delivering enterprise-quality support services. For more information, see https://www.suse.com/lifecycle[https://www.suse.com/lifecycle] and the Support Policy page at https://www.suse.com/support/policy.html[https://www.suse.com/support/policy.html]. If you have any questions about raising a support case, how SUSE classifies severity levels, or the scope of support, please see the Technical Support Handbook at https://www.suse.com/support/handbook/[https://www.suse.com/support/handbook/].
 
-SUSE Edge "3.2" is supported for 18-months of production support, with an initial 6-months of "full support", followed by 12-months of "maintenance support".  After these support phases the product reaches "end of life" (EOL) and is no longer supported. More info about the lifecycle phases can be found in the table below:
+SUSE Edge "3.2" is supported for 24-months of production support, with an initial 6-months of "full support", followed by 18-months of "maintenance support".  After these support phases the product reaches "end of life" (EOL) and is no longer supported. More info about the lifecycle phases can be found in the table below:
 
 |======
 | *Full Support (6 months)* | Urgent and selected high-priority bug fixes will be released during the full support window, and all other patches (non-urgent, enhancements, new capabilities) will be released via the regular release schedule.
-| *Maintenance Support (12 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
+| *Maintenance Support (18 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
 | *End of Life (EOL)*  | Once a product release reaches its End of Life date, the customer may continue to use the product within the terms of product licensing agreement.
 Support Plans from SUSE do not apply to product releases past their EOL date.
 |======


### PR DESCRIPTION
Confirmed with @timirnich that there's a docs bug with 3.2 set as an 18-month lifecycle, whereas it's 24-months. This PR fixes that.