### PR TITLE
Fix SR-IOV chart path/name

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -508,8 +508,8 @@ The following scripts can be used to download, extract, and push the images to t
 [,shell,subs="attributes,specialchars"]
 ----
 $ cat > edge-release-helm-oci-artifacts.txt <<EOF
-edge/sriov-network-operator-chart:{version-sriov-network-operator-chart}
-edge/sriov-crd-chart:{version-sriov-crd-chart}
+edge/charts/sriov-network-operator:{version-sriov-network-operator-chart}
+edge/charts/sriov-crd:{version-sriov-crd-chart}
 EOF
 ----
 +
@@ -521,8 +521,8 @@ $ ./edge-save-oci-artefacts.sh -al ./edge-release-helm-oci-artifacts.txt -s regi
 Pulled: registry.suse.com/edge/charts/sriov-network-operator:{version-sriov-network-operator-chart}
 Pulled: registry.suse.com/edge/charts/sriov-crd:{version-sriov-crd-chart}
 a edge-release-oci-tgz-20240705
-a edge-release-oci-tgz-20240705/sriov-network-operator-chart-{version-sriov-network-operator-chart}.tgz
-a edge-release-oci-tgz-20240705/sriov-crd-chart-{version-sriov-crd-chart}.tgz
+a edge-release-oci-tgz-20240705/sriov-network-operator-{version-sriov-network-operator-chart}.tgz
+a edge-release-oci-tgz-20240705/sriov-crd-{version-sriov-crd-chart}.tgz
 ----
 +
 .. Upload your tarball file to your private registry (e.g. `myregistry:5000`) using the following {link-lifecycle-load-oci-artifacts}[script] to preload your registry with the helm chart OCI images downloaded in the previous step:


### PR DESCRIPTION
This was missed in previous renaming to align with the new chart path and naming convention