### PR TITLE
[release-3.4] atip-features: fix templating and hard-coded version

### DIFF
--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1626,9 +1626,9 @@ The easiest and best way to integrate PTP in your downstream cluster is to add t
 
 Below find a sample EIB manifest with `linuxptp`:
 
-[,yaml]
+[,yaml,subs="attributes"]
 ----
-apiVersion: 1.0
+apiVersion: {version-eib-api-latest}
 image:
   imageType: RAW
   arch: x86_64
@@ -1652,7 +1652,7 @@ operatingSystem:
       - phc2sys
   users:
     - username: root
-      encryptedPassword: ${ROOT_PASSWORD}
+      encryptedPassword: $ROOT_PASSWORD
   packages:
     packageList:
       - jq
@@ -1664,7 +1664,7 @@ operatingSystem:
       - tuned
       - cpupower
       - linuxptp
-    sccRegistrationCode: ${SCC_REGISTRATION_CODE}
+    sccRegistrationCode: $SCC_REGISTRATION_CODE
 ----
 
 [NOTE]


### PR DESCRIPTION
Backport #935

The EIB apiVersion should be set via a variable, and we're missing the attributes configuration so the micro-base-rt-image-raw is not correctly substituted.

Fixes: #924
(cherry picked from commit 462415b516fbd0aa37c3134de2afb53145483594)