### PR TITLE
Added the "forgotten" Endpoint Copier Operator doc

### DIFF
--- a/asciidoc/components/endpoint-copier-operator.adoc
+++ b/asciidoc/components/endpoint-copier-operator.adoc
@@ -18,12 +18,9 @@ At SUSE Edge, the Endpoint Copier Operator plays a crucial role in achieving Hig
 
 == Best Practices
 
-=== Getting started
-
 Comprehensive documentation for using the Endpoint Copier Operator can be found https://github.com/suse-edge/endpoint-copier-operator/blob/main/README.md[here].
 
 Additionally, refer to <<guides-metallb-k3s,our guide>>  on achieving a K3s/RKE2 HA setup using the Endpoint Copier Operator and MetalLB.
 
 == Known issues
-
-* Presently, the Endpoint Copier Operator is limited to working with only one Service/Endpoint. Enhancements to support multiple Services/Endpoints are planned for the future.
+Presently, the Endpoint Copier Operator is limited to working with only one Service/Endpoint. Enhancements to support multiple Services/Endpoints are planned for the future.

--- a/asciidoc/components/metallb.adoc
+++ b/asciidoc/components/metallb.adoc
@@ -33,7 +33,7 @@ SUSE Edge uses MetalLB in two key ways:
 
 [NOTE]
 ====
-In order to be able to expose the API, the `endpoint-copier-operator` is used to keep in sync the K8s API endpoints from the `kubernetes` service to a `kubernetes-vip` LoadBalancer service.
+In order to be able to expose the API, the <<components-eco, Endpoint Copier Operator>> is used to keep in sync the K8s API endpoints from the `kubernetes` service to a `kubernetes-vip` LoadBalancer service.
 ====
 
 == Best practices

--- a/asciidoc/components/rke2.adoc
+++ b/asciidoc/components/rke2.adoc
@@ -68,7 +68,7 @@ For more information about the Metal^3^ use cases, see <<components-metal3>>.
 === High availability
 
 For HA deployments, EIB automatically deploys and configures
-<<components-metallb,MetalLB>> and the link:https://github.com/suse-edge/endpoint-copier-operator[Endpoint Copier Operator] to expose the RKE2 API endpoint externally.
+<<components-metallb,MetalLB>> and the <<components-eco,Endpoint Copier Operator>> to expose the RKE2 API endpoint externally.
 
 === Networking
 

--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -81,6 +81,8 @@ include::../components/neuvector.adoc[leveloffset=+1]
 
 include::../components/metallb.adoc[leveloffset=+1]
 
+include::../components/endpoint-copier-operator.adoc[leveloffset=+1]
+
 include::../components/virtualization.adoc[leveloffset=+1]
 
 include::../components/system-upgrade-controller.adoc[leveloffset=+1]

--- a/asciidoc/guides/metallb-kube-api.adoc
+++ b/asciidoc/guides/metallb-kube-api.adoc
@@ -13,7 +13,7 @@ endif::[]
 
 This guide demonstrates using a MetalLB service to expose the RKE2/K3s API externally on an HA cluster with three control-plane nodes.
 To achieve this, a Kubernetes Service of type `LoadBalancer` and Endpoints will be manually created. The Endpoints keep the IPs of all control plane nodes available in the cluster.
-For the Endpoint to be continuously synchronized with the events occurring in the cluster (adding/removing a node or a node goes offline), the https://github.com/suse-edge/endpoint-copier-operator[Endpoint Copier Operator] will be deployed. The operator monitors the events happening in the default `kubernetes` Endpoint and updates the managed one automatically to keep them in sync.
+For the Endpoint to be continuously synchronized with the events occurring in the cluster (adding/removing a node or a node goes offline), the <<components-eco,Endpoint Copier Operator>> will be deployed. The operator monitors the events happening in the default `kubernetes` Endpoint and updates the managed one automatically to keep them in sync.
 Since the managed Service is of type `LoadBalancer`, MetalLB assigns it a static `ExternalIP`. This `ExternalIP` will be used to communicate with the API Server.
 
 == Prerequisites


### PR DESCRIPTION
* Was merged in PR #147 but not added to the main document (fixes #485)
* Also added links to this document (fixes #149)