### PR TITLE
Addressed typo flagged by the translators

### DIFF
--- a/asciidoc/day2/fleet-helm-upgrade.adoc
+++ b/asciidoc/day2/fleet-helm-upgrade.adoc
@@ -915,7 +915,7 @@ image::day2_helm_chart_upgrade_example_4_{cluster-type}.png[]
 
 . Finally check that the Longhorn Pods are running.
 
-After making the above validations, it is safe to assume that the Longhorn Helm chart has been upgraded from to the `{version-longhorn-chart}` version.
+After making the above validations, it is safe to assume that the Longhorn Helm chart has been upgraded to the `{version-longhorn-chart}` version.
 
 [#{cluster-type}-day2-fleet-helm-upgrade-procedure-eib-deployed-chart-upgrade-third-party]
 ===== Helm chart upgrade using a third-party GitOps tool


### PR DESCRIPTION
https://documentation.suse.com/suse-edge/3.3/html/edge/day2-mgmt-cluster.html

After making the above validations, it is safe to assume that the Longhorn Helm chart has been upgraded **from** to the 106.2.0+up1.8.1 version.

Removed "from".  