### PR TITLE
Replace individual air-gap scripts with seactl procedure in atip-auto…

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1992,27 +1992,27 @@ spec:
     mirrors:
       docker.io:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+          - "$\{PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
       registry.suse.com:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+          - "$\{PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
       registry.suse.de:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+          - "$\{PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
       registry.opensuse.org:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+          - "$\{PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
       registry.rancher.com:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+          - "$\{PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
     configs:

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -459,113 +459,84 @@ cp sriov-auto-filler.sh /opt/sriov/sriov-auto-filler.sh
 
 The content of `custom/files/sriov-auto-filler.sh` is a script that can be used to configure the system for SR-IOV and can be downloaded from the following https://github.com/suse-edge/telco-cloud-examples/blob/{release-tag-telco-cloud}/telco-examples/edge-clusters/dhcp/eib/custom/files/sriov-auto-filler.sh[link].
 
-===== Custom files for air-gap scenarios
-
-The `custom/files` directory contains the `rke2` and the `cni` images to be copied to the image during the image creation process.
-To easily generate the images, prepare them locally using following {link-lifecycle-save-images}[script] and the list of images {link-lifecycle-rke2-images}[here] to generate the artifacts required to be included in `custom/files`.
-Also, you can download the latest `rke2-install` script from https://get.rke2.io/[here].
-
-[,shell]
-----
-$ ./edge-save-rke2-images.sh -o custom/files -l ~/edge-release-rke2-images.txt
-----
-
-After downloading the images, the directory structure should look like this:
-
-[,console]
-----
-└── custom/
-    └ files/
-        └ install.sh
-        └ rke2-images-cilium.linux-amd64.tar.zst
-        └ rke2-images-core.linux-amd64.tar.zst
-        └ rke2-images-multus.linux-amd64.tar.zst
-        └ rke2-images.linux-amd64.tar.zst
-        └ rke2.linux-amd64.tar.zst
-        └ sha256sum-amd64.txt
-----
+===== Preparing the air-gap artifacts
 
 [#preload-private-registry]
-===== Preload your private registry with images required for air-gap scenarios and SR-IOV (optional)
 
-If you want to use SR-IOV in your air-gap scenario or any other workload images, you must preload your local private registry with the images following the next steps:
+The following steps are required to prepare the air-gap artifacts using the release container image in order to populate a registry with the specific version artifacts.
+It handles RKE2 tarball generation, Helm chart OCI mirroring, and container image mirroring in a single command — no separate scripts are needed.
 
-* Download, extract, and push the helm-chart OCI images to the private registry
-* Download, extract, and push the rest of images required to the private registry
-
-The following scripts can be used to download, extract, and push the images to the private registry. We will show an example to preload the SR-IOV images, but you can also use the same approach to preload any other custom images:
-
-. Preload with helm-chart OCI images for SR-IOV:
+. If your private registry requires authentication, create a registry auth file with base64-encoded credentials:
 +
-.. You must create a list with the helm-chart OCI images required:
-+
-[,shell,subs="attributes,specialchars"]
+[,shell]
 ----
-$ cat > edge-release-helm-oci-artifacts.txt <<EOF
-edge/charts/sriov-network-operator:{version-sriov-network-operator-chart}
-edge/charts/sriov-crd:{version-sriov-crd-chart}
-EOF
+$ echo -n "$(echo -n 'myusername' | base64 -w 0):$(echo -n 'mypassword' | base64 -w 0)" > registry-auth.txt
 ----
+
+. If you use a Rancher Apps chart repository (required for Longhorn and Rancher-sourced charts), create a Rancher Apps auth file:
 +
-.. Generate a local tarball file using the following {link-lifecycle-save-oci-artifacts}[script] and the list created above:
+[,shell]
+----
+$ echo -n "$(echo -n 'myusername@apps.rancher.io' | base64 -w 0):$(echo -n 'mypassword' | base64 -w 0)" > rancher-apps-auth.txt
+----
+
+. (Optional) If you want to mirror SUSE Private Registry artifacts (Harbor charts/images), create a SUSE Private Registry auth file using your `SCC mirroring credentials` retrieved following the https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry documentation]:
++
+[,shell]
+----
+$ echo -n "$(echo -n 'SUSE_REGISTRY_USERNAME' | base64 -w 0):$(echo -n 'SUSE_REGISTRY_PASSWORD' | base64 -w 0)" > suse-private-registry-auth.txt
+----
+
+. Run the `mirror` command using the release container image to populate your private registry with all required artifacts for a specific release version (RKE2 images, Helm chart OCI images, and container images).
+Place any auth files and certificates in the current directory so they are accessible inside the container via the `-v ./:/opt:z` bind mount.
++
+Without SUSE Private Registry (Harbor charts/images will be skipped):
 +
 [,shell,subs="attributes"]
 ----
-$ ./edge-save-oci-artefacts.sh -al ./edge-release-helm-oci-artifacts.txt -s registry.suse.com
-Pulled: registry.suse.com/edge/charts/sriov-network-operator:{version-sriov-network-operator-chart}
-Pulled: registry.suse.com/edge/charts/sriov-crd:{version-sriov-crd-chart}
-a edge-release-oci-tgz-20240705
-a edge-release-oci-tgz-20240705/sriov-network-operator-{version-sriov-network-operator-chart}.tgz
-a edge-release-oci-tgz-20240705/sriov-crd-{version-sriov-crd-chart}.tgz
+$ podman run --rm \
+  -v ./:/opt:z \
+  registry.suse.com/edge/{version-edge-registry}/release-manifest:{version-edge} \
+  mirror \
+  -o /opt/output \
+  -a /opt/registry-auth.txt \
+  -c /opt/cert.pem \
+  -r myregistry:5000 \
+  --rancher-apps-authfile /opt/rancher-apps-auth.txt \
+  --insecure --debug
 ----
 +
-.. Upload your tarball file to your private registry (e.g. `myregistry:5000`) using the following {link-lifecycle-load-oci-artifacts}[script] to preload your registry with the helm chart OCI images downloaded in the previous step:
+With SUSE Private Registry:
 +
-[,shell]
+[,shell,subs="attributes"]
 ----
-$ tar zxvf edge-release-oci-tgz-20240705.tgz
-$ ./edge-load-oci-artefacts.sh -ad edge-release-oci-tgz-20240705 -r myregistry:5000
+$ podman run --rm \
+  -v ./:/opt:z \
+  registry.suse.com/edge/{version-edge-registry}/release-manifest:{version-edge} \
+  mirror \
+  -o /opt/output \
+  -a /opt/registry-auth.txt \
+  -c /opt/cert.pem \
+  -r myregistry:5000 \
+  --rancher-apps-authfile /opt/rancher-apps-auth.txt \
+  --suse-private-registry-authfile /opt/suse-private-registry-auth.txt \
+  --debug
 ----
 
-. Preload with the rest of the images required for SR-IOV:
-+
-.. In this case, we must include the `sr-iov container images for telco workloads (e.g. as a reference, you could get them from {link-telco-cloud-sriov-operator-values}[helm-chart values])
+. Copy the generated RKE2 artifacts from the output directory (`/opt/output`in the example) to the `custom/files` folder to be consumed by EIB for Downstream clusters during the build process:
 +
 [,shell]
 ----
-$ cat > edge-release-images.txt <<EOF
-rancher/hardened-sriov-network-operator:v1.3.0-build20240816
-rancher/hardened-sriov-network-config-daemon:v1.3.0-build20240816
-rancher/hardened-sriov-cni:v2.8.1-build20240820
-rancher/hardened-ib-sriov-cni:v1.1.1-build20240816
-rancher/hardened-sriov-network-device-plugin:v3.7.0-build20240816
-rancher/hardened-sriov-network-resources-injector:v1.6.0-build20240816
-rancher/hardened-sriov-network-webhook:v1.3.0-build20240816
-EOF
+$ cp output/rke2-images*.tar.zst custom/files/
+$ cp output/rke2.linux-amd64.tar.gz custom/files/
+$ cp output/sha256sum-amd64.txt custom/files/
 ----
-+
-.. Using the following {link-lifecycle-save-images}[script] and the list created above, you must generate locally the tarball file with the images required:
-+
-[,shell]
-----
-$ ./edge-save-images.sh -l ./edge-release-images.txt -s registry.suse.com
-Image pull success: registry.suse.com/rancher/hardened-sriov-network-operator:v1.3.0-build20240816
-Image pull success: registry.suse.com/rancher/hardened-sriov-network-config-daemon:v1.3.0-build20240816
-Image pull success: registry.suse.com/rancher/hardened-sriov-cni:v2.8.1-build20240820
-Image pull success: registry.suse.com/rancher/hardened-ib-sriov-cni:v1.1.1-build20240816
-Image pull success: registry.suse.com/rancher/hardened-sriov-network-device-plugin:v3.7.0-build20240816
-Image pull success: registry.suse.com/rancher/hardened-sriov-network-resources-injector:v1.6.0-build20240816
-Image pull success: registry.suse.com/rancher/hardened-sriov-network-webhook:v1.3.0-build20240816
-Creating edge-images.tar.gz with 7 images
-----
-+
-.. Upload your tarball file to your private registry (e.g. `myregistry:5000`) using the following {link-lifecycle-load-images}[script] to preload your private registry with the images downloaded in the previous step:
-+
-[,shell]
-----
-$ tar zxvf edge-release-images-tgz-20240705.tgz
-$ ./edge-load-images.sh -ad edge-release-images-tgz-20240705 -r myregistry:5000
-----
+
+[NOTE]
+====
+The release container image already bundles `/release_manifest.yaml` and `/release_images.yaml` internally, so no additional manifest files need to be provided.
+For full flag reference and advanced usage, see the https://github.com/suse-edge/seactl/blob/main/README.md[seactl documentation].
+====
 
 
 ==== Image creation for air-gap scenarios
@@ -2021,7 +1992,29 @@ spec:
     mirrors:
       docker.io:
         endpoint:
-          - "https://$(PRIVATE_REGISTRY_URL)"
+          - "${PRIVATE_REGISTRY_URL}"
+        rewrite:
+          "^(.*)$": "mirror/$1"
+      registry.suse.com:
+        endpoint:
+          - "${PRIVATE_REGISTRY_URL}"
+        rewrite:
+          "^(.*)$": "mirror/$1"
+      registry.suse.de:
+        endpoint:
+          - "${PRIVATE_REGISTRY_URL}"
+        rewrite:
+          "^(.*)$": "mirror/$1"
+      registry.opensuse.org:
+        endpoint:
+          - "${PRIVATE_REGISTRY_URL}"
+        rewrite:
+          "^(.*)$": "mirror/$1"
+      registry.rancher.com:
+        endpoint:
+          - "${PRIVATE_REGISTRY_URL}"
+        rewrite:
+          "^(.*)$": "mirror/$1"
     configs:
       "192.168.100.22:5000":
         authSecret:
@@ -2112,7 +2105,7 @@ spec:
                     name: sriov-crd
                     namespace: kube-system
                   spec:
-                    chart: oci://$\{PRIVATE_REGISTRY_URL}/sriov-crd
+                    chart: oci://$\{PRIVATE_REGISTRY_URL}/mirror/sriov-crd
                     dockerRegistrySecret:
                       name: privregauth
                     repoCAConfigMap:
@@ -2134,7 +2127,7 @@ spec:
                     name: sriov-network-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://$\{PRIVATE_REGISTRY_URL\}/sriov-network-operator
+                    chart: oci://$\{PRIVATE_REGISTRY_URL\}/mirror/sriov-network-operator
                     dockerRegistrySecret:
                       name: privregauth
                     repoCAConfigMap:

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -503,7 +503,7 @@ $ podman run --rm \
   -c /opt/cert.pem \
   -r myregistry:5000 \
   --rancher-apps-authfile /opt/rancher-apps-auth.txt \
-  --insecure --debug
+  --debug
 ----
 +
 With SUSE Private Registry:


### PR DESCRIPTION
This pull request significantly updates the documentation for preparing air-gap artifacts in the `atip-automated-provision.adoc` file. The new instructions consolidate and simplify the process for mirroring and preloading required images and artifacts by leveraging the `seactl` CLI tool, replacing the previous multi-script, manual workflow. The documentation now provides clear, step-by-step guidance on using `seactl` for both standard and advanced scenarios, including authentication setup.

**Air-gap artifact preparation and registry mirroring:**

* Replaced the manual process (multiple scripts and manual image lists) for preparing and preloading air-gap artifacts with a unified workflow using the `seactl` CLI tool, which handles RKE2 tarball generation, Helm chart OCI mirroring, and container image mirroring in a single command.
* Added detailed instructions for creating authentication files for private registries, Rancher Apps, and SUSE Private Registry, ensuring secure and flexible registry access.
* Provided example `podman` commands to run the release container image with `seactl mirror`, covering both standard and SUSE Private Registry scenarios, and clarified how to handle output artifacts for the build process.
* Removed obsolete sections describing the old, script-based workflow and directory structure, reducing confusion and maintenance burden. (Fbf277f2L459…mated-provision