### PR TITLE
fixed broken link

### DIFF
--- a/asciidoc/guides/metallb-kube-api.adoc
+++ b/asciidoc/guides/metallb-kube-api.adoc
@@ -134,7 +134,7 @@ systemctl restart ${KUBE_DISTRIBUTION}
 
 == Installing MetalLB
 
-To deploy `MetalLB`, the https://suse-edge.github.io/docs/quickstart/metallb[MetalLB on K3s] guide can be used.
+To deploy `MetalLB`, the <<guides-metallb-k3s,MetalLB on K3s>> guide can be used.
 
 *NOTE:* Ensure that the IP addresses of the `ip-pool` IPAddressPool do not overlap with the IP addresses previously selected for the `LoadBalancer` service.
 


### PR DESCRIPTION
https://reports.siteimprove.com/scheduled/6339353/2025/8/94751e03-c627-41b0-ab83-ed5cb986282c/d5a968fe-07f1-4c60-97fc-efb56777d471/1 - based on this report, there was a broken link only in 3.1 version of the documentation.
