### PR TITLE
Cherry-pick-3.4-620-Adding control-plane nodes" - Requires tls-sans to be set for LB

### DIFF
--- a/asciidoc/guides/metallb-kube-api.adoc
+++ b/asciidoc/guides/metallb-kube-api.adoc
@@ -292,7 +292,7 @@ For RKE2:
 # As a root user, create the /etc/rancher/rke2/config.yaml config file with the following content:
 
 mkdir -p /etc/rancher/rke2/
-cat << EOF > /etc/rancher/rke2/config.yaml
+cat <<EOF > /etc/rancher/rke2/config.yaml
 # An example of the config.yaml file for an agent node: 
 server: https://${VIP_SERVICE_IP}:9345
 write-kubeconfig-mode: "0644"


### PR DESCRIPTION
Closes #620 

Edited content based on the information in the issue (#947)