### PR TITLE
Adds a title to each of the port-requirements tables, clarifying these are Ingress ports

### DIFF
--- a/asciidoc/product/atip-requirements.adoc
+++ b/asciidoc/product/atip-requirements.adoc
@@ -26,9 +26,10 @@ The hardware requirements for SUSE Telco Cloud are as follows:
   ** SR-IOV: to attach VFs (Virtual Functions) in pass-through mode to CNFs/VNFs, the NIC must support SR-IOV and VT-d/AMD-Vi be enabled in the BIOS.
   ** CPU Processors: To run specific Telco workloads, the CPU Processor model should be adapted to enable most of the features available in this reference <<atip-features,table>>.
   ** Firmware requirements for installing with virtual media:
-
++
 |===
 | Server Hardware | BMC Model | Management
+
 | Dell hardware
 | 15th Generation
 | iDRAC9
@@ -78,8 +79,12 @@ The following table lists the opened ports in nodes running the management clust
 For CNI plug-in related ports, see <<cni-specific-port-requirements,CNI specific port requirements>>.
 ====
 
+
+.Inbound Network Rules for Management Nodes
+[#table-inbound-network-rules-for-management-nodes]
 |===
 | Protocol | Port | Source | Description
+
 | TCP
 | 22
 | Any source that requires SSH access
@@ -162,8 +167,11 @@ In SUSE Telco Cloud, before any (downstream) server becomes part of a running do
 
 Following ports are expected to be exposed from the BMC (they could differ depending on the exact hardware):
 
+.Inbound Network Rules for Baseboard Management Controllers
+[#table-inbound-network-rules-for-baseboard-management-controllers]
 |===
 | Protocol | Port | Source | Description
+
 | TCP
 | 80
 | Ironic conductor (from management cluster)
@@ -177,8 +185,11 @@ Following ports are expected to be exposed from the BMC (they could differ depen
 
 * Once the IPA ramdisk image loaded on the BMC `virtual media` is used to bootup the downstream server image, the hardware inspection phase begins. The following table lists the ports exposed by a running IPA ramdisk image:
 
+.Inbound Network Rules for Downstream Nodes - `Metal^3^/Ironic` Provisioning phase
+[#table-inbound-network-rules-for-downstream-nodes-provisioning-phase]
 |===
 | Protocol | Port | Source | Description
+
 | TCP
 | 22
 | Any source that requires SSH access to IPA ramdisk image
@@ -197,8 +208,11 @@ Following ports are expected to be exposed from the BMC (they could differ depen
 For CNI plug-in related ports, see <<cni-specific-port-requirements,CNI specific port requirements>>.
 ====
 
+.Inbound Network Rules for Downstream Nodes
+[#table-inbound-network-rules-for-downstream-nodes]
 |===
 | Protocol | Port | Source | Description
+
 | TCP
 | 22
 | Any source that requires SSH access
@@ -255,16 +269,18 @@ For CNI plug-in related ports, see <<cni-specific-port-requirements,CNI specific
 
 Each supported CNI variant comes with its own set of port requirements. For more details, refer https://docs.rke2.io/install/requirements#cni-specific-inbound-network-rules[CNI Specific Inbound Network Rules] in RKE2 documentation.
 
-When `cilium` is set as default/primary CNI plug-in, following TCP port is additionally exposed when the cilium-operator workload is configured to expose metrics outside the Kubernetes cluster on which it is deployed. This ensures that an external `Prometheus` server instance running outside that Kubernetes cluster can still collect these metrics.
+When `cilium` is set as default/primary CNI plug-in, following TCP port is additionally exposed when the `cilium-operator` workload is configured to expose metrics outside the Kubernetes cluster on which it is deployed. This ensures that an external `Prometheus` server instance running outside that Kubernetes cluster can still collect these metrics.
 
 [NOTE]
 ====
 This is the default option when deploying `cilium` via the rke2-cilium Helm chart.
 ====
 
-
+.Inbound Network Rules for Management/Downstream Nodes - external metrics exposure from `cilium-operator` enabled
+[#table-inbound-network-rules-for-management-downstream-nodes-external-metrics-cilium-operator]
 |===
 | Protocol | Port | Source | Description
+
 | TCP
 | 9963
 | External (to the Kubernetes cluster) metrics collector


### PR DESCRIPTION
fixes #814 

This PR adds a title to each of the tables listed in `Port requirements` section (in `asciidoc/product/atip-requirements.adoc` file) where it is clarified the listed ports are all Ingress ports.