### PR TITLE
[release-3.2] atip-automated-provision: fix typo in metallb configuration (#582)

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1158,7 +1158,7 @@ spec:
                         - default
                       serviceSelectors:
                         - matchExpressions:
-                          - \{key: "serviceType", operator: In, values: [kubernetes-vip]}
+                          - {key: "serviceType", operator: In, values: [kubernetes-vip]}
                   ---
                   apiVersion: metallb.io/v1beta1
                   kind: L2Advertisement


### PR DESCRIPTION
Backport of #582 to release-3.2

There is a stray character which breaks this example with an error like: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml: yaml: line 14: did not find expected key"

Fixes: #581
(cherry picked from commit 3b2e45914beea7e753ac8870907491688de68b50)