### PR TITLE
[release-3.5] Fix version-edge attribute/usage

### DIFF
--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -10,7 +10,7 @@
 // ============================================================================
 
 // == General Edge ==
-:version-edge: 3.5.1
+:version-edge: 3.5
 :version-edge-registry: 3.5
 
 // == Multi-Linux Manager ==

--- a/asciidoc/troubleshooting/collecting-diagnostics-for-support.adoc
+++ b/asciidoc/troubleshooting/collecting-diagnostics-for-support.adoc
@@ -58,7 +58,7 @@ podman run --rm --privileged \
   -v /tmp:/tmp \
   -e NESSIE_LOG_DIR="/tmp" \
   -e NESSIE_ZIP_DIR="/tmp" \
-  registry.suse.com/edge/{version-edge}/nessie:{version-nessie}
+  registry.suse.com/edge/{version-edge-registry}/nessie:{version-nessie}
 ----
 +
 [NOTE]


### PR DESCRIPTION
This was updated in #1087 but version-edge is used to format some URLs which use only the major version e.g 3.5, not the maintenance release e.g 3.5.1

Also it was noted that the nessie registry reference should use version-edge-registry