### PR TITLE
metal3-quickstart: Clarify storage configuration

### DIFF
--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -58,7 +58,7 @@ The basic steps to install a management cluster and use Metal^3^ are:
 
 . Install an RKE2 management cluster
 . Install Rancher
-. Install a storage provider
+. Install a storage provider (optional)
 . Install the Metal^3^ dependencies
 . Install CAPI dependencies via Rancher Turtles
 . Build a SLEMicro OS image for downstream cluster hosts
@@ -820,3 +820,22 @@ kubectl get secret -n metal3-system ironic-vmedia-cert -o yaml
 
 The certificate can then be configured on the server BMC console, although the process for that is vendor specific (and not possible for all
 vendors, in which case the `enable_vmedia_tls` flag may be required).
+
+=== Storage configuration
+
+For test/PoC environments where the management cluster is a single node, no persistent storage is required, but for production use-cases it
+is recommended to install SUSE Storage (Longhorn) on the management cluster so that images related to Metal^3^ can be persisted during a pod
+restart/reschedule.
+
+To enable this persistent storage, the Metal^3^ chart values required are as follows:
+
+[,yaml]
+----
+metal3-ironic:
+  persistence:
+    ironic:
+      size: "5Gi"
+----
+
+The <<atip-management-cluster, SUSE Edge for Telco Management Cluster Documentation>> has more details on how to configure a management cluster
+with persistent storage.


### PR DESCRIPTION
Persistent storage is now optional and not required by default, so add some details of the configuration needed to enable a PV, also cross-referencing to the telco management cluster docs which already contains details on this.