### PR TITLE
management cluster: Add missing rancher-agent airgap image

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1162,7 +1162,8 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/rancher-webhook:v0.8.1
     - name: registry.rancher.com/rancher/rancher/turtles:v0.24.0
     - name: registry.rancher.com/rancher/rancher:v2.12.1
-    - name: registry.rancher.com/rancher/shell:v0.4.1
+    - name: registry.rancher.com/rancher/rancher-agent:v2.12.1
+    - name: registry.rancher.com/rancher/shell:v0.5.0
     - name: registry.rancher.com/rancher/system-upgrade-controller:v0.16.0
     - name: registry.suse.com/rancher/cluster-api-controller:v1.10.5
     - name: registry.suse.com/rancher/cluster-api-provider-metal3:v1.10.2


### PR DESCRIPTION
It has been reported that the rancher installation has failures when this image is not included, evidently it's not derived from the EIB inspection of the chart.