### PR TITLE
revdate of 3.4 documentation

### DIFF
--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -1,5 +1,5 @@
 = SUSE Edge Documentation
-:revdate: 2025-09-17
+:revdate: 2025-09-26
 :page-revdate: {revdate}
 :experimental:
 :docinfo:


### PR DESCRIPTION
<img width="750" height="161" alt="image" src="https://github.com/user-attachments/assets/258e6623-b79b-4382-a6f9-6c36c7ff2b95" />

I am just updating the revdate of the edge.adoc file as the publish date displays as 2025-09-17. 
