### PR TITLE
Removing dead reference to EIB Tips and Tricks

### DIFF
--- a/asciidoc/troubleshooting/troubleshooting-edge-image-builder.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-edge-image-builder.adoc
@@ -22,7 +22,7 @@ EIB is used to create custom SUSE Edge images.
 * *Operating system group dependencies*: When creating an image with custom users and groups, the groups being set as “`primaryGroup`” should be explicitly created.
 * *Operating system user's sshkeys requires a home folder*: When creating an image with users with sshkeys, the home folder needs to be created as well with `createHomeDir=true`.
 * *Combustion issues*: EIB relies on combustion for the customization of the OS and deployment of all the other SUSE Edge components. This also includes custom scripts being placed in the custom/scripts folder. Note that the combustion process is being executed at `initrd` time, so the system is not completely booted when the scripts are executed.
-* *Podman machine size*: As explained in the <<tips-and-tricks,EIB Tips and Tricks section>>, verify the podman machine has enough CPU/memory to run the EIB container on non-Linux operating systems.
+* *Podman machine size*: Verify the podman machine has enough CPU/memory to run the EIB container on non-Linux operating systems.
 
 .Logs
 


### PR DESCRIPTION
The dead reference causes a build failure