### PR TITLE
Fix broken SLES Precision Time Protocol link

### DIFF
--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1683,7 +1683,7 @@ Hardware Receive Filter Modes:
 
 Replace `p1p1` with name of the interface to be used for PTP.
 
-The following sections will provide guidance on how to install and configure PTP on SUSE Telco Cloud specifically, but familiarity with basic PTP concepts is expected. For a brief overview of PTP and the implementation included in SUSE Telco Cloud, refer to https://documentation.suse.com/sles/html/SLES-all/cha-tuning-ptp.html[].
+The following sections will provide guidance on how to install and configure PTP on SUSE Telco Cloud specifically, but familiarity with basic PTP concepts is expected. For a brief overview of PTP and the implementation included in SUSE Telco Cloud, refer to the https://documentation.suse.com/sles/15-SP7/html/SLES-all/cha-tuning-ptp.html[SLES Precision Time Protocol documentation].
 
 ==== Install PTP software components
 


### PR DESCRIPTION
The Telco documentation covering the PTP feature, refer to some basic steps shared with any SLES installation. However, the recent SLES 16.0 release came with some documentation refactoring, causing one link to change.

Fix this problem by linking to the still existing SLES 15SP7 documentation. Note that SLES 16.0 has not yet migrated that section.

Also change the text string associated with the link.