### PR TITLE
[3.5.0] - bump eib and upgrade-controller versions (#1021)

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -184,7 +184,7 @@ registry.suse.com/edge/3.5/kube-rbac-proxy:0.19.1
 registry.suse.com/rancher/elemental-operator-crds-chart:1.8.0 +
 registry.suse.com/rancher/elemental-operator:1.8.0
 | Elemental Dashboard Extension | 3.0.1 | 3.0.1 | link:https://github.com/rancher/ui-plugin-charts/tree/4.0.0/charts/elemental/3.0.1[Elemental Extension Helm Chart]
-| Edge Image Builder | 1.3.1 | N/A | registry.suse.com/edge/3.4/edge-image-builder:1.3.1
+| Edge Image Builder | 1.3.2 | N/A | registry.suse.com/edge/3.4/edge-image-builder:1.3.2
 | NM Configurator | 0.3.5 | N/A | https://github.com/suse-edge/nm-configurator/releases/tag/v0.3.5[NMConfigurator Upstream Release]
 | KubeVirt | 1.5.2 | 305.0.1+up0.6.0 | registry.suse.com/edge/charts/kubevirt:305.0.1_up0.6.0 +
 registry.suse.com/suse/sles/15.7/virt-operator:1.5.2 +
@@ -218,8 +218,8 @@ registry.suse.com/edge/3.5/akri-webhook-configuration:v0.12.20
 registry.suse.com/edge/charts/sriov-crd:305.0.4_up1.6.0
 | System Upgrade Controller | 0.17.0 | 108.0.0 | https://charts.rancher.io/index.yaml[Rancher Charts Helm Repository] +
 registry.suse.com/rancher/system-upgrade-controller:v0.17.0
-| Upgrade Controller | 0.1.2 | 305.0.2+up0.1.2 | registry.suse.com/edge/charts/upgrade-controller:305.0.2_up0.1.2 +
-registry.suse.com/edge/3.5/upgrade-controller:0.1.2 +
+| Upgrade Controller | 0.1.3 | 305.0.2+up0.1.3 | registry.suse.com/edge/charts/upgrade-controller:305.0.3_up0.1.3 +
+registry.suse.com/edge/3.5/upgrade-controller:0.1.3 +
 registry.suse.com/edge/3.5/kubectl:1.34.2 +
 registry.suse.com/edge/3.5/release-manifest:3.5.0
 | Kiwi Builder | 10.2.29.1 | N/A | registry.suse.com/edge/3.5/kiwi-builder:10.2.29.1

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -46,7 +46,7 @@
 
 // == Non-Release Manifest Charts ==
 :version-suc-chart: 108.0.0
-:version-upgrade-controller-chart: 305.0.1+up0.1.1
+:version-upgrade-controller-chart: 305.0.3+up0.1.3
 :version-nvidia-device-plugin-chart: v0.14.5
 
 // == Release Tags ==


### PR DESCRIPTION
(cherry picked from commit 0f8ed39cd8103fdd7ed927d1b3388e65a8f07f9d)