### PR TITLE
remove the UI missing image

### DIFF
--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -456,25 +456,11 @@ $ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bas
 
 * Install SR-IOV.
 
-This part could be done in two ways, using the `CLI` or using the `Rancher UI`.
-
-Install Operator from CLI::
-+
+[,shell,subs="attributes"]
 ----
 helm install sriov-crd oci://registry.suse.com/edge/{version-edge-registry}/sriov-crd-chart -n sriov-network-operator
 helm install sriov-network-operator oci://registry.suse.com/edge/{version-edge-registry}/sriov-network-operator-chart -n sriov-network-operator
 ----
-+
-Install Operator from Rancher UI::
-+
-Once your cluster is installed, and you have access to the `Rancher UI`, you can install the `SR-IOV Operator` from the `Rancher UI` from the apps tab:
-
-[NOTE]
-====
-Make sure you select the right namespace to install the operator, for example, `sriov-network-operator`.
-====
-+
-image::features_sriov.png[sriov.png]
 
 * Check the  deployed resources crd and pods:
 


### PR DESCRIPTION
as this is the only l place where we said to use the UI and also the installation is based on our helm chart I decided to remove the UI part to keep only the CLI

Fixes: #641 
