### PR TITLE
metal3: document airgap IPA image configuration with hauler

### DIFF
--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -36,6 +36,7 @@
 :version-nvidia-device-plugin: 0.14.5
 :version-kiwi-builder: 10.2.29.1
 :version-private-registry: 1.1.1
+:version-ipa: 3.0.8
 
 // == Nessie ==
 :version-nessie: 1.0.0

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -1086,6 +1086,63 @@ pod/private-registry-harbor-registry-5648b9d89-wdswz      2/2     Running   0   
 pod/private-registry-harbor-trivy-0                       1/1     Running   0          4m30s
 ----
 
+== Metal^3^ Installation [[metal3-install]]
+
+When deploying Metal^3^ in an air-gapped environment using EIB and Hauler, special configuration is required for the Ironic Python Agent (IPA) image. The IPA image is used by Metal^3^ for bare-metal host inspection and provisioning.
+
+[NOTE]
+====
+For more information about Metal^3^ installation and configuration, including MetalLB setup, see <<quickstart-metal3>>.
+====
+
+To include Metal^3^ in an air-gapped deployment, you need to:
+
+1. Add the Metal^3^ Helm chart to your definition file
+2. Add the IPA image to the embedded artifact registry
+3. Create a Helm values file with `useHauler: true`
+
+Add the following to the `kubernetes.helm.charts` section of your definition file:
+
+[,yaml,subs="attributes"]
+----
+  helm:
+    charts:
+      - name: metal3
+        version: {version-metal3-chart}
+        targetNamespace: metal3-system
+        createNamespace: true
+        repositoryName: suse-edge-charts
+        installationNamespace: kube-system
+        valuesFile: metal3-values.yaml
+----
+
+Add the IPA image to the `embeddedArtifactRegistry.images` section:
+
+[,yaml,subs="attributes"]
+----
+embeddedArtifactRegistry:
+  images:
+    - name: registry.suse.com/edge/{version-edge-registry}/ironic-python-agent:{version-ipa}
+----
+
+Create a Helm values file for Metal^3^:
+
+[,shell]
+----
+cat << EOF > $CONFIG_DIR/kubernetes/helm/values/metal3-values.yaml
+global:
+  ironicIP: <STATIC_IRONIC_IP>
+metal3-ironic:
+  ipa:
+    useHauler: true
+EOF
+----
+
+[IMPORTANT]
+====
+The `metal3-ironic.ipa.useHauler` value **must** be set to `true` (boolean value) when deploying in air-gapped environments using EIB/Hauler. This instructs Metal^3^ to retrieve the IPA image from the embedded artifact registry instead of attempting to download it from the internet.
+====
+
 == Troubleshooting
 
 If you run into any issues while building the images or are looking to further test and debug the process, please refer to the https://github.com/suse-edge/edge-image-builder/tree/release-1.1/docs[upstream documentation].

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -868,6 +868,8 @@ global:
   enable_vmedia_tls: false
   additionalTrustedCAs: false
 metal3-ironic:
+  ipa:
+    useHauler: true
   global:
     predictableNicNames: "true"
   persistence:
@@ -875,6 +877,11 @@ metal3-ironic:
       size: "5Gi"
 
 ----
++
+[IMPORTANT]
+====
+The `metal3-ironic.ipa.useHauler` value **must** be set to `true` (boolean value) in air-gapped environments. This instructs Metal^3^ to retrieve the Ironic Python Agent (IPA) image from the embedded artifact registry instead of attempting to download it from the internet. The IPA image must also be included in the `embeddedArtifactRegistry.images` list as shown in the definition file example above.
+====
 
 [#metal3-media-server]
 [NOTE]
@@ -1208,6 +1215,7 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.10.2
     - name: registry.rancher.com/rancher/scc-operator:v0.3.1
     - name: registry.rancher.com/rancher/kubectl:v1.33.1
+    - name: registry.suse.com/edge/{version-edge-registry}/ironic-python-agent:{version-ipa}
 ----
 
 [#mgmt-cluster-custom-folder-airgap]


### PR DESCRIPTION
When using EIB/hauler to install metal3 in airgap environments, the ironic-python-agent (IPA) image must be:
- Added to the embedded artifact registry images list
- Configured to use hauler via metal3-ironic.ipa.useHauler: true

Changes:
- Add version-ipa attribute (3.0.8) to versions.adoc for templating
- Add Metal3 Installation section to air-gapped-eib-deployments.adoc with configuration snippets and useHauler requirement
- Update atip-management-cluster.adoc to include IPA image in embeddedArtifactRegistry and useHauler in metal3.yaml values