### PR TITLE
EIB quickstart: clarify build host support

### DIFF
--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -27,7 +27,7 @@ Older versions, such as SUSE Linux Enterprise Micro 5.5, or 6.0 are not supporte
 ====
 
 == Prerequisites
-* An {x86-64} build host machine (physical or virtual) running SLES 15 SP6
+* An {x86-64} build host machine (physical or virtual) running SLES 15 SP6.
 * The Podman container engine
 * A SUSE Linux Micro {version-sl-micro} SelfInstall ISO image created using the <<guides-kiwi-builder-images,Kiwi Builder procedure>>
 

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -27,13 +27,16 @@ Older versions, such as SUSE Linux Enterprise Micro 5.5, or 6.0 are not supporte
 ====
 
 == Prerequisites
-
-* An {x86-64} physical host (or virtual machine) running SLES 15 SP6, openSUSE Leap 15.6, or openSUSE Tumbleweed.
-* An available container runtime (e.g. Podman)
+* An {x86-64} build host machine (physical or virtual) running SLES 15 SP6
+* The Podman container engine
 * A SUSE Linux Micro {version-sl-micro} SelfInstall ISO image created using the <<guides-kiwi-builder-images,Kiwi Builder procedure>>
 
-NOTE: Other operating systems may function so long as a compatible container runtime is available, but testing on other platforms has not been extensive. The documentation focuses on Podman, but the same functionality should be able to be achieved with Docker.
-
+[NOTE]
+====
+For non-production purposes, openSUSE Leap 15.6, or openSUSE Tumbleweed may be used as a build host machine. 
+Other operating systems may function, so long as a compatible container runtime is available.
+====
+         
 === Getting the EIB Image
 
 The EIB container image is publicly available and can be downloaded from the SUSE Edge registry by running the following command on your image build host:


### PR DESCRIPTION
# Clarifying build host support in Prerequisites

I believe this clarifies what is supported, while still communicating that non supported OS and container runtimes can be used for testing. Let me know what you think

Fixes: #345