### PR TITLE
Update CAPI examples for v1beta2

### DIFF
--- a/asciidoc/components/rke2.adoc
+++ b/asciidoc/components/rke2.adoc
@@ -54,7 +54,7 @@ In those cases, the RKE2 configuration must be applied on the different CRDs inv
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster

--- a/asciidoc/guides/clusterclass.adoc
+++ b/asciidoc/guides/clusterclass.adoc
@@ -52,7 +52,7 @@ The code snippet below illustrates the resource types that must be configured:
 [,yaml,subs="attributes"]
 ----
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: emea-spa-cluster-3
@@ -68,15 +68,15 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: emea-spa-cluster-3
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: emea-spa-cluster-3
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: emea-spa-cluster-3
@@ -87,14 +87,14 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: emea-spa-cluster-3
   namespace: emea-spa
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3MachineTemplate
     name: emea-spa-cluster-3
   replicas: 1
@@ -222,7 +222,7 @@ spec:
         - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-3
@@ -245,7 +245,7 @@ spec:
         format: raw
         url: http://fileserver.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-3
@@ -288,7 +288,7 @@ The clusterclass definition file is defined based on the 3 following resources:
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlaneTemplate
 metadata:
   name: example-controlplane-type2
@@ -296,11 +296,12 @@ metadata:
 spec:
   template:
     spec:
-      infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: Metal3MachineTemplate
-        name: example-controlplane    # This will be replaced by the patch applied in each cluster instances
-        namespace: emea-spa
+      machineTemplate:
+        infrastructureRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+          kind: Metal3MachineTemplate
+          name: example-controlplane    # This will be replaced by the patch applied in each cluster instances
+          namespace: emea-spa
       replicas: 1
       version: {version-kubernetes-rke2}
       rolloutStrategy:
@@ -324,7 +325,7 @@ spec:
             - provider-id=metal3://BAREMETALHOST_UUID
         nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3ClusterTemplate
 metadata:
   name: example-cluster-template-type2
@@ -337,7 +338,7 @@ spec:
         port: 6443
       noCloudProvider: true
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: example-clusterclass-type2
@@ -362,20 +363,20 @@ spec:
           items:
             type: string
   infrastructure:
-    ref:
+    templateRef:
       kind: Metal3ClusterTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       name: example-cluster-template-type2
   controlPlane:
-    ref:
+    templateRef:
       kind: RKE2ControlPlaneTemplate
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       name: example-controlplane-type2
   patches:
     - name: setControlPlaneMachineTemplate
       definitions:
         - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
             kind: RKE2ControlPlaneTemplate
             matchResources:
               controlPlane: true
@@ -387,7 +388,7 @@ spec:
     - name: setControlPlaneEndpoint
       definitions:
         - selector:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
             kind: Metal3ClusterTemplate
             matchResources:
               infrastructureCluster: true  # Added to select InfraCluster
@@ -399,7 +400,7 @@ spec:
     - name: setRegistrationAddress
       definitions:
         - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
             kind: RKE2ControlPlaneTemplate
             matchResources:
               controlPlane: true  # Added to select ControlPlane
@@ -411,7 +412,7 @@ spec:
     - name: setTlsSan
       definitions:
         - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
             kind: RKE2ControlPlaneTemplate
             matchResources:
               controlPlane: true  # Added to select ControlPlane
@@ -423,7 +424,7 @@ spec:
     - name: updateAdditionalUserData
       definitions:
         - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
             kind: RKE2ControlPlaneTemplate
             matchResources:
               controlPlane: true
@@ -556,7 +557,7 @@ The variables defined previously in the template (clusterclass definition file) 
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: emea-spa-cluster-3
@@ -565,7 +566,10 @@ metadata:
     cluster-api.cattle.io/rancher-auto-import: "true"
 spec:
   topology:
-    class: example-clusterclass-type2  # Correct way to reference ClusterClass
+
+    classRef:
+
+      name: example-clusterclass-type2  # Correct way to reference ClusterClass
     version: {version-kubernetes-rke2}
     controlPlane:
       replicas: 1
@@ -579,7 +583,7 @@ spec:
           - 192.168.122.203
           - https://192.168.122.203.sslip.io
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-3-machinetemplate
@@ -602,7 +606,7 @@ spec:
         format: raw
         url: http://fileserver.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-3

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -674,7 +674,7 @@ The following block is the cluster definition, where the networking can be confi
 
 [,yaml]
 ----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -692,11 +692,11 @@ spec:
         - 10.96.0.0/12
         - fd00:bad:bad:cafe::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ----
@@ -714,7 +714,7 @@ The `Metal3Cluster` object specifies the control-plane endpoint (replacing the `
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -734,7 +734,7 @@ The last block of information contains the Kubernetes version to be used. `$\{RK
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -744,10 +744,11 @@ metadata:
   }
 
 spec:
+  machineTemplate:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: $\{RKE2_VERSION}
   rolloutStrategy:
@@ -816,7 +817,7 @@ The `Metal3MachineTemplate` object specifies the following information:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -840,7 +841,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -976,7 +977,7 @@ Below is the cluster definition, where the cluster network can be configured usi
 
 [,yaml]
 ----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -994,11 +995,11 @@ spec:
         - 10.96.0.0/12
         - fd00:5678:8765:4321::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ----
@@ -1014,7 +1015,7 @@ See the https://documentation.suse.com/cloudnative/cluster-api/latest/en/tutoria
 The `Metal3Cluster` object specifies the control-plane endpoint that uses the `VIP` address already reserved (replacing the `$\{EDGE_VIP_ADDRESS_IPV4\}`) to be configured and the `noCloudProvider` because the three bare-metal nodes are used.
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -1043,7 +1044,7 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
@@ -1053,7 +1054,7 @@ metadata:
   }
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3MachineTemplate
     name: multinode-cluster-controlplane
   replicas: 3
@@ -1212,7 +1213,7 @@ The `Metal3MachineTemplate` object specifies the following information:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -1236,7 +1237,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -1259,7 +1260,7 @@ A `MachineDeployment`:
 
 [,yaml]
 ----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   labels:
@@ -1282,22 +1283,24 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
           kind: RKE2ConfigTemplate
           name: multinode-cluster-workers
       clusterName: multinode-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3MachineTemplate
         name: multinode-cluster-workers
-      nodeDrainTimeout: 0s
+      deletion:
+
+        nodeDrainTimeoutSeconds: 0
       version: ${RKE2_VERSION}
 ----
 
 The RKE2ConfigTemplate` object specifies the configuration template to be used for multinode cluster worker nodes. 
 [,yaml]
 ----
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: multinode-cluster-workers
@@ -1340,7 +1343,7 @@ The `Metal3MachineTemplate` object contain references to `dataTemplate`, `hostSe
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-workers
@@ -1364,7 +1367,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-workers-template
@@ -1634,14 +1637,14 @@ With all these changes mentioned, the `RKE2ControlPlane` block in the `capi-prov
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
@@ -1862,14 +1865,14 @@ With all these changes mentioned, the `RKE2ControlPlane` block in the `capi-prov
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
@@ -1987,14 +1990,14 @@ data:
   username: $\{REGISTRY_USERNAME}
   password: $\{REGISTRY_PASSWORD}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1907,14 +1907,14 @@ Whenever a cluster is deployed through a management cluster and directed network
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -81,14 +81,14 @@ The changes required to upgrade the `RKE2` cluster using the automated workflow 
 
 [,yaml]
 ----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   version: ${RKE2_NEW_VERSION}
@@ -142,7 +142,7 @@ spec:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -494,7 +494,7 @@ NOTE: For simplicity this example assumes a single-node control plane where the 
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: sample-cluster
@@ -510,15 +510,15 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: sample-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: sample-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: sample-cluster
@@ -529,14 +529,14 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: sample-cluster
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3MachineTemplate
     name: sample-cluster-controlplane
   replicas: 1
@@ -574,7 +574,7 @@ spec:
                 [Install]
                 WantedBy=multi-user.target
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: sample-cluster-controlplane
@@ -593,7 +593,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/SLE-Micro-eib-output.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: sample-cluster-controlplane-template
@@ -641,7 +641,7 @@ Similar to the control plane deployment, we define a YAML manifest which contain
 
 [,yaml,subs="attributes"]
 ----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   labels:
@@ -666,10 +666,12 @@ spec:
           name: sample-cluster-workers
       clusterName: sample-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3MachineTemplate
         name: sample-cluster-workers
-      nodeDrainTimeout: 0s
+      deletion:
+
+        nodeDrainTimeoutSeconds: 0
       version: {version-kubernetes-rke2}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
@@ -710,7 +712,7 @@ spec:
                     [Install]
                     WantedBy=multi-user.target
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: sample-cluster-workers
@@ -729,7 +731,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/SLE-Micro-eib-output.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: sample-cluster-workers-template

--- a/asciidoc/tips/metal3.adoc
+++ b/asciidoc/tips/metal3.adoc
@@ -69,7 +69,7 @@ Both https://doc.crds.dev/github.com/metal3-io/cluster-api-provider-metal3/infra
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: foobar-cluster-controlplane
@@ -83,7 +83,7 @@ spec:
           cluster: foobar
 <snip>
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: foobar-cluster-worker


### PR DESCRIPTION
Migrate the resources as described in https://documentation.suse.com/cloudnative/cluster-api/v0.26/en/tutorials/capi-v1beta2.html