### PR TITLE
Update for SL Micro 6.2

### DIFF
--- a/asciidoc/components/linux-micro.adoc
+++ b/asciidoc/components/linux-micro.adoc
@@ -38,6 +38,9 @@ SUSE Edge uses the <<components-eib,Edge Image Builder>> to preconfigure the SUS
 SUSE Linux Micro comes with Cockpit to allow the local management of the host through a Web application.
 
 This service is disabled by default but can be started by enabling the systemd service `cockpit.socket`.
+As cockpit forbids root login by default, the creation of a user with administrative privileges is recommended, refer to the {link-micro-official-docs}[SUSE Linux Micro official documentation] for more information.
+
+
 
 == Known issues
 

--- a/asciidoc/components/longhorn.adoc
+++ b/asciidoc/components/longhorn.adoc
@@ -20,7 +20,7 @@ SUSE Storage is a lightweight, reliable, and user-friendly distributed block sto
 
 If you are following this guide, it assumes that you have the following already available:
 
-* At least one host with SUSE Linux Micro {version-sl-micro} installed; this can be physical or virtual
+* At least one host with SUSE Linux Micro {version-operatingsystem} installed; this can be physical or virtual
 * A Kubernetes cluster installed; either K3s or RKE2
 * Helm
 

--- a/asciidoc/edge-book/version-matrix.adoc
+++ b/asciidoc/edge-book/version-matrix.adoc
@@ -18,7 +18,7 @@ endif::[]
 [options="header"]
 |======
 | Name | Version | Chart Version
-| SUSE Linux Micro | {version-sl-micro} | N/A
+| SUSE Linux Micro | {version-operatingsystem} | N/A
 | Rancher Prime | {version-rancher-prime} | {version-rancher-prime}
 | Fleet | {version-fleet} | {version-fleet-chart}
 | K3s | {version-kubernetes-k3s} | N/A

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -13,14 +13,6 @@
 :version-edge: 3.4
 :version-edge-registry: 3.4
 
-// == SUSE Linux Micro ==
-:micro-base-image-raw: SL-Micro.x86_64-6.1-Base-GM.raw
-:micro-base-rt-image-raw: SL-Micro.x86_64-6.1-Base-RT-GM.raw
-:micro-base-rt-image-iso: SL-Micro.x86_64-6.1-Base-RT-SelfInstall-GM.install.iso
-:micro-base-image-iso: SL-Micro.x86_64-6.1-Base-SelfInstall-GM.install.iso
-:micro-default-image-iso: SL-Micro.x86_64-6.1-Default-SelfInstall-GM.install.iso
-:version-sl-micro: 6.1
-
 // == Multi-Linux Manager ==
 :version-mlm: 5.0.5
 
@@ -75,7 +67,7 @@
 :version-kubernetes-k3s: v1.33.3+k3s1
 :version-kubernetes-rke2: v1.33.3+rke2r1
 
-:version-operatingsystem: 6.1
+:version-operatingsystem: 6.2
 
 :version-akri-chart: 304.0.0+up0.12.20
 :version-akri-dashboard-extension-chart: 304.0.2+up1.3.1
@@ -104,6 +96,22 @@
 // edu, Oct 9, 2025 :: Used to link the CRDs on the docs site like
 // https://doc.crds.dev/github.com/metal3-io/cluster-api-provider-metal3/infrastructure.cluster.x-k8s.io/Metal3MachineTemplate/v1beta1@v1.11.0#spec-template-spec-hostSelector-matchLabels
 :version-capi-provider-metal3: v1beta1@v1.10.2
+
+// ============================================================================
+// Derived Version Entries
+//
+// The following are derived from previously defined versions, ensure they
+// are not using elements defined below them
+//
+// ============================================================================
+
+// == SUSE Linux Micro ==
+:micro-base-image-raw: SL-Micro.x86_64-{version-operatingsystem}-Base-GM.raw
+:micro-base-rt-image-raw: SL-Micro.x86_64-{version-operatingsystem}-Base-RT-GM.raw
+:micro-base-rt-image-iso: SL-Micro.x86_64-{version-operatingsystem}-Base-RT-SelfInstall-GM.install.iso
+:micro-base-image-iso: SL-Micro.x86_64-{version-operatingsystem}-Base-SelfInstall-GM.install.iso
+:micro-default-image-iso: SL-Micro.x86_64-{version-operatingsystem}-Default-SelfInstall-GM.install.iso
+
 
 // ============================================================================
 // Manual Version Entries

--- a/asciidoc/guides/kiwi-builder-images.adoc
+++ b/asciidoc/guides/kiwi-builder-images.adoc
@@ -24,7 +24,7 @@ This process makes use of https://osinside.github.io/kiwi/[Kiwi] to run the imag
 * "*Default*" - A SUSE Linux Micro disk image based on the "Base" above but with a few more tools, including the virtualization stack, Cockpit and salt-minion.
 * "*Default-SelfInstall*" - A SelfInstall image based on the "Default" above
 
-See https://documentation.suse.com/sle-micro/{version-sl-micro}/html/Micro-deployment-images/index.html#alp-images-installer-type[SUSE Linux Micro {version-sl-micro}] documentation for more details.
+See https://documentation.suse.com/sle-micro/{version-operatingsystem}/html/Micro-deployment-images/index.html#alp-images-installer-type[SUSE Linux Micro {version-operatingsystem}] documentation for more details.
 
 NOTE: This process works for both {x86-64} and {aarch64} architectures but it is necessary to use a build host with the same architecture of the images being built. In other words, to build an {aarch64} image, it is required to use an {aarch64} build host, and vice-versa for {x86-64} - cross-builds are not supported at this time.
 
@@ -32,7 +32,7 @@ NOTE: This process works for both {x86-64} and {aarch64} architectures but it is
 
 Kiwi image builder requires the following:
 
-* A SUSE Linux Micro {version-sl-micro} host ("build system") with the same architecture of the image being built.
+* A SUSE Linux Micro {version-operatingsystem} host ("build system") with the same architecture of the image being built.
 * The build system needs to be already registered via `SUSEConnect` (the registration is used to pull the latest packages from the SUSE repositories)
 * An internet connection that can be used to pull the required packages. If connected via proxy, the build host needs to be pre-configured.
 * SELinux needs to be disabled on the build host (as SELinux labelling takes place in the container and it can conflict with the host policy)
@@ -40,7 +40,7 @@ Kiwi image builder requires the following:
 
 == Getting Started
 
-Due to certain limitations, it is currently required to disable SELinux. Connect to the SUSE Linux Micro {version-sl-micro} image build host and ensure SELinux is disabled:
+Due to certain limitations, it is currently required to disable SELinux. Connect to the SUSE Linux Micro {version-operatingsystem} image build host and ensure SELinux is disabled:
 
 [,console]
 ----
@@ -88,10 +88,10 @@ After a few minutes the images can be found in the local output directory:
 INFO: Image build successful, generated images are available in the 'output' directory.
 
 # ls -1 output/
-SLE-Micro.x86_64-{version-sl-micro}.changes
-SLE-Micro.x86_64-{version-sl-micro}.packages
-SLE-Micro.x86_64-{version-sl-micro}.raw
-SLE-Micro.x86_64-{version-sl-micro}.verified
+SLE-Micro.x86_64-{version-operatingsystem}.changes
+SLE-Micro.x86_64-{version-operatingsystem}.packages
+SLE-Micro.x86_64-{version-operatingsystem}.raw
+SLE-Micro.x86_64-{version-operatingsystem}.verified
 build
 kiwi.result
 kiwi.result.json

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -123,7 +123,6 @@ image:
 operatingSystem:
   kernelArgs:
     - ignition.platform.id=openstack
-    - net.ifnames=1
   systemd:
     disable:
       - rebootmgr
@@ -152,11 +151,7 @@ For the production environments, it is recommended to use the SSH keys that can 
 ====
 `arch: x86_64` is the architecture of the image. For arm64 architecture, use `arch: aarch64`.
 
-`net.ifnames=1` enables https://documentation.suse.com/smart/network/html/network-interface-predictable-naming/index.html[Predictable Network Interface Naming]
-
-This matches the default configuration for the metal3 chart, but the setting must match the configured chart `predictableNicNames` value.
-
-Also note `ignition.platform.id=openstack` is mandatory, without this argument SLEMicro configuration via ignition will fail in the Metal^3^ automated flow.
+Note `ignition.platform.id=openstack` is mandatory, without this argument SLEMicro configuration via ignition will fail in the Metal^3^ automated flow.
 ====
 
 [#add-custom-script-growfs]
@@ -240,7 +235,6 @@ image:
 operatingSystem:
   kernelArgs:
     - ignition.platform.id=openstack
-    - net.ifnames=1
   systemd:
     disable:
       - rebootmgr

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -123,14 +123,14 @@ This provides an example of kernel arguments for a 32-core Intel server, includi
 [,shell]
 ----
 $ cat /proc/cmdline
-BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=77b713de-5cc7-4d4c-8fc6-f5eca0a43cf9 skew_tick=1 rd.timeout=60 rd.retry=45 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack intel_iommu=on iommu=pt irqaffinity=0,31,32,63 isolcpus=domain,nohz,managed_irq,1-30,33-62 nohz_full=1-30,33-62 nohz=on mce=off net.ifnames=0 nosoftlockup nowatchdog nmi_watchdog=0 quiet rcu_nocb_poll rcu_nocbs=1-30,33-62 rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll
+BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=77b713de-5cc7-4d4c-8fc6-f5eca0a43cf9 skew_tick=1 rd.timeout=60 rd.retry=45 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack intel_iommu=on iommu=pt irqaffinity=0,31,32,63 isolcpus=domain,nohz,managed_irq,1-30,33-62 nohz_full=1-30,33-62 nohz=on mce=off nosoftlockup nowatchdog nmi_watchdog=0 quiet rcu_nocb_poll rcu_nocbs=1-30,33-62 rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll
 ----
 
 Here is another configuration example for a 64-core AMD server. Among the 128 logical processors (`0-127`), first 8 cores (`0-7`) are designated for housekeeping, while the remaining 120 cores (`8-127`) are pinned for the applications:
 [,shell]
 ----
 $ cat /proc/cmdline
-BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=575291cf-74e8-42cf-8f2c-408a20dc00b8 skew_tick=1 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack amd_iommu=on iommu=pt irqaffinity=0-7 isolcpus=domain,nohz,managed_irq,8-127 nohz_full=8-127 rcu_nocbs=8-127 mce=off nohz=on net.ifnames=0 nowatchdog nmi_watchdog=0 nosoftlockup quiet rcu_nocb_poll rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll
+BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=575291cf-74e8-42cf-8f2c-408a20dc00b8 skew_tick=1 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack amd_iommu=on iommu=pt irqaffinity=0-7 isolcpus=domain,nohz,managed_irq,8-127 nohz_full=8-127 rcu_nocbs=8-127 mce=off nohz=on nowatchdog nmi_watchdog=0 nosoftlockup quiet rcu_nocb_poll rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll
 ----
 
 [#cpu-pinning-host]
@@ -209,7 +209,7 @@ Edit the `/etc/default/grub` file with above parameters and the file will look l
 
 [,shell]
 ----
-GRUB_CMDLINE_LINUX="BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=77b713de-5cc7-4d4c-8fc6-f5eca0a43cf9 skew_tick=1 rd.timeout=60 rd.retry=45 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack intel_iommu=on iommu=pt irqaffinity=0,31,32,63 isolcpus=domain,nohz,managed_irq,1-30,33-62 nohz_full=1-30,33-62 nohz=on mce=off net.ifnames=0 nosoftlockup nowatchdog nmi_watchdog=0 quiet rcu_nocb_poll rcu_nocbs=1-30,33-62 rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll"
+GRUB_CMDLINE_LINUX="BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=77b713de-5cc7-4d4c-8fc6-f5eca0a43cf9 skew_tick=1 rd.timeout=60 rd.retry=45 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack intel_iommu=on iommu=pt irqaffinity=0,31,32,63 isolcpus=domain,nohz,managed_irq,1-30,33-62 nohz_full=1-30,33-62 nohz=on mce=off nosoftlockup nowatchdog nmi_watchdog=0 quiet rcu_nocb_poll rcu_nocbs=1-30,33-62 rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll"
 ----
 
 Update the GRUB configuration:
@@ -1206,7 +1206,7 @@ To enable the parameters, add them to the `/etc/default/grub` file:
 
 [,shell]
 ----
-GRUB_CMDLINE_LINUX="BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=77b713de-5cc7-4d4c-8fc6-f5eca0a43cf9 skew_tick=1 rd.timeout=60 rd.retry=45 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack intel_iommu=on iommu=pt irqaffinity=0,31,32,63 isolcpus=domain,nohz,managed_irq,1-30,33-62 nohz_full=1-30,33-62 nohz=on mce=off net.ifnames=0 nosoftlockup nowatchdog nmi_watchdog=0 quiet rcu_nocb_poll rcu_nocbs=1-30,33-62 rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll"
+GRUB_CMDLINE_LINUX="BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=77b713de-5cc7-4d4c-8fc6-f5eca0a43cf9 skew_tick=1 rd.timeout=60 rd.retry=45 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack intel_iommu=on iommu=pt irqaffinity=0,31,32,63 isolcpus=domain,nohz,managed_irq,1-30,33-62 nohz_full=1-30,33-62 nohz=on mce=off nosoftlockup nowatchdog nmi_watchdog=0 quiet rcu_nocb_poll rcu_nocbs=1-30,33-62 rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll"
 ----
 
 Update the GRUB configuration and reboot the system to apply the changes:
@@ -1300,7 +1300,7 @@ Modify the GRUB file `/etc/default/grub` to add them to the kernel command line:
 
 [,shell]
 ----
-GRUB_CMDLINE_LINUX="BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=77b713de-5cc7-4d4c-8fc6-f5eca0a43cf9 skew_tick=1 rd.timeout=60 rd.retry=45 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack intel_iommu=on iommu=pt irqaffinity=0,31,32,63 isolcpus=domain,nohz,managed_irq,1-30,33-62 nohz_full=1-30,33-62 nohz=on mce=off net.ifnames=0 nosoftlockup nowatchdog nmi_watchdog=0 quiet rcu_nocb_poll rcu_nocbs=1-30,33-62 rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll"
+GRUB_CMDLINE_LINUX="BOOT_IMAGE=/boot/vmlinuz-6.4.0-9-rt root=UUID=77b713de-5cc7-4d4c-8fc6-f5eca0a43cf9 skew_tick=1 rd.timeout=60 rd.retry=45 console=ttyS1,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=40 hugepagesz=2M hugepages=0 ignition.platform.id=openstack intel_iommu=on iommu=pt irqaffinity=0,31,32,63 isolcpus=domain,nohz,managed_irq,1-30,33-62 nohz_full=1-30,33-62 nohz=on mce=off nosoftlockup nowatchdog nmi_watchdog=0 quiet rcu_nocb_poll rcu_nocbs=1-30,33-62 rcupdate.rcu_cpu_stall_suppress=1 rcupdate.rcu_expedited=1 rcupdate.rcu_normal_after_boot=1 rcupdate.rcu_task_stall_timeout=0 rcutree.kthread_prio=99 security=selinux selinux=1 idle=poll"
 ----
 
 Update the GRUB configuration and reboot the system to apply the changes:
@@ -1711,7 +1711,6 @@ operatingSystem:
     timezone: America/New_York
   kernelArgs:
     - ignition.platform.id=openstack
-    - net.ifnames=1
   systemd:
     disable:
       - rebootmgr

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -24,14 +24,14 @@ For more information, read the <<components-eib,Edge Image Builder Introduction>
 
 [WARNING]
 ====
-Edge Image Builder {version-eib} supports customizing SUSE Linux Micro {version-sl-micro} images.
+Edge Image Builder {version-eib} supports customizing SUSE Linux Micro {version-operatingsystem} images.
 Older versions, such as SUSE Linux Enterprise Micro 5.5, or 6.0 are not supported.
 ====
 
 == Prerequisites
 * An {x86-64} build host machine (physical or virtual) running SLES 15 SP6.
 * The Podman container engine
-* A SUSE Linux Micro {version-sl-micro} SelfInstall ISO image created using the <<guides-kiwi-builder-images,Kiwi Builder procedure>>
+* A SUSE Linux Micro {version-operatingsystem} SelfInstall ISO image created using the <<guides-kiwi-builder-images,Kiwi Builder procedure>>
 
 [NOTE]
 ====

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -231,7 +231,6 @@ operatingSystem:
         - 10.0.0.2
   kernelArgs:
     - ignition.platform.id=openstack
-    - net.ifnames=1
   systemd:
     disable:
       - rebootmgr
@@ -256,11 +255,7 @@ For the production environments, it is recommended to use the SSH keys that can 
 
 [NOTE]
 ====
-`net.ifnames=1` enables https://documentation.suse.com/smart/network/html/network-interface-predictable-naming/index.html[Predictable Network Interface Naming]
-
-This matches the default configuration for the Metal^3^ chart, but the setting must match the configured chart `predictableNicNames` value.
-
-Also note that `ignition.platform.id=openstack` is mandatory - without this argument SUSE Linux Micro configuration via ignition will fail in the Metal^3^ automated flow.
+Note that `ignition.platform.id=openstack` is mandatory - without this argument SUSE Linux Micro configuration via ignition will fail in the Metal^3^ automated flow.
 
 The `time` section is optional but it is highly recommended to be configured to avoid potential issues with certificates and clock skew. The values provided in this example are for illustrative purposes only. Please adjust them to fit your specific requirements.
 ====

--- a/asciidoc/quickstart/suse-multilinux-manager.adoc
+++ b/asciidoc/quickstart/suse-multilinux-manager.adoc
@@ -110,8 +110,8 @@ On the `Organization Credentials` tab create a new credential with your `Usernam
 
 Go to the next tab `SUSE Products`. You need to wait until the first data synchronization with SUSE Customer Center has finished.
 
-Once the list is populated, you use the filter to only show "Micro {version-sl-micro}".
-Check the box for SUSE Linux Micro {version-sl-micro} for the hardware architecture your edge nodes will run on (`x86_64` or `aarch64`).
+Once the list is populated, you use the filter to only show "Micro {version-operatingsystem}".
+Check the box for SUSE Linux Micro {version-operatingsystem} for the hardware architecture your edge nodes will run on (`x86_64` or `aarch64`).
 
 Click `Add Products`. This will add the main package repository ("channel") for SUSE Linux Micro and automatically add the channel for the SUSE Manager client tools as a sub-channel.
 
@@ -135,7 +135,7 @@ A number prefix is automatically added to the key. For the default organization,
 
 If you haven't created any cloned software channels, you can keep the setting for the Base Channel to "SUSE Manager Default". This will automatically assign the correct SUSE update repository for your edge nodes.
 
-As "Child Channel", select the "include recommended" slider for the hardware architecture your activation key is used for. This will add the "SUSE-Manager-Tools-For-SL-Micro-{version-sl-micro}" channel.
+As "Child Channel", select the "include recommended" slider for the hardware architecture your activation key is used for. This will add the "SUSE-Manager-Tools-For-SL-Micro-{version-operatingsystem}" channel.
 
 On the "Groups" tab, add the group you've created before. All nodes that are onboarded using this activation key will automatically be added to that group.
 
@@ -171,7 +171,7 @@ Building {aarch64} images on an Arm-based build host is a technology preview in 
 
 In `/opt/eib`, create a file called `iso-definition.yaml`. This is your build definition for Edge Image Builder.
 
-Here is a simple example that installs SL Micro {version-sl-micro}, sets a root password and the keymap, starts the Cockpit graphical UI and registers your node to SUSE Multi-Linux Manager:
+Here is a simple example that installs SL Micro {version-operatingsystem}, sets a root password, an additional user and the keymap, starts the Cockpit graphical UI and registers your node to SUSE Multi-Linux Manager:
 
 [,yaml]
 ----
@@ -186,6 +186,9 @@ operatingSystem:
   - username: root
     createHomeDir: true
     encryptedPassword: $6$aaBTHyqDRUMY1HAp$pmBY7.qLtoVlCGj32XR/Ogei4cngc3f4OX7fwBD/gw7HWyuNBOKYbBWnJ4pvrYwH2WUtJLKMbinVtBhMDHQIY0
+  - username: admin
+    createHomeDir: true
+    encryptedPassword: $6$8EGZXU1iFcLiHHxk$Hs3nVtzO.yZhApT.YBHaNvLRZvXG3Iv/km92BtiNiGXhSSUG0ZbNHxlm7c//ROFj3W9M5xIkB.RLQpPKOFxP91
   keymap: de
   systemd:
     enable:
@@ -202,6 +205,8 @@ Edge Image Builder can also configure the network, automatically install Kuberne
 For `baseImage`, specify the actual name of the ISO in the `base-images` directory that you want to use.
 
 In this example, the root password would be "root". See <<id-configuring-os-users>> for creating password hashes for the secure password you want to use.
+
+As Cockpit forbids connection as root user, an additional user is needed. In this example that user is "admin" with password "admin".
 
 Set the keymap to the actual keyboard layout you want the system to have after installation.
 

--- a/asciidoc/troubleshooting/troubleshooting-edge-networking.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-edge-networking.adoc
@@ -20,7 +20,7 @@ NMC is injected on SL Micro EIB images to configure the network of the Edge host
 * *Host not being able to boot properly the first time*: Malformed network definition files can lead to the combustion phase to fail and then the host drops a root shell.
 * *Files are not properly generated*: Ensure the network files matches https://nmstate.io/examples.html[NMState] format.
 * *Network interfaces are not correctly configured*: Ensure the MAC addresses match the interfaces being used on the host.
-* *Mismatch between interface names*: The `net.ifnames=1` kernel argument enables https://documentation.suse.com/smart/network/html/network-interface-predictable-naming/index.html[Predictable Naming Scheme for Network Interfaces] so there is no `eth0` anymore but other naming schema such as `enp2s0`.
+* *Mismatch between interface names*: SL Micro enables https://documentation.suse.com/smart/network/html/network-interface-predictable-naming/index.html[Predictable Naming Scheme for Network Interfaces] by default so there is no `eth0` anymore but other naming schema such as `enp2s0`.
 
 .Logs
 


### PR DESCRIPTION
- Align all uses of `version-sl-micro` to `version-operatingsystem`
- Bump `version-operatingsystem` to 6.2
- Remove `net.ifnames=1` parameters as they are now default
- Remove `net.ifnames=0` paremeters as they were unintended leftovers
- Adapt comments Predictable Naming Scheme for Network Interfaces to highlight the new default
- Add comments about the need for extra non root user for cockpit use