### PR TITLE
edited image width from 100% to 85% for 2 images 

### DIFF
--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -124,11 +124,11 @@ helm install -n cattle-elemental-system \
 
 . To use the Elemental UI, log in to your Rancher instance, click the three-line menu in the upper left:
 +
-image::installing-elemental-extension-1.png[Installing Elemental extension 1,scaledwidth=100%]
+image::installing-elemental-extension-1.png[Installing Elemental extension 1,scaledwidth=85%]
 +
 . From the "Available" tab on this page, click "Install" on the Elemental card:
 +
-image::installing-elemental-extension-2.png[Installing Elemental extension 2,scaledwidth=100%]
+image::installing-elemental-extension-2.png[Installing Elemental extension 2,scaledwidth=85%]
 +
 . Confirm that you want to install the extension:
 +


### PR DESCRIPTION
Based on the feedback from translators, edited the images "scaledwidth" from 100% to 85%.

https://github.com/suse-edge/suse-edge.github.io/pull/846/files

I have not added content on Deploying arm64 downstream cluster as it has been removed from the main file. 
