### PR TITLE
clarifies the non usage of SRIOV Bonding with DPDK

### DIFF
--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -560,6 +560,11 @@ spec:
 ===== Bond CNI with SR-IOV
 Using the Bond CNI with SR-IOV is fairly straight forward. For more details on how to set up SR-IOV, see <<sriov>>. As described there, you have to create `SriovNetworkNodePolicies` that defines `resourceNames`, as well as number of virtual functions and such. The `resourceNames` are being used by the `SriovNetwork` which is used as interfaces in the pod definition. The bond definition is exactly the same as for the MACVLAN and host device cases.
 
+[NOTE]
+====
+Bond CNI with SR-IOV is only applicable to SRIOV Virtual Functions (VF) using the kernel driver. Userspace driver VFs - such as those used in DPDK workloads - can not be bonded with the Bond CNI.
+====
+
 [#sriov]
 === SR-IOV
 


### PR DESCRIPTION
This PR adds a NOTE in the [42.4.3.3 Bond CNI with SR-IOV](https://suse-edge.github.io/atip-features.html#id-bond-cni-with-sr-iov) section to clarify that Bonding SRIOV VFs is not applicable in case of DPDK being used for any of those SRIOV VFs (as already clarified in bond-cni upstream doc: [Integration with Multus, SRIOV CNI and SRIOV Device Plugin](https://github.com/k8snetworkplumbingwg/bond-cni?tab=readme-ov-file#integration-with-multus-sriov-cni-and-sriov-device-plugin)
`[...] Specifically the below functionality shows how to set up failover for SR-IOV interfaces in Kubernetes. This configuration is only applicable to SRIOV VFs using the kernel driver. Userspace driver VFs - such as those used in DPDK workloads - can not be bonded with the Bond CNI.`