### PR TITLE
Fix hard-coded link in sriov chart version

### DIFF
--- a/asciidoc/edge-book/links.adoc
+++ b/asciidoc/edge-book/links.adoc
@@ -83,7 +83,6 @@
 :link-atip-examples: https://github.com/suse-edge/atip/tree/{release-tag-atip}/telco-examples/edge-clusters
 :link-atip-performance-settings: https://github.com/suse-edge/atip/blob/{release-tag-atip}/telco-examples/edge-clusters/dhcp/eib/custom/files/performance-settings.sh
 :link-atip-sriov-auto-filler: https://github.com/suse-edge/atip/blob/{release-tag-atip}/telco-examples/edge-clusters/dhcp/eib/custom/files/sriov-auto-filler.sh
-:link-atip-sriov-operator-values: https://github.com/suse-edge/charts/blob/main/charts/sriov-network-operator/1.4.0/values.yaml
-//:link-atip-sriov-operator-values: https://github.com/suse-edge/charts/blob/{release-tag-atip}/charts/sriov-network-operator/{version-sriov-network-operator-chart}/values.yaml
+:link-atip-sriov-operator-values: https://github.com/suse-edge/charts/blob/main/charts/sriov-network-operator/{version-sriov-upstream}/values.yaml
 
 :link-atip-micro-download-url: https://download.opensuse.org/repositories/isv:/SUSE:/Edge:/Telco/SL-Micro_6.0_images/

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -87,6 +87,7 @@
 :version-rancher-turtles-chart: 302.0.0+up0.14.1
 :version-sriov-crd-chart: 302.0.0+up1.4.0
 :version-sriov-network-operator-chart: 302.0.0+up1.4.0
+:version-sriov-upstream: 1.4.0
 
 
 // ============================================================================


### PR DESCRIPTION
The link has a hard-coded version, so move this to the versions.adoc to ensure we remember to update it - follow-up to #604