### PR TITLE
Edge book versions: Fix typos in image names

### DIFF
--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -12,10 +12,10 @@
 :version-edge-registry: 3.2
 
 // == SUSE Linux Micro ==
-:micro-base-image-raw: SL-Micro.x86_64-6.0-Base-GM2.raw
+:micro-base-image-raw: SL-Micro.x86_64-6.0-Base-GM2.raw.xz
 :micro-base-image-iso: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
 :micro-default-image-iso: SL-Micro.x86_64-6.0-Default-SelfInstall-GM2.install.iso
-:micro-default-image-raw: SL-Micro.x86_64-6.0-Default-SelfInstall-GM2.install.raw
+:micro-default-image-raw: SL-Micro.x86_64-6.0-Default-GM2.raw.xz
 :version-sl-micro: 6.0
 
 // == Edge Image Builder ==

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -12,10 +12,9 @@
 :version-edge-registry: 3.2
 
 // == SUSE Linux Micro ==
-:micro-base-image-raw: SL-Micro.x86_64-6.0-Base-GM2.raw.xz
+:micro-base-image-raw: SL-Micro.x86_64-6.0-Base-GM2.raw
 :micro-base-image-iso: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
 :micro-default-image-iso: SL-Micro.x86_64-6.0-Default-SelfInstall-GM2.install.iso
-:micro-default-image-raw: SL-Micro.x86_64-6.0-Default-GM2.raw.xz
 :version-sl-micro: 6.0
 
 // == Edge Image Builder ==


### PR DESCRIPTION
Correcting image names for SL Micro 6.0 raw images to match https://www.suse.com/download/sle-micro/ as that will be the source for customer downloads.