### PR TITLE
add arm64 instructions

### DIFF
--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -13,6 +13,8 @@
 
 // == SUSE Linux Micro ==
 :micro-base-image-raw: SL-Micro.x86_64-6.0-Base-GM2.raw
+:micro-base-rt-image-raw: SL-Micro.x86_64-6.0-Base-RT-GM2.raw
+:micro-base-rt-image-iso: SL-Micro.x86_64-6.0-Base-RT-SelfInstall-GM2.install.iso
 :micro-base-image-iso: SL-Micro.x86_64-6.0-Base-SelfInstall-GM2.install.iso
 :micro-default-image-iso: SL-Micro.x86_64-6.0-Default-SelfInstall-GM2.install.iso
 :version-sl-micro: 6.0

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -340,18 +340,22 @@ Much of the configuration is possible with Edge Image Builder, but in this guide
 ==== Prerequisites for air-gap scenarios
 
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop] is required to run Edge Image Builder.
-* For the x86_64 architecture, the base image `{micro-base-image-raw}` (or `{micro-base-rt-image-raw}` for the Real-Time kernel) must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
-* For the arm64 architecture, the base image will be built using the following guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel).
+* The base image will be built using the following guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel). The process is the same for both architectures (x86-64 and aarch64).
+* To deploy aarch64 downstream clusters, you must set before the management cluster deployment the `deployArchitecture: arm64` parameter in the `metal3.yaml` file explained in <<arm64-mgmt-cluster,Management Cluster Documentation>>. This is required to ensure that the correct architecture is used for the downstream cluster.
 * If you want to use SR-IOV or any other workload which require a container image, a local private registry must be deployed and already configured (with/without TLS and/or authentication). This registry will be used to store the images and the helm chart OCI images.
+
+[NOTE]
+====
+It is required to use a build host with the same architecture of the images being built. In other words, to build an `aarch64` image, it is required to use an `aarch64` build host, and vice-versa for `x86-64` (cross-builds are not supported at this time).
+====
 
 ==== Image configuration for air-gap scenarios
 
 When running Edge Image Builder, a directory is mounted from the host, so it is necessary to create a directory structure to store the configuration files used to define the target image.
 
 * `downstream-cluster-airgap-config.yaml` is the image definition file, see <<quickstart-eib>> for more details.
-* The base image folder depending on the architecture will contain:
-    1. For x86_64 architecture, the image downloaded is `xz` compressed, which must be uncompressed with `unxz` and copied/moved under the `base-images` folder.
-    2. For arm64 architecture, the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel) must be copied/moved under the `base-images` folder.* The `network` folder is optional, see <<add-network-eib>> for more details.
+* The base image folder will contain the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel) must be copied/moved under the `base-images` folder.
+* The `network` folder is optional, see <<add-network-eib>> for more details.
 * The `custom/scripts` directory contains scripts to be run on first-boot:
     1. `01-fix-growfs.sh` script is required to resize the OS root partition on deployment.
     2. `02-airgap.sh` script is required to copy the images to the right place during the image creation process for air-gapped environments.
@@ -1446,9 +1450,8 @@ The directed network provisioning workflow allows to automate the Telco features
 
 *Requirements*
 
-- The image generated using `EIB` has to include the base images downloaded from https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page] with the RT kernel `{micro-base-rt-image-raw}`.
-- The image generated using `EIB` has to include the specific Telco packages following xref:add-telco-feature-eib[this section].
 - The image generated using `EIB`, as described in the xref:eib-edge-image-connected[previous section],  has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
+- The image generated using `EIB` has to include the specific Telco packages following xref:add-telco-feature-eib[this section].
 - The management server created and available to be used on the following sections. For more information, refer to the Management Cluster section: <<atip-management-cluster>>.
 
 *Configuration*

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -67,14 +67,20 @@ Much of the configuration via Edge Image Builder is possible, but in this guide,
 ==== Prerequisites for connected scenarios
 
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop] is required to run Edge Image Builder.
-* The base image `{micro-base-image-raw}` must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
+* The base image will be built using the following guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel). The process is the same for both architectures (x86-64 and aarch64).
+* To deploy aarch64 downstream clusters, you must set before the management cluster deployment the `deployArchitecture: arm64` parameter in the `metal3.yaml` file explained in <<arm64-mgmt-cluster,Management Cluster Documentation>>. This is required to ensure that the correct architecture is used for the downstream cluster.
+
+[NOTE]
+====
+It is required to use a build host with the same architecture of the images being built. In other words, to build an `aarch64` image, it is required to use an `aarch64` build host, and vice-versa for `x86-64` (cross-builds are not supported at this time).
+====
 
 ==== Image configuration for connected scenarios
 
 When running Edge Image Builder, a directory is mounted from the host, so it is necessary to create a directory structure to store the configuration files used to define the target image.
 
 * `downstream-cluster-config.yaml` is the image definition file, see <<quickstart-eib>> for more details.
-* The base image when downloaded is `xz` compressed, which must be uncompressed with `unxz` and copied/moved under the `base-images` folder.
+* The base image folder will contain the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel) must be copied/moved under the `base-images` folder.
 * The `network` folder is optional, see <<add-network-eib>> for more details.
 * The `custom/scripts` directory contains scripts to be run on first-boot:
     1. `01-fix-growfs.sh` script is required to resize the OS root partition on deployment
@@ -141,6 +147,8 @@ For the production environments, it is recommended to use the SSH keys that can 
 
 [NOTE]
 ====
+`arch: x86_64` is the architecture of the image. For arm64 architecture, use `arch: aarch64`.
+
 `net.ifnames=1` enables https://documentation.suse.com/smart/network/html/network-interface-predictable-naming/index.html[Predictable Network Interface Naming]
 
 This matches the default configuration for the metal3 chart, but the setting must match the configured chart `predictableNicNames` value.
@@ -257,6 +265,11 @@ operatingSystem:
 Where `$SCC_REGISTRATION_CODE` is the registration code copied from https://scc.suse.com/[SUSE Customer Center], and the package list contains the minimum packages to be used for the Telco profiles.
 To use the `pf-bb-config` package (to enable the `FEC` feature and binding with drivers), the `additionalRepos` block must be included to add the `SUSE Edge Telco` repository.
 
+[NOTE]
+====
+`arch: x86_64` is the architecture of the image. For arm64 architecture, use `arch: aarch64`.
+====
+
 [#add-network-eib]
 ===== Additional script for Advanced Network Configuration
 
@@ -327,7 +340,8 @@ Much of the configuration is possible with Edge Image Builder, but in this guide
 ==== Prerequisites for air-gap scenarios
 
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop] is required to run Edge Image Builder.
-* The base image `{micro-base-image-raw}` must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
+* For the x86_64 architecture, the base image `{micro-base-image-raw}` (or `{micro-base-rt-image-raw}` for the Real-Time kernel) must be downloaded from the https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page].
+* For the arm64 architecture, the base image will be built using the following guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel).
 * If you want to use SR-IOV or any other workload which require a container image, a local private registry must be deployed and already configured (with/without TLS and/or authentication). This registry will be used to store the images and the helm chart OCI images.
 
 ==== Image configuration for air-gap scenarios
@@ -335,8 +349,9 @@ Much of the configuration is possible with Edge Image Builder, but in this guide
 When running Edge Image Builder, a directory is mounted from the host, so it is necessary to create a directory structure to store the configuration files used to define the target image.
 
 * `downstream-cluster-airgap-config.yaml` is the image definition file, see <<quickstart-eib>> for more details.
-* The base image when downloaded is `xz` compressed, which must be uncompressed with `unxz` and copied/moved under the `base-images` folder.
-* The `network` folder is optional, see <<add-network-eib>> for more details.
+* The base image folder depending on the architecture will contain:
+    1. For x86_64 architecture, the image downloaded is `xz` compressed, which must be uncompressed with `unxz` and copied/moved under the `base-images` folder.
+    2. For arm64 architecture, the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel) must be copied/moved under the `base-images` folder.* The `network` folder is optional, see <<add-network-eib>> for more details.
 * The `custom/scripts` directory contains scripts to be run on first-boot:
     1. `01-fix-growfs.sh` script is required to resize the OS root partition on deployment.
     2. `02-airgap.sh` script is required to copy the images to the right place during the image creation process for air-gapped environments.
@@ -1431,6 +1446,7 @@ The directed network provisioning workflow allows to automate the Telco features
 
 *Requirements*
 
+- The image generated using `EIB` has to include the base images downloaded from https://scc.suse.com/[SUSE Customer Center] or the https://www.suse.com/download/sle-micro/[SUSE Download page] with the RT kernel `{micro-base-rt-image-raw}`.
 - The image generated using `EIB` has to include the specific Telco packages following xref:add-telco-feature-eib[this section].
 - The image generated using `EIB`, as described in the xref:eib-edge-image-connected[previous section],  has to be located in the management cluster exactly on the path you configured on xref:metal3-media-server[this section].
 - The management server created and available to be used on the following sections. For more information, refer to the Management Cluster section: <<atip-management-cluster>>.

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -839,7 +839,31 @@ metal3-ironic:
   persistence:
     ironic:
       size: "5Gi"
+
 ----
+[#arm64-mgmt-cluster]
+In case you want to deploy arm64 downstream clusters using this x86_64 management cluster, you need to add the following `deployArchitecture: arm64` to the `global` section of the `metal3.yaml` file:
++
+[,yaml]
+----
+global:
+  ironicIP: ${METAL3_VIP}
+  enable_vmedia_tls: false
+  additionalTrustedCAs: false
+  deployArchitecture: arm64
+metal3-ironic:
+  global:
+    predictableNicNames: "true"
+  persistence:
+    ironic:
+      size: "5Gi"
+----
+
+[NOTE]
+====
+In the current version, a limitation exists regarding the use of `deployArchitecture: arm64`. Specifically, if you enable the deployment of downstream arm64 clusters using this directive, the management cluster will subsequently only be able to deploy this architecture.
+To deploy clusters on both architectures (x86_64 and arm64), you will need to provision two separate management clusters. This limitation will be removed in future versions.
+====
 
 [#metal3-media-server]
 [NOTE]

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -862,7 +862,7 @@ metal3-ironic:
 [NOTE]
 ====
 In the current version, a limitation exists regarding the use of `deployArchitecture: arm64`. Specifically, if you enable the deployment of downstream arm64 clusters using this directive, the management cluster will subsequently only be able to deploy this architecture.
-To deploy clusters on both architectures (x86_64 and arm64), you will need to provision two separate management clusters. This limitation will be removed in future versions.
+To deploy clusters on both architectures (x86_64 and arm64), you will need to provision two separate management clusters. This limitation will be removed in a future version.
 ====
 
 [#metal3-media-server]


### PR DESCRIPTION
- Add versions for RT kernel (it was missing)
- Add the management cluster configuration in values.yaml metal3 for arm64
- Add the downstream clusters explanation using kiwi in EIB preparation, splitting the current EIB step in different architectures