### PR TITLE
atip-management-cluster: Configure HelmChartConfig via os-files

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -100,9 +100,16 @@ eib
 ├── mgmt-cluster.yaml
 ├── network
 │ └── mgmt-cluster-node1.yaml
+├── os-files
+│ └── var
+│   └── lib
+│     └── rancher
+│       └── rke2
+│         └── server
+│           └── manifests
+│             └── rke2-ingress-config.yaml
 ├── kubernetes
 │ ├── manifests
-│ │ ├── rke2-ingress-config.yaml
 │ │ ├── neuvector-namespace.yaml
 │ │ ├── ingress-l2-adv.yaml
 │ │ └── ingress-ippool.yaml
@@ -731,7 +738,7 @@ system-default-registry: registry.rancher.com
 This is an optional file to define certain Kubernetes customization, like the CNI plug-ins to be used or many options you can check in the https://docs.rke2.io/install/configuration[official documentation].
 ====
 
-The `kubernetes/manifests` folder contains the following files:
+The `os-files/var/lib/rancher/rke2/server/manifests` folder contains the following file:
 
 - `rke2-ingress-config.yaml`: contains the configuration to create the `Ingress` service for the management cluster (no modifications needed).
 +
@@ -755,6 +762,13 @@ spec:
         type: LoadBalancer
         externalTrafficPolicy: Local
 ----
+
+[NOTE]
+====
+The `HelmChartConfig` must be included via `os-files` to the `/var/lib/rancher/rke2/server/manifests` directory, not via `kubernetes/manifests` as described in previous releases.
+====
+
+The `kubernetes/manifests` folder contains the following files:
 
 - `neuvector-namespace.yaml`: contains the configuration to create the `NeuVector` namespace (no modifications needed).
 +


### PR DESCRIPTION
This aligns with https://github.com/suse-edge/edge-image-builder/pull/764 which was the resolution for the issues discussed in https://github.com/rancher/rke2/issues/8357

Also related to #792