### PR TITLE
Update versions and release notes for 3.5.0

### DIFF
--- a/asciidoc/day2/migration.adoc
+++ b/asciidoc/day2/migration.adoc
@@ -149,7 +149,7 @@ The *key* differences being that:
 
 . The fleets *must be used* from the link:https://github.com/suse-edge/fleet-examples/releases/tag/{static-fleet-examples-tag}[{static-fleet-examples-tag}] release of the `suse-edge/fleet-examples` repository.
 
-. Charts scheduled for an upgrade *must* be upgraded to versions compatible with the `Edge {static-edge-version}` release. For a list of the `Edge {static-edge-version}` components, refer to <<release-notes-3-4-0>>.
+. Charts scheduled for an upgrade *must* be upgraded to versions compatible with the `Edge {static-edge-version}` release. For a list of the `Edge {static-edge-version}` components, refer to <<release-notes-3-5-0>>.
 
 [IMPORTANT]
 ====
@@ -173,7 +173,7 @@ The *key* differences being that:
 
 . The fleets *must be used* from the link:https://github.com/suse-edge/fleet-examples/releases/tag/{static-fleet-examples-tag}[{static-fleet-examples-tag}] release of the `suse-edge/fleet-examples` repository.
 
-. Charts scheduled for an upgrade *must* be upgraded to versions compatible with the `Edge {static-edge-version}` release. For a list of the `Edge {static-edge-version}` components, refer to <<release-notes-3-4-0>>.
+. Charts scheduled for an upgrade *must* be upgraded to versions compatible with the `Edge {static-edge-version}` release. For a list of the `Edge {static-edge-version}` components, refer to <<release-notes-3-5-0>>.
 
 [IMPORTANT]
 ====

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -1,7 +1,7 @@
 [#release-notes]
 
 = Abstract
-:revdate: 2025-09-25
+:revdate: 2026-01-13
 :page-revdate: {revdate}
 ifdef::env-github[]
 :imagesdir: ../images/
@@ -12,7 +12,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-SUSE Edge 3.4 is a tightly integrated and comprehensively validated end-to-end solution for addressing the unique challenges of the deployment of infrastructure and cloud-native applications at the edge. Its driving focus is to provide an opinionated, yet highly flexible, highly scalable, and secure platform that spans initial deployment image building, node provisioning and onboarding, application deployment, observability, and lifecycle management.
+SUSE Edge 3.5 is a tightly integrated and comprehensively validated end-to-end solution for addressing the unique challenges of the deployment of infrastructure and cloud-native applications at the edge. Its driving focus is to provide an opinionated, yet highly flexible, highly scalable, and secure platform that spans initial deployment image building, node provisioning and onboarding, application deployment, observability, and lifecycle management.
 
 The solution is designed with the notion that there is no "one-size-fits-all" edge platform due to our customers’ widely varying requirements and expectations. Edge deployments push us to solve, and continually evolve, some of the most challenging problems, including massive scalability, restricted network availability, physical space constraints, new security threats and attack vectors, variations in hardware architecture and system resources, the requirement to deploy and interface with legacy infrastructure and applications, and customer solutions that have extended lifespans.
 
@@ -20,7 +20,7 @@ SUSE Edge is built on best-of-breed open source software from the ground up, con
 
 For more information on product support lifecycle updates for SUSE Edge, see link:https://www.suse.com/lifecycle/#suse-edge-33[Product Support Lifecycle]. 
 
-NOTE: SUSE Telco Cloud (formerly known as SUSE Edge for Telco) is a derivative of SUSE Edge, with additional optimizations and components that enable the platform to address the requirements found in telecommunications use-cases. Unless explicitly stated, all the release notes are applicable for both SUSE Edge 3.4, and SUSE Telco Cloud 3.4.
+NOTE: SUSE Telco Cloud (formerly known as SUSE Edge for Telco) is a derivative of SUSE Edge, with additional optimizations and components that enable the platform to address the requirements found in telecommunications use-cases. Unless explicitly stated, all the release notes are applicable for both SUSE Edge 3.5, and SUSE Telco Cloud 3.5.
 
 = About
 
@@ -28,41 +28,35 @@ These Release Notes are, unless explicitly specified and explained, identical ac
 
 Entries are only listed once, but they can be referenced in several places if they are important and belong to more than one section. Release notes usually only list changes that happened between two subsequent releases. Certain important entries from the release notes of previous product versions may be repeated. To make these entries easier to identify, they contain a note to that effect.
 
-However, repeated entries are provided as a courtesy only. Therefore, if you are skipping one or more releases, check the release notes of the skipped releases also. If you are only reading the release notes of the current release, you could miss important changes that may affect system behavior. SUSE Edge versions are defined as x.y.z, where 'x' denotes the major version, 'y' denotes the minor, and 'z' denotes the patch version, also known as the "z-stream". SUSE Edge product lifecycles are defined based around a given minor release, e.g. "3.4", but ship with subsequent patch updates through its lifecycle, e.g. "3.4.1".
+However, repeated entries are provided as a courtesy only. Therefore, if you are skipping one or more releases, check the release notes of the skipped releases also. If you are only reading the release notes of the current release, you could miss important changes that may affect system behavior. SUSE Edge versions are defined as x.y.z, where 'x' denotes the major version, 'y' denotes the minor, and 'z' denotes the patch version, also known as the "z-stream". SUSE Edge product lifecycles are defined based around a given minor release, e.g. "3.5", but ship with subsequent patch updates through its lifecycle, e.g. "3.5.1".
 
 NOTE: SUSE Edge z-stream releases are tightly integrated and thoroughly tested as a versioned stack. Upgrade of any individual components to a different versions to those listed above is likely to result in system downtime. While it's possible to run Edge clusters in untested configurations, it is not recommended, and it may take longer to provide resolution through the support channels.
 
-[#release-notes-3-4-0]
-= Release 3.4.0
+[#release-notes-3-5-0]
+= Release 3.5.0
 
-Availability Date: 24th September 2025
+Availability Date: TBC
 
-Full Support End Date: 20th March 2026
+Full Support End Date: TBC
 
-Maintenance Support End Date: 20th September 2027
+Maintenance Support End Date: TBC
 
-EOL: 21st September 2027
+EOL: TBC
 
-Summary: SUSE Edge 3.4.0 is the first release in the SUSE Edge 3.4 release stream.
+Summary: SUSE Edge 3.5.0 is the first release in the SUSE Edge 3.5 release stream.
 
 == New Features
 
-* Updated to Kubernetes 1.33 and Rancher Prime 2.12
-* Updated Rancher Turtles, Cluster API and Metal3/Ironic versions
-* Updated to SUSE Storage (Longhorn) 1.9.1 https://longhorn.io/docs/1.9.1/[Release Notes]
-* More flexible deployment of {aarch64} downstream clusters is now possible via the directed network provisioning flow. See <<atip-automated-provisioning>> for more details.
-* Deployment of dual-stack clusters is now fully supported (single-stack ipv6 remains in <<tech-previews>>)
-* BGP mode for MetalLB is now available as a tech preview see <<tech-previews>> and <<guides-metallb-k3s-l3>> for more details.
-* Edge Image Builder has been updated to 1.3.0, see https://github.com/suse-edge/edge-image-builder/blob/release-1.3/RELEASE_NOTES.md[Upstream Release Notes]
+* Updated to Kubernetes 1.34 and Rancher Prime 2.13
+* Updated Metal3/Ironic versions
+* Updated to SUSE Storage (Longhorn) 1.10.1 https://longhorn.io/docs/1.10.1/[Release Notes]
+* TODO
 
 == Bug & Security Fixes
 
-* Rancher Prime 2.12 contains several bugfixes https://github.com/rancher/rancher/releases/tag/v2.12.1[Upstream Rancher Release Notes]
-* Rancher Prime 2.12 contains a fix for issues related to AppVersion when determining extension upgrade availability, which impacted operation with Edge charts https://github.com/rancher/dashboard/issues/14204[Upstream Issue]
-* SUSE Storage (Longhorn) 1.9.1 contains several bugfixes https://github.com/longhorn/longhorn/releases/tag/v1.9.1[Upstream Longhorn Bug Fixes]
-* The updated Metal^3^ chart fixes an issue where the wrong MAC may be collected for bonded interfaces during inspection https://bugs.launchpad.net/ironic-python-agent/+bug/2103450[Upstream IPA issue]
-* The updated Metal^3^ chart fixes an issue where the deployment may not be correctly restarted on ConfigMap updates https://github.com/suse-edge/charts/issues/219[Upstream Issue]
-* The Rancher Turtles update includes a fix which resolves an issue where MachineTemplate ownerReferences were not applied by the RKE2 CAPI provider https://github.com/rancher/cluster-api-provider-rke2/issues/500[Upstream Issue]
+* Rancher Prime 2.13 contains several bugfixes https://github.com/rancher/rancher/releases/tag/v2.13.1[Upstream Rancher Release Notes]
+* SUSE Storage (Longhorn) 1.10.1 contains several bugfixes https://github.com/longhorn/longhorn/releases/tag/v1.10.1[Upstream Longhorn Bug Fixes]
+* TODO
 
 == Known Issues
 
@@ -73,7 +67,7 @@ If deploying new clusters, please follow <<guides-kiwi-builder-images>> to build
 
 * When deploying via Edge Image Builder, `HelmChartConfigs` manifests may fail if they are put in the `kubernetes/manifests` configuration directory. Instead it is recommended to place any `HelmChartConfigs` in `/var/lib/rancher/{rke2/k3s}/server/manifests/` using the EIB os-files interface, see <<mgmt-cluster-directory-structure>> for example.  Failure to do this may cause nodes to stay in `NotReady` state on initial startup, as discussed in https://github.com/rancher/rke2/issues/8357[#8357 RKE2 issue]
 
-* On RKE2/K3s 1.31, 1.32 and 1.33 versions, the directory `/etc/cni` being used to store CNI configurations may not trigger a notification of the files being written there to `containerd` due to certain conditions related to `overlayfs` (see the https://github.com/rancher/rke2/issues/8356[#8356 RKE2 issue]). This in turn results in the deployment of RKE2/K3s to get stuck waiting for the CNI to start, and the RKE2/K3s nodes to stay in `NotReady` state. This can be seen at node level with `kubectl describe node <affected_node>`:
+* On RKE2/K3s 1.31, 1.32, 1.33 and 1.34 versions, the directory `/etc/cni` being used to store CNI configurations may not trigger a notification of the files being written there to `containerd` due to certain conditions related to `overlayfs` (see the https://github.com/rancher/rke2/issues/8356[#8356 RKE2 issue]). This in turn results in the deployment of RKE2/K3s to get stuck waiting for the CNI to start, and the RKE2/K3s nodes to stay in `NotReady` state. This can be seen at node level with `kubectl describe node <affected_node>`:
 
 [,bash]
 ----
@@ -124,68 +118,53 @@ and a custom script named `30a-copy-elemental-system-agent-override.sh` can be u
 
 == Component Versions
 
-The following table describes the individual components that make up the 3.4.0 release, including the version, the Helm chart version (if applicable), and from where the released artifact can be pulled in the binary format. Please follow the associated documentation for usage and deployment examples.
+The following table describes the individual components that make up the 3.5.0 release, including the version, the Helm chart version (if applicable), and from where the released artifact can be pulled in the binary format. Please follow the associated documentation for usage and deployment examples.
 
 |======
 | Name | Version | Helm Chart Version | Artifact Location (URL/Image)
 | SUSE Linux Micro | 6.1 (latest) | N/A | https://www.suse.com/download/sle-micro/[SUSE Linux Micro Download Page] +
-SL-Micro.x86_64-6.1-Base-SelfInstall-GM.install.iso (sha256 70b9be28f2d92bc3b228412e4fc2b1d5026e691874b728e530b8063522158854) +
-SL-Micro.x86_64-6.1-Base-RT-SelfInstall-GM.install.iso (sha256 9ce83e4545d4b36c7c6a44f7841dc3d9c6926fe32dbff694832e0fbd7c496e9d) +
-SL-Micro.x86_64-6.1-Base-GM.raw.xz (sha256 36e3efa55822113840dd76fdf6914e933a7b7e88a1dce5cb20c424ccf2fb4430) +
-SL-Micro.x86_64-6.1-Base-RT-GM.raw.xz (sha256 2ee66735da3e1da107b4878e73ae68f5fb7309f5ec02b5dfdb94e254fda8415e) +
-| SUSE Multi-Linux Manager | 5.0.5 | N/A | https://www.suse.com/download/suse-manager/[SUSE Multi-Linux Manager Download Page]
-| K3s | 1.33.3 | N/A | https://github.com/k3s-io/k3s/releases/tag/v1.33.3%2Bk3s1[Upstream K3s Release]
-| RKE2 | 1.33.3 | N/A | https://github.com/rancher/rke2/releases/tag/v1.33.3%2Brke2r1[Upstream RKE2 Release]
-| SUSE Rancher Prime | 2.12.1 | 2.12.1 | https://charts.rancher.com/server-charts/prime/index.yaml[Rancher Prime Helm Repository] +
-https://github.com/rancher/rancher/releases/download/v2.12.1/rancher-images.txt[Rancher 2.12.1 Container Images]
-| SUSE Storage (Longhorn) | 1.9.1 | 107.0.0+up1.9.1 | https://charts.rancher.io/index.yaml[Rancher Charts Helm Repository] +
-registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.9.0-20250709 +
-registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709 +
-registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20250709 +
-registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709 +
-registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.14.0-20250709 +
-registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.16.0-20250709 +
-registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.9.1 +
-registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.1 +
-registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.9.1 +
-registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.1 +
-registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.9.1 +
-registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.1 +
-registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.61 +
-registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.1 +
-| SUSE Security | 5.4.5 | 107.0.0+up2.8.7 | https://charts.rancher.io/index.yaml[Rancher Charts Helm Repository] +
-registry.suse.com/rancher/neuvector-controller:5.4.5 +
-registry.suse.com/rancher/neuvector-enforcer:5.4.5 +
-registry.suse.com/rancher/neuvector-manager:5.4.5 +
-registry.suse.com/rancher/neuvector-compliance-config:1.0.6 +
-registry.suse.com/rancher/neuvector-registry-adapter:0.1.8 +
+SL-Micro.x86_64-6.2-Base-SelfInstall-GM.install.iso (sha256 76390cec4537821d90975d924bf9d7575c9912da89fa460383eff0c623fd403e) +
+SL-Micro.x86_64-6.2-Base-RT-SelfInstall-GM.install.iso (sha256 8f4d03c6953966174efb4c4b176cbe6dd5cab6e2a406033fc5c2bf6884da8b5d) +
+SL-Micro.x86_64-6.2-Base-GM.raw.xz (sha256 bea3ac202b54ee29fabc28568f50c86d34939cf861679f21a91dfbae9c54c92e) +
+SL-Micro.x86_64-6.2-Base-RT-GM.raw.xz (sha256 b9af7763c8d63143e31e5f80eb8d06fcc9477a576de8e358ab2e9835ab39d305) +
+| SUSE Multi-Linux Manager | 5.0.6 | N/A | https://www.suse.com/download/suse-manager/[SUSE Multi-Linux Manager Download Page]
+| K3s | 1.34.2 | N/A | https://github.com/k3s-io/k3s/releases/tag/v1.34.2%2Bk3s1[Upstream K3s Release]
+| RKE2 | 1.34.2 | N/A | https://github.com/rancher/rke2/releases/tag/v1.34.2%2Brke2r1[Upstream RKE2 Release]
+| SUSE Rancher Prime | 2.13.1 | 2.13.1 | https://charts.rancher.com/server-charts/prime/index.yaml[Rancher Prime Helm Repository] +
+https://prime.ribs.rancher.io/rancher/v2.13.1/rancher-images.txt[Rancher 2.13.1 Container Images]
+| SUSE Storage (Longhorn) | 1.10.1 | 1.10.1 | https://apps.rancher.io/applications/suse-storage[SUSE Storage Helm Repository] +
+https://apps.rancher.io/applications/suse-storage/components[SUSE Storage Container Images]
+| SUSE Security | 5.4.8 | 108.0.1+up2.8.10 | https://charts.rancher.io/index.yaml[Rancher Charts Helm Repository] +
+registry.suse.com/rancher/neuvector-controller:5.4.8 +
+registry.suse.com/rancher/neuvector-enforcer:5.4.8 +
+registry.suse.com/rancher/neuvector-manager:5.4.8 +
+registry.suse.com/rancher/neuvector-compliance-config:1.0.9 +
+registry.suse.com/rancher/neuvector-registry-adapter:0.2.2 +
 registry.suse.com/rancher/neuvector-scanner:6 +
-registry.suse.com/rancher/neuvector-updater:0.0.4
-| Rancher Turtles (CAPI) | 0.24.0 | 304.0.6+up0.24.0 | registry.suse.com/edge/charts/rancher-turtles:304.0.6_up0.24.0 +
-registry.rancher.com/rancher/rancher/turtles:v0.24.0 +
-registry.rancher.com/rancher/cluster-api-metal3-controller:v1.10.2 +
-registry.rancher.com/rancher/cluster-api-metal3-ipam-controller:v1.10.2 +
-registry.suse.com/rancher/cluster-api-controller:v1.10.5 +
-registry.suse.com/rancher/cluster-api-provider-rke2-bootstrap:v0.20.1 +
-registry.suse.com/rancher/cluster-api-provider-rke2-controlplane:v0.20.1
-| Rancher Turtles Airgap Resources | 0.24.0 | 304.0.6+up0.24.0 | registry.suse.com/edge/charts/rancher-turtles-airgap-resources:304.0.6_up0.24.0
-| Metal^3^ | 0.11.5 | 304.0.16+up0.12.6 | registry.suse.com/edge/charts/metal3:304.0.16_up0.12.6 +
-registry.suse.com/edge/3.4/baremetal-operator:0.10.2.1 +
-registry.suse.com/edge/3.4/ironic:29.0.4.3 +
-registry.suse.com/edge/3.4/ironic-ipa-downloader:3.0.9 +
-registry.suse.com/edge/mariadb:10.6.15.1
-| MetalLB | 0.14.9 | 304.0.0+up0.14.9 | registry.suse.com/edge/charts/metallb:304.0.0_up0.14.9 +
-registry.suse.com/edge/3.4/metallb-controller:v0.14.8 +
-registry.suse.com/edge/3.4/metallb-speaker:v0.14.8 +
-registry.suse.com/edge/3.4/frr:8.4 +
-registry.suse.com/edge/3.4/frr-k8s:v0.0.14
+registry.suse.com/rancher/neuvector-updater:0.0.7
+| Rancher Turtles Providers (CAPI) | 0.25.1 | 305.0.4+up0.25.1 | registry.suse.com/edge/charts/rancher-turtles-providers:305.0.4+up0.25.1 +
+registry.rancher.com/rancher/cluster-api-metal3-controller:v1.10.4 +
+registry.rancher.com/rancher/cluster-api-metal3-ipam-controller:v1.10.4 +
+registry.suse.com/rancher/cluster-api-provider-rke2-bootstrap:v0.21.1 +
+registry.suse.com/rancher/cluster-api-provider-rke2-controlplane:v0.21.1
+| Metal^3^ | 0.13.0 | 305.0.21+up0.13.0 | registry.suse.com/edge/charts/metal3:305.0.21_up0.13.0 +
+registry.suse.com/edge/3.5/baremetal-operator:0.11.2.0 +
+registry.suse.com/edge/3.5/ironic:32.0.0.1 +
+registry.suse.com/edge/3.5/ironic-ipa-downloader:3.0.10 +
+registry.suse.com/edge/mariadb:10.11
+| MetalLB | 0.15.2 | 305.0.1+up0.15.2 | registry.suse.com/edge/charts/metallb:305.0.1_up0.15.2 +
+registry.suse.com/edge/3.5/metallb-controller:v0.15.2 +
+registry.suse.com/edge/3.5/metallb-speaker:v0.15.2 +
+registry.suse.com/edge/3.5/frr:10.2.1 +
+registry.suse.com/edge/3.5/frr-k8s:v0.0.20 +
+registry.suse.com/edge/3.5/kube-rbac-proxy:0.19.1
 | Elemental | 1.7.3 | 1.7.3 | registry.suse.com/rancher/elemental-operator-chart:1.7.3 +
 registry.suse.com/rancher/elemental-operator-crds-chart:1.7.3 +
 registry.suse.com/rancher/elemental-operator:1.7.3
 | Elemental Dashboard Extension | 3.0.1 | 3.0.1 | link:https://github.com/rancher/ui-plugin-charts/tree/4.0.0/charts/elemental/3.0.1[Elemental Extension Helm Chart]
-| Edge Image Builder | 1.3.0 | N/A | registry.suse.com/edge/3.4/edge-image-builder:1.3.0
-| NM Configurator | 0.3.3 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.3[NMConfigurator Upstream Release]
-| KubeVirt | 1.5.2 | 304.0.1+up0.6.0 | registry.suse.com/edge/charts/kubevirt:304.0.1_up0.6.0 +
+| Edge Image Builder | 1.3.1 | N/A | registry.suse.com/edge/3.4/edge-image-builder:1.3.1
+| NM Configurator | 0.3.5 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.5[NMConfigurator Upstream Release]
+| KubeVirt | 1.5.2 | 305.0.1+up0.6.0 | registry.suse.com/edge/charts/kubevirt:305.0.1_up0.6.0 +
 registry.suse.com/suse/sles/15.7/virt-operator:1.5.2 +
 registry.suse.com/suse/sles/15.7/virt-api:1.5.2 +
 registry.suse.com/suse/sles/15.7/virt-controller:1.5.2 +
@@ -193,8 +172,8 @@ registry.suse.com/suse/sles/15.7/virt-exportproxy:1.5.2 +
 registry.suse.com/suse/sles/15.7/virt-exportserver:1.5.2 +
 registry.suse.com/suse/sles/15.7/virt-handler:1.5.2 +
 registry.suse.com/suse/sles/15.7/virt-launcher:1.5.2
-| KubeVirt Dashboard Extension | 1.3.2 | 304.0.3+up1.3.2 | registry.suse.com/edge/charts/kubevirt-dashboard-extension:304.0.3_up1.3.2
-| Containerized Data Importer | 1.62.0 | 304.0.1+up0.6.0 | registry.suse.com/edge/charts/cdi:304.0.1_up0.6.0 +
+| KubeVirt Dashboard Extension | 1.3.3 | 305.0.4+up1.3.3 | registry.suse.com/edge/charts/kubevirt-dashboard-extension:305.0.4_up1.3.3
+| Containerized Data Importer | 1.62.0 | 305.0.1+up0.6.0 | registry.suse.com/edge/charts/cdi:305.0.1_up0.6.0 +
 registry.suse.com/suse/sles/15.7/cdi-operator:1.62.0 +
 registry.suse.com/suse/sles/15.7/cdi-controller:1.62.0 +
 registry.suse.com/suse/sles/15.7/cdi-importer:1.62.0 +
@@ -202,26 +181,26 @@ registry.suse.com/suse/sles/15.7/cdi-cloner:1.62.0 +
 registry.suse.com/suse/sles/15.7/cdi-apiserver:1.62.0 +
 registry.suse.com/suse/sles/15.7/cdi-uploadserver:1.62.0 +
 registry.suse.com/suse/sles/15.7/cdi-uploadproxy:1.62.0
-| Endpoint Copier Operator | 0.3.0 | 304.0.1+up0.3.0 | registry.suse.com/edge/charts/endpoint-copier-operator:304.0.1_up0.3.0 +
-registry.suse.com/edge/3.4/endpoint-copier-operator:0.3.0
-| Akri (Deprecated) | 0.12.20 | 304.0.0+up0.12.20 | registry.suse.com/edge/charts/akri:304.0.0_up0.12.20 +
-registry.suse.com/edge/charts/akri-dashboard-extension:304.0.0_up1.3.1 +
-registry.suse.com/edge/3.4/akri-agent:v0.12.20 +
-registry.suse.com/edge/3.4/akri-controller:v0.12.20 +
-registry.suse.com/edge/3.4/akri-debug-echo-discovery-handler:v0.12.20 +
-registry.suse.com/edge/3.4/akri-onvif-discovery-handler:v0.12.20 +
-registry.suse.com/edge/3.4/akri-opcua-discovery-handler:v0.12.20 +
-registry.suse.com/edge/3.4/akri-udev-discovery-handler:v0.12.20 +
-registry.suse.com/edge/3.4/akri-webhook-configuration:v0.12.20
-| SR-IOV Network Operator | 1.5.0 | 304.0.2+up1.5.0 | registry.suse.com/edge/charts/sriov-network-operator:304.0.2_up1.5.0 +
-registry.suse.com/edge/charts/sriov-crd:304.0.2_up1.5.0
-| System Upgrade Controller | 0.16.0 | 107.0.0 | https://charts.rancher.io/index.yaml[Rancher Charts Helm Repository] +
-registry.suse.com/rancher/system-upgrade-controller:v0.16.0
-| Upgrade Controller | 0.1.1 | 304.0.1+up0.1.1 | registry.suse.com/edge/charts/upgrade-controller:304.0.1_up0.1.1 +
-registry.suse.com/edge/3.4/upgrade-controller:0.1.1 +
-registry.suse.com/edge/3.4/kubectl:1.33.4 +
-registry.suse.com/edge/3.4/release-manifest:3.4.0
-| Kiwi Builder | 10.2.12.0 | N/A | registry.suse.com/edge/3.4/kiwi-builder:10.2.12.0
+| Endpoint Copier Operator | 0.3.0 | 305.0.1+up0.3.0 | registry.suse.com/edge/charts/endpoint-copier-operator:305.0.1_up0.3.0 +
+registry.suse.com/edge/3.5/endpoint-copier-operator:0.3.0
+| Akri (Deprecated) | 0.12.20 | 305.0.0+up0.12.20 | registry.suse.com/edge/charts/akri:305.0.0_up0.12.20 +
+registry.suse.com/edge/charts/akri-dashboard-extension:305.0.0_up1.3.1 +
+registry.suse.com/edge/3.5/akri-agent:v0.12.20 +
+registry.suse.com/edge/3.5/akri-controller:v0.12.20 +
+registry.suse.com/edge/3.5/akri-debug-echo-discovery-handler:v0.12.20 +
+registry.suse.com/edge/3.5/akri-onvif-discovery-handler:v0.12.20 +
+registry.suse.com/edge/3.5/akri-opcua-discovery-handler:v0.12.20 +
+registry.suse.com/edge/3.5/akri-udev-discovery-handler:v0.12.20 +
+registry.suse.com/edge/3.5/akri-webhook-configuration:v0.12.20
+| SR-IOV Network Operator | 1.6.0 | 305.0.4+up1.6.0 | registry.suse.com/edge/charts/sriov-network-operator:305.0.4_up1.6.0 +
+registry.suse.com/edge/charts/sriov-crd:305.0.4_up1.6.0
+| System Upgrade Controller | 0.17.0 | 108.0.0 | https://charts.rancher.io/index.yaml[Rancher Charts Helm Repository] +
+registry.suse.com/rancher/system-upgrade-controller:v0.17.0
+| Upgrade Controller | 0.1.2 | 305.0.2+up0.1.2 | registry.suse.com/edge/charts/upgrade-controller:305.0.2_up0.1.2 +
+registry.suse.com/edge/3.5/upgrade-controller:0.1.2 +
+registry.suse.com/edge/3.5/kubectl:1.34.2 +
+registry.suse.com/edge/3.5/release-manifest:3.5.0
+| Kiwi Builder | 10.2.29.1 | N/A | registry.suse.com/edge/3.5/kiwi-builder:10.2.29.1
 |======
 
 = Deprecated features
@@ -288,11 +267,11 @@ Refer to the <<day-2-operations>> for details around how to upgrade to a new rel
 
 SUSE Edge is backed by award-winning support from SUSE, an established technology leader with a proven history of delivering enterprise-quality support services. For more information, see https://www.suse.com/lifecycle[https://www.suse.com/lifecycle] and the Support Policy page at https://www.suse.com/support/policy.html[https://www.suse.com/support/policy.html]. If you have any questions about raising a support case, how SUSE classifies severity levels, or the scope of support, please see the Technical Support Handbook at https://www.suse.com/support/handbook/[https://www.suse.com/support/handbook/].
 
-SUSE Edge "3.4" is supported for 24-months of production support, with an initial 6-months of "full support", followed by 18-months of "maintenance support".  After these support phases the product reaches "end of life" (EOL) and is no longer supported. More info about the lifecycle phases can be found in the table below:
+SUSE Edge "3.5" is supported for 18-months of production support, with an initial 6-months of "full support", followed by 12-months of "maintenance support".  After these support phases the product reaches "end of life" (EOL) and is no longer supported. More info about the lifecycle phases can be found in the table below:
 
 |======
 | *Full Support (6 months)* | Urgent and selected high-priority bug fixes will be released during the full support window, and all other patches (non-urgent, enhancements, new capabilities) will be released via the regular release schedule.
-| *Maintenance Support (18 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
+| *Maintenance Support (12 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
 | *End of Life (EOL)*  | Once a product release reaches its End of Life date, the customer may continue to use the product within the terms of product licensing agreement.
 Support Plans from SUSE do not apply to product releases past their EOL date.
 |======

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -1,5 +1,5 @@
 // ============================================================================
-:revdate: 2025-09-17
+:revdate: 2026-01-13
 :page-revdate: {revdate}
 // Automatic Version Substitutions
 // 
@@ -10,34 +10,34 @@
 // ============================================================================
 
 // == General Edge ==
-:version-edge: 3.4
-:version-edge-registry: 3.4
+:version-edge: 3.5
+:version-edge-registry: 3.5
 
 // == Multi-Linux Manager ==
-:version-mlm: 5.0.5
+:version-mlm: 5.0.6
 
 // == Edge Image Builder ==
-:version-eib: 1.3.0
+:version-eib: 1.3.1
 :version-eib-api-latest: 1.3
 
 // KubeVirt
 //  This is used in download URLs and filenames from upstream, so it must have
 //  the leading "v". If needed, a separate version-kubevirt should be created
 //  with simply the version number itself.
-:version-kubevirt-release: v1.5.2
+:version-kubevirt-release: v0.6.0
 
 // == Component Versions ==
-:version-rancher-prime: 2.12.1
-:version-cert-manager: 1.18.2
+:version-rancher-prime: 2.13.1
+:version-cert-manager: 1.19.2
 :version-elemental-operator: 1.7.3
-:version-longhorn: 1.9.1
-:version-neuvector: 5.4.5
+:version-longhorn: 1.9.2
+:version-neuvector: 5.4.8
 :version-kubevirt: 1.5.2
 :version-endpoint-copier-operator: 0.3.0
-:version-suc: 0.16.0
-:version-nm-configurator: 0.3.4
-:version-fleet: 0.13.1
-:version-cdi: 1.62.0
+:version-suc: 0.17.0
+:version-nm-configurator: 0.3.5
+:version-fleet: 0.14.1
+:version-cdi: 0.6.0
 :version-nvidia-device-plugin: 0.14.5
 :version-kiwi-builder: 10.2.12.0
 
@@ -45,16 +45,16 @@
 :version-nessie: 1.0.0
 
 // == Non-Release Manifest Charts ==
-:version-suc-chart: 107.0.0
-:version-upgrade-controller-chart: 304.0.1+up0.1.1
+:version-suc-chart: 108.0.0
+:version-upgrade-controller-chart: 305.0.1+up0.1.1
 :version-nvidia-device-plugin-chart: v0.14.5
 
 // == Release Tags ==
 :release-tag-eib: release-1.3
-:release-tag-edge-charts: release-3.4
-:release-tag-telco-cloud: release-3.4
-:release-tag-fleet-examples: release-3.4.0
-:release-tag-rancher: v2.12.1
+:release-tag-edge-charts: release-3.5
+:release-tag-telco-cloud: release-3.5
+:release-tag-fleet-examples: release-3.5.0
+:release-tag-rancher: v2.13.1
 
 
 // ============================================================================
@@ -64,33 +64,33 @@
 // and should not be renamed without thinking through the implications.
 // ============================================================================
 
-:version-kubernetes-k3s: v1.33.3+k3s1
-:version-kubernetes-rke2: v1.33.3+rke2r1
+:version-kubernetes-k3s: v1.34.2+k3s1
+:version-kubernetes-rke2: v1.34.2+rke2r1
 
 :version-operatingsystem: 6.2
 
-:version-akri-chart: 304.0.0+up0.12.20
-:version-akri-dashboard-extension-chart: 304.0.2+up1.3.1
-:version-cdi-chart: 304.0.1+up0.6.0
-:version-elemental-operator-chart: 107.1.0+up1.7.3
-:version-elemental-operator-crds-chart: 107.1.0+up1.7.3
-:version-endpoint-copier-operator-chart: 304.0.1+up0.3.0
-:version-fleet-chart: 107.0.1+up0.13.1
-:version-kubevirt-chart: 304.0.1+up0.6.0
-:version-kubevirt-dashboard-extension-chart: 304.0.2+up1.3.2
-:version-longhorn-chart: 107.0.0+up1.9.1
-:version-longhorn-crd-chart: 107.0.0+up1.9.1
-:version-longhorn-docs: 1.9.1
-:version-metal3-chart: 304.0.16+up0.12.6
-:version-metallb-chart: 304.0.0+up0.14.9
-:version-neuvector-chart: 107.0.0+up2.8.7
-:version-neuvector-crd-chart: 107.0.0+up2.8.7
-:version-neuvector-dashboard-extension-chart: 2.1.3
-:version-rancher-chart: 2.12.1
+:version-akri-chart: 305.0.0+up0.12.20
+:version-akri-dashboard-extension-chart: 305.0.4+up1.3.2
+:version-cdi-chart: 305.0.1+up0.6.0
+:version-elemental-operator-chart: 1.7.3
+:version-elemental-operator-crds-chart: 1.7.3
+:version-endpoint-copier-operator-chart: 305.0.1+up0.3.0
+:version-fleet-chart: 108.0.1+up0.14.1
+:version-kubevirt-chart: 305.0.1+up0.6.0
+:version-kubevirt-dashboard-extension-chart: 305.0.4+up1.3.3
+:version-longhorn-chart: 108.1.0+up1.9.2
+:version-longhorn-crd-chart: 108.1.0+up1.9.2
+:version-longhorn-docs: 1.9.2
+:version-metal3-chart: 305.0.21+up0.13.0
+:version-metallb-chart: 305.0.1+up0.15.2
+:version-neuvector-chart: 108.0.1+up2.8.10
+:version-neuvector-crd-chart: 108.0.1+up2.8.10
+:version-neuvector-dashboard-extension-chart: 2.1.5
+:version-rancher-chart: 2.13.1
 :version-rancher-turtles-chart: 304.0.6+up0.24.0
-:version-sriov-crd-chart: 304.0.2+up1.5.0
-:version-sriov-network-operator-chart: 304.0.2+up1.5.0
-:version-sriov-upstream: 1.5.0
+:version-sriov-crd-chart: 305.0.4+up1.6.0
+:version-sriov-network-operator-chart: 305.0.4+up1.6.0
+:version-sriov-upstream: 1.6.0
 
 // capi-provider-metal3
 // edu, Oct 9, 2025 :: Used to link the CRDs on the docs site like


### PR DESCRIPTION
First pass of updates for 3.5.0 - note the versions are derived from #1008 but I will follow up with the script changes in another PR

The release notes will require further work but this is hopefully a reasonable first pass we can iterate on