### PR TITLE
Update virtualization.adoc

### DIFF
--- a/asciidoc/components/virtualization.adoc
+++ b/asciidoc/components/virtualization.adoc
@@ -453,7 +453,7 @@ spec:
         resources: {}
       volumes:
       - containerDisk:
-          image: registry.opensuse.org/home/roxenham/tumbleweed-container-disk/containerfile/cloud-image:latest
+          image: quay.io/containerdisks/opensuse-tumbleweed:1.0.0
         name: tumbleweed-containerdisk-0
       - cloudInitNoCloud:
           userDataBase64: I2Nsb3VkLWNvbmZpZwpkaXNhYmxlX3Jvb3Q6IGZhbHNlCnNzaF9wd2F1dGg6IFRydWUKdXNlcnM6CiAgLSBkZWZhdWx0CiAgLSBuYW1lOiBzdXNlCiAgICBncm91cHM6IHN1ZG8KICAgIHNoZWxsOiAvYmluL2Jhc2gKICAgIHN1ZG86ICBBTEw9KEFMTCkgTk9QQVNTV0Q6QUxMCiAgICBsb2NrX3Bhc3N3ZDogRmFsc2UKICAgIHBsYWluX3RleHRfcGFzc3dkOiAnc3VzZScKcnVuY21kOgogIC0genlwcGVyIGluIC15IG5naW54CiAgLSBzeXN0ZW1jdGwgZW5hYmxlIC0tbm93IG5naW54CiAgLSBlY2hvICJJdCB3b3JrcyEiID4gL3Nydi93d3cvaHRkb2NzL2luZGV4Lmh0bQo=


### PR DESCRIPTION
Replace old image for virtual machine object to registry.opensuse.org/home/roxenham/tumbleweed-container-disk/containerfile/cloud-image:latest with quay.io/containerdisks/opensuse-tumbleweed:1.0.0