### PR TITLE
Improve the PHC to system clock synchronization section

### DIFF
--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1884,10 +1884,11 @@ Check the synchronization status by observing the logs with:
 # journalctl -e -u ptp4l
 ----
 
-===== Configuration of phc2sys
+===== Synchronization of the system clock from PTP
 
-Although not required, it is recommended that you fully complete the configuration of `ptp4l` before moving to `phc2sys`.
-`phc2sys` does not require a configuration file and its execution parameters can be solely controlled through the `OPTIONS=` variable present in `/etc/sysconfig/ptp4l`, in a similar fashion to `ptp4l`:
+It is important to keep in mind that PTP works by synchronizing NIC local hardware clocks. This does not automatically align the system clock with the GM, as the system clock is derived from a different hardware clock.
+In order to keep the system clock in sync with PTP, `phc2sys` must be run. It is recommended that you fully complete the configuration of `ptp4l` before moving to `phc2sys`.
+`phc2sys` does not require a configuration file by default and its execution parameters can be solely controlled through the `OPTIONS=` variable present in `/etc/sysconfig/ptp4l`, in a similar fashion to `ptp4l`:
 
 [source,]
 ----

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1897,6 +1897,13 @@ OPTIONS="-s $IFNAME -w"
 
 Where `$IFNAME` is the name of the interface already set up in ptp4l that will be used as the source for the system clock. This is used to identify the source PHC.
 
+However, if a specific PTP profile or domain number is used, `phc2sys` might require to be provided with a configuration file in accordance with the one provided to `ptp4l`. In most cases it can also be directly reused with phc2sys:
+
+[source,]
+----
+OPTIONS="-f /etc/ptp4l-G.8275.1.conf -s $IFNAME -w"
+----
+
 [#ptp-capi]
 ==== Cluster API integration
 

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1,6 +1,6 @@
 [#atip-features]
 == Telco features configuration
-:revdate: 2025-08-25
+:revdate: 2026-05-07
 :page-revdate: {revdate}
 :experimental:
 


### PR DESCRIPTION
The existing [42.13.2.3 Configuration of phc2sys](https://documentation.suse.com/suse-edge/3.5/html/edge/atip-features.html#id-configuration-of-phc2sys) isn't particularly refined, expand and improve wording.