### PR TITLE
Pin GHA - docbook.yml

### DIFF
--- a/.github/workflows/docbook.yml
+++ b/.github/workflows/docbook.yml
@@ -37,7 +37,7 @@ jobs:
       allow-build: ${{ steps.select-dc-build.outputs.allow-build }}
       relevant-branches: ${{ steps.select-dc-build.outputs.relevant-branches }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checking basic soundness of DC files
         uses: openSUSE/doc-ci@gha-select-dcs
@@ -66,7 +66,7 @@ jobs:
       matrix:
         dc-files: ${{ fromJson(needs.select-dc-files.outputs.validate-list) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validating DC file(s) ${{ matrix.dc-files }}
         uses: openSUSE/doc-ci@gha-validate
         with:
@@ -84,14 +84,15 @@ jobs:
       matrix:
         dc-files: ${{ fromJson(needs.select-dc-files.outputs.build-list) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Building DC file(s) ${{ matrix.dc-files }}
         id: build-dc
         uses: openSUSE/doc-ci@gha-build
         with:
           dc-files: ${{ matrix.dc-files }}
       - name: Uploading builds as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+ 
         with:
           name: ${{ steps.build-dc.outputs.artifact-name }}
           path: ${{ steps.build-dc.outputs.artifact-dir }}/*
@@ -105,11 +106,11 @@ jobs:
     continue-on-error: true
     steps:
       - name: Downloading all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifact-dir
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:


### PR DESCRIPTION
In order to address the recent supply chain attack risks, this properly pins the versions of all mutable components to a specific SHA.

Closes #2111