### PR TITLE
Fixes incorrect registrationMethod for VIP (issue #578)

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1058,7 +1058,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       maxSurge: 0
-  registrationMethod: "address"
+  registrationMethod: "control-plane-endpoint"
   registrationAddress: $\{EDGE_VIP_ADDRESS}
   serverConfig:
     cni: cilium


### PR DESCRIPTION
In
https://documentation.suse.com/suse-edge/3.2/html/edge/atip-automated-provisioning.html#multi-node

Also needs to be corrected in the the 3.0 - 3.2 branches.