### PR TITLE
[release-3.4] workflows: enable running on release-3.* PRs

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-3.*"
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 


### PR DESCRIPTION
Backport #911 

Currently issues like that mentioned in #908 won't be caught because we're not testing stable branch PRs

(cherry picked from commit 7229178b18868260686a7526e1c38f5fb80f1b35)