### PR TITLE
add prime overrides configs

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -108,6 +108,7 @@ eib
 │ │ └── values
 │ │     ├── rancher.yaml
 │ │     ├── neuvector.yaml
+│ │     ├── longhorn.yaml
 │ │     ├── metal3.yaml
 │ │     └── certmanager.yaml
 │ └── config
@@ -182,6 +183,7 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
+        valuesFile: longhorn.yaml
       - name: metal3
         version: {version-metal3-chart}
         repositoryName: suse-edge-charts
@@ -311,6 +313,7 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
+        valuesFile: longhorn.yaml
       - name: metal3
         version: {version-metal3-chart}
         repositoryName: suse-edge-charts
@@ -716,6 +719,9 @@ The `kubernetes/config` folder contains the following files:
 cni:
 - multus
 - cilium
+write-kubeconfig-mode: '0644'
+selinux: true
+system-default-registry: registry.rancher.com
 ----
 
 [NOTE]
@@ -802,7 +808,9 @@ The `kubernetes/helm/values` folder contains the following files:
 hostname: rancher-${INGRESS_VIP}.sslip.io
 bootstrapPassword: "foobar"
 replicas: 1
-global.cattle.psp.enabled: "false"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"
 ----
 
 - `neuvector.yaml`: contains the configuration to create the `NeuVector` component (no modifications needed).
@@ -823,6 +831,19 @@ k3s:
   enabled: true
 crdwebhook:
   enabled: false
+registry: "registry.rancher.com"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"
+----
+
+- `longhorn.yaml`: contains the configuration to create the `Longhorn` component (no modifications needed).
++
+[,yaml]
+----
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"
 ----
 
 - `metal3.yaml`: contains the configuration to create the `Metal^3^` component. The `$\{METAL3_VIP\}` must be set properly to define the IP address to be consumed by the `Metal^3^` component.
@@ -1051,6 +1072,7 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
+        valuesFile: longhorn.yaml
       - name: metal3
         version: {version-metal3-chart}
         repositoryName: suse-edge-charts
@@ -1156,6 +1178,7 @@ embeddedArtifactRegistry:
     - name: registry.suse.com/rancher/hardened-sriov-network-operator:v1.5.0-build20250425
     - name: registry.suse.com/rancher/ip-address-manager:v1.9.4
     - name: registry.rancher.com/rancher/kubectl:v1.32.2
+    - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.9.5
 ----
 
 [#mgmt-cluster-custom-folder-airgap]


### PR DESCRIPTION
- Add overrides to use prime registry images (including the new longhorn.yaml values file)
- Add missing image to the airgap list