### PR TITLE
release-notes: correct 3.3 maintenance support

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -443,7 +443,7 @@ SUSE Edge "3.3" is supported for 18-months of production support, with an initia
 
 |======
 | *Full Support (6 months)* | Urgent and selected high-priority bug fixes will be released during the full support window, and all other patches (non-urgent, enhancements, new capabilities) will be released via the regular release schedule.
-| *Maintenance Support (18 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
+| *Maintenance Support (12 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
 | *End of Life (EOL)*  | Once a product release reaches its End of Life date, the customer may continue to use the product within the terms of product licensing agreement.
 Support Plans from SUSE do not apply to product releases past their EOL date.
 |======


### PR DESCRIPTION
This still says 18 months which was copied from 3.2 and conflicts with the prior statement

Fixes: #708