### PR TITLE
Remove duplicated sentence from section 41.3.2

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -385,7 +385,7 @@ The `network` section contains the configuration for the network, like the `apiH
 The `apiVIP` should be an IP address that is not used in the network and should not be part of the DHCP pool (in case we use DHCP). Also, when we use the `apiVIP` in a multi-node cluster, it is used to access the Kubernetes API server.
 The `apiHost` is the name resolution to `apiVIP` to be used by the `RKE2` component.
 
-The `nodes` section contains the list of nodes to be used in the cluster. The `nodes` section contains the list of nodes to be used in the cluster. In this example, a single-node cluster is being used, but it can be extended to a multi-node cluster by adding more nodes to the list (by uncommenting the lines).
+The `nodes` section contains the list of nodes to be used in the cluster. In this example, a single-node cluster is being used, but it can be extended to a multi-node cluster by adding more nodes to the list (by uncommenting the lines).
 
 [NOTE]
 ====


### PR DESCRIPTION
The "Management cluster definition file" contains the same sentence two times, likely due to copy-and-paste error. Remove it.