### PR TITLE
Update package list in atip-automated-provision and atip-features wit…

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -249,11 +249,19 @@ operatingSystem:
       - $user1Key1
   packages:
     packageList:
-      - jq
-      - dpdk
-      - dpdk-tools
-      - libdpdk-25
-      - pf-bb-config
+      - jq            # Non Telco specific - category: testing/utils
+      - dpdk          # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: testing/utils
+      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - pf-bb-config  # TelCo RAN (gNB: DU) - category: config.
+      - open-iscsi    # Non Telco specific (required by SUSE Storage/Longhorn) - category: runtime
+      - tuned         # Non Telco specific (linux tuning) - category: config.
+      - cpupower      # Non Telco specific (linux tuning - CPU power related settings) - category: config.
+      - rt-tests      # Non Telco specific (RT scheduler-latency testing) - category: testing/utils
+      - linuxptp      # TelCo RAN; time sync (gNB: DU) - category: runtime
+      - synce4l       # TelCo RAN; time sync (gNN: DU) - category: runtime
+      - pciutils      # Non Telco specific (provides "lspci" command) - category: testing/utils
+      - numactl       # Non Telco specific (provides "numatcl" command) - category: testing/utils
     sccRegistrationCode: $SCC_REGISTRATION_CODE
 ----
 

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -250,9 +250,9 @@ operatingSystem:
   packages:
     packageList:
       - jq            # Non Telco specific - category: testing/utils
-      - dpdk          # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
-      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: testing/utils
-      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - dpdk          # TelCo Core-Network UserPlane (5G UPF) and RAN UserPlane (gNB: DU and CU-UP) - category: runtime
+      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) and RAN UserPlane (gNB: DU and CU-UP) - category: testing/utils
+      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) and RAN UserPlane (gNB: DU and CU-UP) - category: runtime
       - pf-bb-config  # TelCo RAN (gNB: DU) - category: config.
       - open-iscsi    # Non Telco specific (required by SUSE Storage/Longhorn) - category: runtime
       - tuned         # Non Telco specific (linux tuning) - category: config.

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1727,9 +1727,9 @@ operatingSystem:
   packages:
     packageList:
       - jq            # Non Telco specific - category: testing/utils
-      - dpdk          # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
-      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: testing/utils
-      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - dpdk          # TelCo Core-Network UserPlane (5G UPF) and RAN UserPlane (gNB: DU and CU-UP) - category: runtime
+      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) and RAN UserPlane (gNB: DU and CU-UP) - category: testing/utils
+      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) and RAN UserPlane (gNB: DU and CU-UP) - category: runtime
       - pf-bb-config  # TelCo RAN (gNB: DU) - category: config.
       - open-iscsi    # Non Telco specific (required by SUSE Storage/Longhorn) - category: runtime
       - tuned         # Non Telco specific (linux tuning) - category: config.

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1726,15 +1726,19 @@ operatingSystem:
       encryptedPassword: $ROOT_PASSWORD
   packages:
     packageList:
-      - jq
-      - dpdk
-      - dpdk-tools
-      - libdpdk-25
-      - pf-bb-config
-      - open-iscsi
-      - tuned
-      - cpupower
-      - linuxptp
+      - jq            # Non Telco specific - category: testing/utils
+      - dpdk          # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: testing/utils
+      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - pf-bb-config  # TelCo RAN (gNB: DU) - category: config.
+      - open-iscsi    # Non Telco specific (required by SUSE Storage/Longhorn) - category: runtime
+      - tuned         # Non Telco specific (linux tuning) - category: config.
+      - cpupower      # Non Telco specific (linux tuning - CPU power related settings) - category: config.
+      - rt-tests      # Non Telco specific (RT scheduler-latency testing) - category: testing/utils
+      - linuxptp      # TelCo RAN; time sync (gNB: DU) - category: runtime
+      - synce4l       # TelCo RAN; time sync (gNN: DU) - category: runtime
+      - pciutils      # Non Telco specific (provides "lspci" command) - category: testing/utils
+      - numactl       # Non Telco specific (provides "numatcl" command) - category: testing/utils
     sccRegistrationCode: $SCC_REGISTRATION_CODE
 ----
 


### PR DESCRIPTION
This pull request updates the package lists in both the `atip-automated-provision.adoc` and `atip-features.adoc` documentation files to include additional packages and detailed comments for each package. The changes aim to clarify the purpose and categorization of each package, as well as to expand the list to cover more utilities and tools relevant for TelCo and non-TelCo environments.

**Documentation updates for package lists:**

- Expanded the `packageList` in both `asciidoc/product/atip-automated-provision.adoc` and `asciidoc/product/atip-features.adoc` to include additional packages such as `rt-tests`, `synce4l`, `pciutils`, and `numactl`, which support testing, time synchronization, and system utilities. [[1]](diffhunk://#diff-be29a01bd67c46510778dffc45b95a4d11f02a7149a4ecdeaa2c17dc957d186eL252-R264) [[2]](diffhunk://#diff-4e9904e95f33f200e9cda23ca2242257c9f68e34746a4130a3211c5a7bb47ce1L1729-R1741)
- Added descriptive comments next to each package entry to specify its use case (e.g., TelCo Core-Network, RAN, non-TelCo), its relevance (e.g., runtime, config, testing/utils), and any special notes (such as dependencies for other systems). [[1]](diffhunk://#diff-be29a01bd67c46510778dffc45b95a4d11f02a7149a4ecdeaa2c17dc957d186eL252-R264) [[2]](diffhunk://#diff-4e9904e95f33f200e9cda23ca2242257c9f68e34746a4130a3211c5a7bb47ce1L1729-R1741)…h detailed comments on Telco-specific categories