### PR TITLE
kiwi builder guide: Clarify profiles for aarch64

### DIFF
--- a/asciidoc/guides/kiwi-builder-images.adoc
+++ b/asciidoc/guides/kiwi-builder-images.adoc
@@ -1,6 +1,6 @@
 [#guides-kiwi-builder-images]
 = Building Updated SUSE Linux Micro Images with Kiwi
-:revdate: 2025-03-26
+:revdate: 2025-10-09
 :page-revdate: {revdate}
 :experimental:
 
@@ -26,9 +26,7 @@ This process makes use of https://osinside.github.io/kiwi/[Kiwi] to run the imag
 
 See https://documentation.suse.com/sle-micro/{version-sl-micro}/html/Micro-deployment-images/index.html#alp-images-installer-type[SUSE Linux Micro {version-sl-micro}] documentation for more details.
 
-This process works for both {x86-64} and {aarch64} architectures, although not all image profiles are available for both architectures, e.g. in SUSE Edge {version-edge-registry}, where SUSE Linux Micro {version-sl-micro} is used, a profile with a real-time kernel (i.e. "Base-RT" or "Base-RT-SelfInstall") is not currently available for {aarch64}.
-
-NOTE: It is required to use a build host with the same architecture of the images being built. In other words, to build an {aarch64} image, it is required to use an {aarch64} build host, and vice-versa for {x86-64} - cross-builds are not supported at this time.
+NOTE: This process works for both {x86-64} and {aarch64} architectures but it is necessary to use a build host with the same architecture of the images being built. In other words, to build an {aarch64} image, it is required to use an {aarch64} build host, and vice-versa for {x86-64} - cross-builds are not supported at this time.
 
 == Prerequisites
 


### PR DESCRIPTION
We did not have RT profiles for 6.0, but since moving to 6.1 this statement is no longer correct

Fixes: #875