### PR TITLE
fix: frr-k8s versions for 3.3

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -141,7 +141,7 @@ registry.suse.com/edge/mariadb:10.6.15.1
 registry.suse.com/edge/3.3/metallb-controller:v0.14.8 +
 registry.suse.com/edge/3.3/metallb-speaker:v0.14.8 +
 registry.suse.com/edge/3.3/frr:8.4 +
-registry.suse.com/edge/3.3/frr-k8s:v0.0.14
+registry.suse.com/edge/3.3/frr-k8s:v0.0.16
 | Elemental | 1.6.8 | 1.6.8 | registry.suse.com/rancher/elemental-operator-chart:1.6.8 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.6.8 +
 registry.suse.com/rancher/elemental-operator:1.6.8
@@ -299,7 +299,7 @@ registry.suse.com/edge/mariadb:10.6.15.1
 registry.suse.com/edge/3.3/metallb-controller:v0.14.8 +
 registry.suse.com/edge/3.3/metallb-speaker:v0.14.8 +
 registry.suse.com/edge/3.3/frr:8.4 +
-registry.suse.com/edge/3.3/frr-k8s:v0.0.14
+registry.suse.com/edge/3.3/frr-k8s:v0.0.16
 | Elemental | 1.6.8 | 1.6.8 | registry.suse.com/rancher/elemental-operator-chart:1.6.8 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.6.8 +
 registry.suse.com/rancher/elemental-operator:1.6.8
@@ -459,7 +459,7 @@ registry.suse.com/edge/mariadb:10.6.15.1
 registry.suse.com/edge/3.3/metallb-controller:v0.14.8 +
 registry.suse.com/edge/3.3/metallb-speaker:v0.14.8 +
 registry.suse.com/edge/3.3/frr:8.4 +
-registry.suse.com/edge/3.3/frr-k8s:v0.0.14
+registry.suse.com/edge/3.3/frr-k8s:v0.0.16
 | Elemental | 1.6.8 | 1.6.8 | registry.suse.com/rancher/elemental-operator-chart:1.6.8 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.6.8 +
 registry.suse.com/rancher/elemental-operator:1.6.8
@@ -631,7 +631,7 @@ registry.suse.com/edge/mariadb:10.6.15.1
 registry.suse.com/edge/3.3/metallb-controller:v0.14.8 +
 registry.suse.com/edge/3.3/metallb-speaker:v0.14.8 +
 registry.suse.com/edge/3.3/frr:8.4 +
-registry.suse.com/edge/3.3/frr-k8s:v0.0.14
+registry.suse.com/edge/3.3/frr-k8s:v0.0.16
 | Elemental | 1.6.8 | 1.6.8 | registry.suse.com/rancher/elemental-operator-chart:1.6.8 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.6.8 +
 registry.suse.com/rancher/elemental-operator:1.6.8


### PR DESCRIPTION
```
❯ crane ls -O registry.suse.com/edge/3.3/frr-k8s
v0.0.16
v0.0.16-1.11
v0.0.16-1.2
v0.0.16-1.39
v0.0.16-1.50
```