### PR TITLE
added open-iscsi to packagelist to allow longhorn to install

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -158,6 +158,7 @@ operatingSystem:
   packages:
     packageList:
     - jq
+    - open-iscsi
     sccRegistrationCode: $SCC_REGISTRATION_CODE
 kubernetes:
   version: {version-kubernetes-rke2}


### PR DESCRIPTION
In the `40.3.2 Management cluster definition file` section, the example file `mgmt-cluster.yaml` is listing longhorn and metal3 helm charts among the others to get installed.

Previously, the `SL-Micro.x86_64-6.1-Base-SelfInstall-GM.install.iso` image file is recommended to be used.

The package `open-iscsi` is a hard requirement for longhorn and such package is not included in the `SL-Micro.x86_64-6.1-Base-SelfInstall-GM.install.iso` image, which leads to a condition where longhorn is never completing the install process also impacting metal3 install process because it is waiting for its PVC to be provisioned.

It's necessary to add `open-iscsi` to the packageList in order for setup to successfully complete.

Fixes: #472