### PR TITLE
Cherry-pick-3.1-896 - [doc] "Standalone clusters with Edge Image Builder" doesn't explain the os-files feature 

### DIFF
--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -189,6 +189,28 @@ Certificate files with the extension ".pem" or ".crt" stored in the `certificate
 
 See the https://documentation.suse.com/smart/security/html/tls-certificates/index.html#tls-adding-new-certificates["Securing Communication with TLS Certificate" guide] for more information.
 
+[#adding-operating-system-files]
+=== Adding Operating System Files
+
+The files placed in the `os-files` directory in the image configuration directory are automatically copied into the filesystem of the built image. 
+The exact directory directory will be retained when they are copied. 
+For example, if a file exists in a subdirectory named `os-files/etc`, it is placed in the `/etc` directory of the built image. 
+
+[NOTE]
+====
+If the `os-files` directory exists, it cannot be empty. 
+====
+
+[,console]
+----
+.
+├── definition.yaml
+└── os-files
+    └── etc
+        └── ssh
+            └── sshd_config
+----
+
 [#eib-configuring-rpm-packages]
 === Configuring RPM packages
 


### PR DESCRIPTION
Closes https://github.com/suse-edge/suse-edge.github.io/issues/896

Added content on Operating System Files (https://github.com/suse-edge/suse-edge.github.io/pull/909)

@hardys 2 new sections have been added. Please review.