### PR TITLE
Update ironic ConfigMap name

### DIFF
--- a/asciidoc/troubleshooting/troubleshooting-directed-network-provisioning.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-directed-network-provisioning.adoc
@@ -110,7 +110,7 @@ This is only for debug purposes as it gives full access to the host.
 +
 To enable autologin, the Metal3 helm `global.ironicKernelParams` value should look like: `console=ttyS0 suse.autologin=ttyS0` (depending on the console, `ttyS0` can be changed). Then a redeployment of the Metal^3^ chart should be performed. (Note `ttyS0` is an example, this should match the actual terminal e.g may be `tty1` in many cases on bare metal, this can be verified by looking at the console output from the IPA ramdisk on boot where `/etc/issue` prints the console name).
 +
-Another way to do it is by changing the `IRONIC_KERNEL_PARAMS` parameter on the `ironic-bmo` configmap on the `metal3-system` namespace. This can be easier as it can be done via `kubectl` edit but it will be overwritten when updating the chart. Then the Metal^3^ pod needs to be restarted with `kubectl delete pod -n metal3-system -l app.kubernetes.io/component=ironic`.
+Another way to do it is by changing the `IRONIC_KERNEL_PARAMS` parameter on the `ironic` configmap on the `metal3-system` namespace. This can be easier as it can be done via `kubectl` edit but it will be overwritten when updating the chart. Then the Metal^3^ pod needs to be restarted with `kubectl delete pod -n metal3-system -l app.kubernetes.io/component=ironic`.
 
 * Inject an ssh key for the root user on the IPA.
 + 
@@ -121,7 +121,7 @@ This is only for debug purposes as it gives full access to the host.
 +
 To inject the ssh key for the root user, the Metal^3^ helm `debug.ironicRamdiskSshKey` value should be used. Then a redeployment of the Metal^3^ chart should be performed.
 +
-Another way to do it is by changing the `IRONIC_RAMDISK_SSH_KEY` parameter on the `ironic-bmo configmap` on the `metal3-system` namespace. This can be easier as it can be done via `kubectl` edit but it will be overwritten when updating the chart. Then the Metal^3^ pod needs to be restarted with `kubectl delete pod -n metal3-system -l app.kubernetes.io/component=ironic`
+Another way to do it is by changing the `IRONIC_RAMDISK_SSH_KEY` parameter on the `ironic configmap` on the `metal3-system` namespace. This can be easier as it can be done via `kubectl` edit but it will be overwritten when updating the chart. Then the Metal^3^ pod needs to be restarted with `kubectl delete pod -n metal3-system -l app.kubernetes.io/component=ironic`
 
 
 [NOTE]


### PR DESCRIPTION
Ironic ConfigMap, ironic-bmo, has been renamed to ironic so this commit updates the troubleshooting documentation with the updated ConfigMap name.