### PR TITLE
fix: Proper frr-k8s version

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -178,7 +178,7 @@ registry.suse.com/edge/mariadb:10.6.15.1
 registry.suse.com/edge/3.4/metallb-controller:v0.14.8 +
 registry.suse.com/edge/3.4/metallb-speaker:v0.14.8 +
 registry.suse.com/edge/3.4/frr:8.4 +
-registry.suse.com/edge/3.4/frr-k8s:v0.0.14
+registry.suse.com/edge/3.4/frr-k8s:v0.0.16
 | Elemental | 1.7.3 | 1.7.3 | registry.suse.com/rancher/elemental-operator-chart:1.7.3 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.7.3 +
 registry.suse.com/rancher/elemental-operator:1.7.3


### PR DESCRIPTION
```
❯ crane ls -O registry.suse.com/edge/3.4/frr-k8s
v0.0.16
v0.0.16-1.1
v0.0.16-1.7
```