### PR TITLE
Documentation updates around dual-stack support for downstream clusters

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -941,13 +941,14 @@ Where:
 - `$\{BMC_NODE1_USERNAME\}` — The username for the BMC of the first bare-metal host.
 - `$\{BMC_NODE1_PASSWORD\}` — The password for the BMC of the first bare-metal host.
 - `$\{BMC_NODE1_MAC\}` — The MAC address of the first bare-metal host to be used.
-- `$\{BMC_NODE1_ADDRESS\}` — The URL for the first bare-metal host BMC (for example, `redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/`). To learn more about the different options available depending on your hardware provider, check the following https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md[link].
+- `$\{BMC_NODE1_ADDRESS\}` — The URL for the first bare-metal host BMC (for example, `redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/`). The host part of the URL can be an IP address (v4 or v6) or a domain name, where the existing infrastructure allows. To learn more about the different options available depending on your hardware provider, check the following https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md[link].
 
 [NOTE]
 ====
 * If no network configuration for the host has been specified, either at image build time or through the `BareMetalHost` definition, an autoconfiguration mechanism (DHCP, DHCPv6, SLAAC) will be used. For more details or complex configurations, check the xref:advanced-network-configuration[].
 * Single-stack IPv6 clusters are in tech preview status and not yet officially supported.
 * Architecture must be either `x86_64` or `aarch64`, depending on the architecture of the bare-metal host to be enrolled.
+* All modern servers come with a dual-stack capable BMC, however IPv6 support (and possibly the option of using hostnames for the VirtualMedia capability) should be verified before use in production in a dual-stack environment.
 ====
 
 Once the file is created, the following command must be executed in the management cluster to start enrolling the bare-metal hosts in the management cluster:


### PR DESCRIPTION
Refresh the documentation for the Automated directed network provisioning with some minor updates for dual-stack, which should be considered the default at this point.