### PR TITLE
[release-3.2] Multi Linux Manager: Fix image name for client #636

### DIFF
--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -14,6 +14,8 @@
 // == SUSE Linux Micro ==
 :micro-base-image-raw: SL-Micro.x86_64-6.0-Base-GM2.raw
 :micro-base-image-iso: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
+:micro-default-image-iso: SL-Micro.x86_64-6.0-Default-SelfInstall-GM2.install.iso
+:micro-default-image-raw: SL-Micro.x86_64-6.0-Default-SelfInstall-GM2.install.raw
 :version-sl-micro: 6.0
 
 // == Edge Image Builder ==

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -162,7 +162,7 @@ If you either want to preload the image directly to a physical node or directly 
 
 You can find those images in the SUSE Customer Center or on https://www.suse.com/download/sle-micro/
 
-Download or copy the image `{micro-base-image-iso}` to the `base-images` directoy and name it "slemicro.iso".
+Download or copy the image `{micro-default-image-iso}` to the `base-images` directoy and name it "slemicro.iso".
 
 Building {aarch64} images on an Arm-based build host is a technology preview in SUSE Edge {version-edge}. It will most likely work, but isn't supported yet. If you want to try it out, you need to be running Podman on a 64-bit Arm machine, and you need to replace "x86_64" in all the examples and code snippets with "aarch64".
 


### PR DESCRIPTION
This is a backport of fix for issue https://github.com/suse-edge/suse-edge.github.io/issues/636 for release 3.2
For relevance, here is the commit message from that fix:
This is a typo fix.

As described on https://github.com/suse-edge/suse-edge.github.io/issues/636 the example for SUSE Multi Linux Manager Quick Start is using the Base SL Micro 6.0 image for the client while at the same time enabling cockpit socket in the configuration. This is not possible as cockpit is available in the Default image for SL Micro 6.0.

Therefore I added support for the Default image in edge-book/versions.adoc and then changed the image to point to the Default one.

Fixes: https://github.com/suse-edge/suse-edge.github.io/issues/636