### PR TITLE
[release-3.3] Fix issues with suse-edge charts location/names

### DIFF
--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -744,7 +744,7 @@ kubernetes:
         installationNamespace: kube-system
     repositories:
       - name: suse-edge
-        url: oci://registry.suse.com/edge/{version-edge-registry}
+        url: oci://registry.suse.com/edge/charts
 embeddedArtifactRegistry:
   images:
     - name: registry.suse.com/suse/sles/15.6/cdi-uploadproxy:1.60.1-150600.3.9.1

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -182,14 +182,14 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
-      - name: metal3-chart
+      - name: metal3
         version: {version-metal3-chart}
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
-      - name: rancher-turtles-chart
+      - name: rancher-turtles
         version: {version-rancher-turtles-chart}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
@@ -311,14 +311,14 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
-      - name: metal3-chart
+      - name: metal3
         version: {version-metal3-chart}
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
-      - name: rancher-turtles-chart
+      - name: rancher-turtles
         version: {version-rancher-turtles-chart}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
@@ -1051,21 +1051,21 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
-      - name: metal3-chart
+      - name: metal3
         version: {version-metal3-chart}
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
-      - name: rancher-turtles-chart
+      - name: rancher-turtles
         version: {version-rancher-turtles-chart}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: turtles.yaml
-      - name: rancher-turtles-airgap-resources-chart
+      - name: rancher-turtles-airgap-resources
         version: {version-rancher-turtles-chart}
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -222,7 +222,7 @@ kubernetes:
       - name: rancher-charts
         url: https://charts.rancher.io/
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/{version-edge-registry}
+        url: oci://registry.suse.com/edge/charts
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
   network:
@@ -351,7 +351,7 @@ kubernetes:
       - name: rancher-charts
         url: https://charts.rancher.io/
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/{version-edge-registry}
+        url: oci://registry.suse.com/edge/charts
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
     network:
@@ -1098,7 +1098,7 @@ kubernetes:
       - name: rancher-charts
         url: https://charts.rancher.io/
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/{version-edge-registry}
+        url: oci://registry.suse.com/edge/charts
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
     network:

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -250,7 +250,7 @@ kubernetes:
         repositoryName: suse-edge
     repositories:
       - name: suse-edge
-        url: oci://registry.suse.com/edge/{version-edge-registry}
+        url: oci://registry.suse.com/edge/charts
 ----
 
 The resulting full definition file should now look like:
@@ -283,7 +283,7 @@ kubernetes:
         repositoryName: suse-edge
     repositories:
       - name: suse-edge
-        url: oci://registry.suse.com/edge/{version-edge-registry}
+        url: oci://registry.suse.com/edge/charts
 ----
 
 [NOTE]

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -245,7 +245,7 @@ kubernetes:
       - https://k8s.io/examples/application/nginx-app.yaml
   helm:
     charts:
-      - name: kubevirt-chart
+      - name: kubevirt
         version: {version-kubevirt-chart}
         repositoryName: suse-edge
     repositories:
@@ -278,7 +278,7 @@ kubernetes:
       - https://k8s.io/examples/application/nginx-app.yaml
   helm:
     charts:
-      - name: kubevirt-chart
+      - name: kubevirt
         version: {version-kubevirt-chart}
         repositoryName: suse-edge
     repositories:
@@ -484,7 +484,7 @@ The contents of this directory should look like:
 │   ├── eib-build.log
 │   ├── embedded-registry.log
 │   ├── helm
-│   │   └── kubevirt-chart
+│   │   └── kubevirt
 │   │       └── kubevirt-0.4.0.tgz
 │   ├── helm-pull.log
 │   ├── helm-template.log


### PR DESCRIPTION
Backport #690 

For 3.3 we moved the charts to registry.suse.com/edge/charts but missed some updates to the examples in https://github.com/suse-edge/suse-edge.github.io/pull/649

The chart names also changed so ensure the examples are updated and aligned with e.g the examples in https://github.com/suse-edge/atipFor 3.3 we moved the charts to registry.suse.com/edge/charts but missed some updates to the examples in https://github.com/suse-edge/suse-edge.github.io/pull/649

The chart names also changed so ensure the examples are updated and aligned with e.g the examples in https://github.com/suse-edge/atip