### PR TITLE
Fix workaround example in Edge 3.2.1

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -80,9 +80,9 @@ However, if you're creating new images via Edge Image Builder, you can apply the
 
 [,console]
 ----
-mkdir $CONFIG_DIR/os-files/var/lib/rancher/rke2/server/manifests
+mkdir -p $CONFIG_DIR/kubernetes/manifests
 
-cat << EOF > $CONFIG_DIR/os-files/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml
+cat << EOF > $CONFIG_DIR/kubernetes/manifests/rke2-ingress-nginx-config.yaml
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:


### PR DESCRIPTION
Using the "OS files" in EIB will fail as /var is not mounted by default so the example is adjusted to use the Kubernetes manifests functionality.