### PR TITLE
Addresses 1031 - Update configure-network.sh

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -289,6 +289,16 @@ fi
 
 mount -o ro $CONFIG_DRIVE /mnt
 
+META_DATA_FILE="/mnt/openstack/latest/meta_data.json"
+if [ ! -f "${META_DATA_FILE}" ]; then
+  umount /mnt
+  echo "No meta_data.json found, skipping hostname configuration"
+  exit 0
+fi
+
+DESIRED_HOSTNAME=$(cat /mnt/openstack/latest/meta_data.json | tr ',{}' '\n' | grep '"metal3-name"' | sed 's/.*\"metal3-name\": \"\(.*\)\"/\1/')
+echo "${DESIRED_HOSTNAME}" > /etc/hostname
+
 NETWORK_DATA_FILE="/mnt/openstack/latest/network_data.json"
 
 if [ ! -f "${NETWORK_DATA_FILE}" ]; then
@@ -296,9 +306,6 @@ if [ ! -f "${NETWORK_DATA_FILE}" ]; then
   echo "No network_data.json found, skipping network configuration"
   exit 0
 fi
-
-DESIRED_HOSTNAME=$(cat /mnt/openstack/latest/meta_data.json | tr ',{}' '\n' | grep '\"metal3-name\"' | sed 's/.*\"metal3-name\": \"\(.*\)\"/\1/')
-echo "${DESIRED_HOSTNAME}" > /etc/hostname
 
 mkdir -p /tmp/nmc/{desired,generated}
 cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/_all.yaml

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -381,6 +381,16 @@ fi
 
 mount -o ro $CONFIG_DRIVE /mnt
 
+META_DATA_FILE="/mnt/openstack/latest/meta_data.json"
+if [ ! -f "${META_DATA_FILE}" ]; then
+  umount /mnt
+  echo "No meta_data.json found, skipping hostname configuration"
+  exit 0
+fi
+
+DESIRED_HOSTNAME=$(cat /mnt/openstack/latest/meta_data.json | tr ',{}' '\n' | grep '"metal3-name"' | sed 's/.*\"metal3-name\": \"\(.*\)\"/\1/')
+echo "${DESIRED_HOSTNAME}" > /etc/hostname
+
 NETWORK_DATA_FILE="/mnt/openstack/latest/network_data.json"
 
 if [ ! -f "${NETWORK_DATA_FILE}" ]; then
@@ -388,9 +398,6 @@ if [ ! -f "${NETWORK_DATA_FILE}" ]; then
   echo "No network_data.json found, skipping network configuration"
   exit 0
 fi
-
-DESIRED_HOSTNAME=$(cat /mnt/openstack/latest/meta_data.json | tr ',{}' '\n' | grep '\"metal3-name\"' | sed 's/.*\"metal3-name\": \"\(.*\)\"/\1/')
-echo "${DESIRED_HOSTNAME}" > /etc/hostname
 
 mkdir -p /tmp/nmc/{desired,generated}
 cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/_all.yaml


### PR DESCRIPTION
This is to address situations where we don't get any network data but still want to set the hostaname (e.g. in the case of Sylva). This MR fixes #1031 