### PR TITLE
[release-3.4] Fix metallb image versions

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -168,10 +168,11 @@ registry.suse.com/edge/3.4/ironic:29.0.4.3 +
 registry.suse.com/edge/3.4/ironic-ipa-downloader:3.0.9 +
 registry.suse.com/edge/mariadb:10.6.15.1
 | MetalLB | 0.14.9 | 304.0.0+up0.14.9 | registry.suse.com/edge/charts/metallb:304.0.0_up0.14.9 +
-registry.suse.com/edge/3.4/metallb-controller:v0.14.8 +
-registry.suse.com/edge/3.4/metallb-speaker:v0.14.8 +
-registry.suse.com/edge/3.4/frr:8.4 +
-registry.suse.com/edge/3.4/frr-k8s:v0.0.14
+registry.suse.com/edge/3.4/metallb-controller:v0.14.9 +
+registry.suse.com/edge/3.4/metallb-speaker:v0.14.9 +
+registry.suse.com/edge/3.4/frr:8.5.6 +
+registry.suse.com/edge/3.4/frr-k8s:v0.0.16 +
+registry.suse.com/edge/3.4/kube-rbac-proxy:0.18.1
 | Elemental | 1.7.3 | 1.7.3 | registry.suse.com/rancher/elemental-operator-chart:1.7.3 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.7.3 +
 registry.suse.com/rancher/elemental-operator:1.7.3
@@ -353,10 +354,11 @@ registry.suse.com/edge/3.4/ironic:29.0.4.3 +
 registry.suse.com/edge/3.4/ironic-ipa-downloader:3.0.9 +
 registry.suse.com/edge/mariadb:10.6.15.1
 | MetalLB | 0.14.9 | 304.0.0+up0.14.9 | registry.suse.com/edge/charts/metallb:304.0.0_up0.14.9 +
-registry.suse.com/edge/3.4/metallb-controller:v0.14.8 +
-registry.suse.com/edge/3.4/metallb-speaker:v0.14.8 +
-registry.suse.com/edge/3.4/frr:8.4 +
-registry.suse.com/edge/3.4/frr-k8s:v0.0.14
+registry.suse.com/edge/3.4/metallb-controller:v0.14.9 +
+registry.suse.com/edge/3.4/metallb-speaker:v0.14.9 +
+registry.suse.com/edge/3.4/frr:8.5.6 +
+registry.suse.com/edge/3.4/frr-k8s:v0.0.16 +
+registry.suse.com/edge/3.4/kube-rbac-proxy:0.18.1
 | Elemental | 1.7.3 | 1.7.3 | registry.suse.com/rancher/elemental-operator-chart:1.7.3 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.7.3 +
 registry.suse.com/rancher/elemental-operator:1.7.3


### PR DESCRIPTION
These versions are outdated and don't match the 3.4 chart:

 ```
% helm template oci://registry.suse.com/edge/charts/metallb --version 304.0.0+up0.14.9 --set frrk8s.enabled=true 2>&1 | grep image: | sed "s/^ *//" | sort | uniq
image: registry.suse.com/edge/3.4/frr-k8s:v0.0.16
image: registry.suse.com/edge/3.4/frr:8.5.6
image: registry.suse.com/edge/3.4/kube-rbac-proxy:0.18.1
image: registry.suse.com/edge/3.4/metallb-controller:v0.14.9
image: registry.suse.com/edge/3.4/metallb-speaker:v0.14.9
```