### PR TITLE
Added the table for clusters and methods for upgrade

### DIFF
--- a/asciidoc/day2/migration.adoc
+++ b/asciidoc/day2/migration.adoc
@@ -1,6 +1,6 @@
 [#day2-migration]
 = Edge 3.3 migration
-:revdate: 2025-05-20
+:revdate: 2025-09-24
 :page-revdate: {revdate}
 :experimental:
 
@@ -25,6 +25,23 @@ Always perform cluster migrations from the `latest Z-stream` release of `Edge {p
 
 Always migrate to the `Edge {static-edge-version}` release. For subsequent post-migration upgrades, refer to the <<day2-mgmt-cluster, management>> and <<day2-downstream-clusters, downstream>> cluster sections.
 ====
+
+The following table lists the different types of clusters and the methods to upgrade clusters:
+
+[[Clusters-and-methods-to-upgrade-downstream-clusters]]
+.Clusters and methods to upgrade downstream clusters
+|===
+| Cluster type  | Method
+
+|EIB provisioned clusters
+|See <<day2-migration-mgmt-fleet>> for details.
+
+|Metal^3^ provisioned clusters
+|See <<atip-lifecycle-downstream, Downstream cluster upgrades>> for details.
+
+|Phone-home provisioned clusters
+|See https://ranchermanager.docs.rancher.com/{rancher-docs-version}/getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes#upgrading-the-kubernetes-version[Upgrading the Kubernetes Version] for Kubernetes version upgrade and <<day2-downstream-clusters, Downstream clusters>> for SUC, Operating system, and other components.
+|===
 
 [#day2-migration-mgmt]
 == Management Cluster


### PR DESCRIPTION
https://github.com/suse-edge/suse-edge.github.io/issues/829

I have created the table as per the description provided. 

For downstream clusters, we have (at least) 3 different scenarios, and each of them involve different upgrade procedures/mechanisms. AFAIK:

For EIB provisioned clusters -> Fleet approach
For Metal3 provisioned clusters -> Redeploy with a fresh image
For phone-home provisioned clusters -> K8s upgrade via rancher + SUC for the OS and everything else
It would be nice to have a table/matrix/something to explicitly clarify each scenario.

