### PR TITLE
Rename Product as SUSE Telco Cloud

### DIFF
--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -167,10 +167,10 @@ include::../day2/mgmt-cluster.adoc[leveloffset=+1]
 include::../day2/downstream-clusters.adoc[leveloffset=+1]
 
 //--------------------------------------------
-// Product Documentation
+// SUSE Telco Cloud Documentation
 //--------------------------------------------
 
-= Product Documentation
+= SUSE Telco Cloud Documentation
 
 [partintro]
 Find the SUSE Edge for Telco documentation here

--- a/asciidoc/images/product-atip-architecture1.svg
+++ b/asciidoc/images/product-atip-architecture1.svg
@@ -557,7 +557,7 @@
          id="tspan1277"
          x="141.50389"
          y="67.003082"
-         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93889px;font-family:SUSE;-inkscape-font-specification:'SUSE Semi-Bold';fill:#ffffff;stroke-width:0.264583">K3s | RKE2</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93889px;font-family:SUSE;-inkscape-font-specification:'SUSE Semi-Bold';fill:#ffffff;stroke-width:0.264583">RKE2</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:SUSE;-inkscape-font-specification:'SUSE Semi-Bold';letter-spacing:0px;fill:#ffffff;stroke-width:0.264583"

--- a/asciidoc/product/atip-architecture.adoc
+++ b/asciidoc/product/atip-architecture.adoc
@@ -37,7 +37,7 @@ There are two different blocks, the management stack and the runtime stack:
   ** GitOps Engine for managing the lifecycle of the clusters using Git repositories with <<components-fleet,Fleet>>
 
 * *Runtime stack*: This is the part of SUSE Edge for Telco that is used to run the workloads.
-  ** Kubernetes with secure and lightweight distributions like <<components-k3s,K3s>> and <<components-rke2,RKE2>> (`RKE2` is hardened, certified and optimized for government use and regulated industries).
+  ** <<components-rke2,RKE2>> serves as the security-hardened, lightweight Kubernetes distribution, optimized for edge and compliance-focused telecom environments.
   ** <<components-suse-security,SUSE Security>> to enable security features like image vulnerability scanning, deep packet inspection and automatic intra-cluster traffic control.
   ** Block Storage with <<components-suse-storage,SUSE Storage>> to enable a simple and easy way to use a cloud native storage solution.
   ** Optimized Operating System with <<components-slmicro,SUSE Linux Micro>> to enable a secure, lightweight and immutable (transactional file system) OS for running containers. SUSE Linux Micro is available on {aarch64} and {x86-64} architectures, and it also supports `Real-Time Kernel` for Telco and edge use cases.

--- a/asciidoc/product/atip.adoc
+++ b/asciidoc/product/atip.adoc
@@ -12,9 +12,9 @@ ifdef::env-github[]
 endif::[]
 :toc: preamble
 
-SUSE Edge for Telco (formerly known as Adaptive Telco Infrastructure Platform/ATIP) is a Telco-optimized edge computing platform that enables telecom companies to innovate and accelerate the modernization of their networks.
+SUSE Edge for Telco (formerly known as Adaptive Telco Infrastructure Platform/ATIP) is a telecom-optimized computing platform that enables telecom operators and teelcom network vendors to innovate and accelerate the modernization of their networks.
 
-SUSE Edge for Telco is a complete Telco cloud stack for hosting CNFs such as 5G Packet Core and Cloud RAN.
+SUSE Edge for Telco is a complete Telco cloud stack for hosting CNFs, including 5G Packet Core, Cloud RAN, OSS and BSS.
 
 - Automates zero-touch rollout and lifecycle management of complex edge stack configurations at Telco scale.
 - Continuously assures quality on Telco-grade hardware, using Telco-specific configurations and workloads.


### PR DESCRIPTION
Update some of the documentation to reflect the new product name: SUSE Telco Cloud. The previous name, 'SUSE Edge for Telco', caused a big confusion to customers and partners regarding the product's positioning.

This PR also does:
* Rename 'Product Doc' chapter to 'SUSE Telco Cloud'. Technically we offer 2 products: SUSE Edge and SUSE Telco Cloud. So referring SUSE Telco Cloud as the only product is not the correct statement.
* Update the architecture diagram, fixing #669 
* Correct the product positioning statement. SUSE Telco Cloud, unlike SUSE Edge, is not limited to edge sites.
* Remove k3s from SUSE Telco Cloud offering 