### PR TITLE
[release-3.3] Fix metallb image versions (#941)

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -458,7 +458,7 @@ registry.suse.com/edge/3.3/ironic:26.1.2.4 +
 *registry.suse.com/edge/3.3/ironic-ipa-downloader:3.0.7* +
 registry.suse.com/edge/mariadb:10.6.15.1
 | MetalLB | 0.14.9 | 303.0.0+up0.14.9 | registry.suse.com/edge/charts/metallb:303.0.0_up0.14.9 +
-registry.suse.com/edge/3.3/etallb-controller:v0.14.9 +
+registry.suse.com/edge/3.3/metallb-controller:v0.14.9 +
 registry.suse.com/edge/3.3/metallb-speaker:v0.14.9 +
 registry.suse.com/edge/3.3/frr:8.5.6 +
 registry.suse.com/edge/3.3/frr-k8s:v0.0.16 +


### PR DESCRIPTION
Backport of #941 - manually created due to different releases for 3.3

These versions are outdated and don't match the 3.3 chart:

```
 % helm template oci://registry.suse.com/edge/charts/metallb --version 303.0.0+up0.14.9 --set frrk8s.enabled=true 2>&1 | grep image: | sed "s/^ *//" | sort | uniq
image: registry.suse.com/edge/3.3/frr-k8s:v0.0.16
image: registry.suse.com/edge/3.3/frr:8.5.6
image: registry.suse.com/edge/3.3/kube-rbac-proxy:0.18.1
image: registry.suse.com/edge/3.3/metallb-controller:v0.14.9
image: registry.suse.com/edge/3.3/metallb-speaker:v0.14.9
```