### PR TITLE
metal3 quickstart: Clarify that storage provider is optional

### DIFF
--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -77,11 +77,6 @@ TIP: The steps here can also be fully automated as described in the <<atip-manag
 
 If not already installed as part of the Rancher installation, cert-manager must be installed and running.
 
-A persistent storage provider must be installed. SUSE Storage is recommended but `local-path-provisioner` can also be used for
-dev/PoC environments. The instructions below assume a StorageClass has been
-https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/[marked as default],
-otherwise additional configuration for the Metal^3^ chart is required.
-
 An additional IP is required, which is managed by https://metallb.universe.tf/[MetalLB] to provide a
 consistent endpoint for the Metal^3^ management services.
 This IP must be part of the control plane subnet and reserved for static configuration (not part of any DHCP pool).


### PR DESCRIPTION
This was missed in #610 - the storage provider is now optional so we can remove this statement

Fixes: #837