### PR TITLE
Fix publishing workflows

### DIFF
--- a/.github/workflows/docbook.yml
+++ b/.github/workflows/docbook.yml
@@ -117,6 +117,13 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [select-dc-files, build-html]
     steps:
+      - name: Checkout repo (for root index.html)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Only need the landing page; sparse-checkout keeps the workspace tidy.
+          sparse-checkout: |
+            index.html
+          sparse-checkout-cone-mode: false
       - name: Download all build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -128,11 +135,11 @@ jobs:
         # Each DC file produces a self-contained build with its own index.html,
         # so flavors must live in separate subdirectories on gh-pages —
         # otherwise their filenames would collide. Result:
+        #   site/index.html       → https://suse-edge.github.io/   (landing page)
         #   site/edge/index.html  → https://suse-edge.github.io/edge/
         #   site/telco/index.html → https://suse-edge.github.io/telco/
-        # Note: this changes URLs from the pre-split layout (HTML at root).
-        # Add a root index.html under asciidoc/ (or wherever the build pulls
-        # static assets) if you want a landing page at suse-edge.github.io/.
+        # The root index.html is copied from the repo so it stays under
+        # version control and rendering is deterministic.
         run: |
           set -euo pipefail
           mkdir -p site
@@ -149,6 +156,12 @@ jobs:
           if [ "$found" -eq 0 ]; then
             echo "No site-* artifacts found — nothing to publish." >&2
             exit 1
+          fi
+          if [ -f index.html ]; then
+            cp index.html site/index.html
+            echo "Copied root landing page into site/index.html"
+          else
+            echo "WARNING: no root index.html in repo — gh-pages will have no landing page." >&2
           fi
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3

--- a/.github/workflows/docbook.yml
+++ b/.github/workflows/docbook.yml
@@ -128,26 +128,44 @@ jobs:
           pattern: site-*
           path: downloads
       - name: Stage gh-pages site
-        # Each DC file produces a self-contained build with its own index.html,
-        # so flavors must live in separate subdirectories on gh-pages —
-        # otherwise their filenames would collide. Result:
-        #   site/index.html       → https://suse-edge.github.io/   (landing page)
-        #   site/edge/index.html  → https://suse-edge.github.io/edge/
-        #   site/telco/index.html → https://suse-edge.github.io/telco/
+        # gha-build's artifact contains html/<book>/ (multi-page) and
+        # single-html/<book>/ (single-page) inside each downloaded artifact
+        # dir. Promote the multi-page tree to site/<flavor>/ so each flavor's
+        # HTML lives at clean URLs:
+        #   site/index.html              → https://suse-edge.github.io/
+        #   site/edge/index.html         → https://suse-edge.github.io/edge/
+        #   site/edge/single-page/...    → https://suse-edge.github.io/edge/single-page/
+        #   site/telco/index.html        → https://suse-edge.github.io/telco/
+        #   site/telco/single-page/...   → https://suse-edge.github.io/telco/single-page/
+        # The book directory name comes from each DC file's MAIN attribute,
+        # so we discover it via glob rather than assuming it equals $flavor.
         # The root index.html is copied from the repo so it stays under
         # version control and rendering is deterministic.
         run: |
           set -euo pipefail
-          mkdir -p site
           shopt -s nullglob
+          mkdir -p site
           found=0
           for d in downloads/site-*; do
             [ -d "$d" ] || continue
             flavor=$(basename "$d")
             flavor=${flavor#site-}
-            mv "$d" "site/${flavor}"
+
+            html_books=("$d"/html/*/)
+            if [ ${#html_books[@]} -ne 1 ]; then
+              echo "ERROR: expected exactly one html/<book>/ dir in $d, found ${#html_books[@]}" >&2
+              exit 1
+            fi
+            mv "${html_books[0]%/}" "site/$flavor"
+
+            single_books=("$d"/single-html/*/)
+            if [ ${#single_books[@]} -eq 1 ]; then
+              mv "${single_books[0]%/}" "site/$flavor/single-page"
+            fi
+
+            rm -rf "$d"
             found=$((found + 1))
-            echo "Staged flavor: ${flavor}"
+            echo "Staged flavor: $flavor"
           done
           if [ "$found" -eq 0 ]; then
             echo "No site-* artifacts found — nothing to publish." >&2

--- a/.github/workflows/docbook.yml
+++ b/.github/workflows/docbook.yml
@@ -22,11 +22,13 @@ on:
       - 'DC-*'
       - 'xml/**'
       - 'adoc/**'
+      - 'asciidoc/**'
       - 'images/src/**'
       - '**/DC-*'
       - '**/xml/**'
       - '**/adoc/**'
       - '**/images/src/**'
+      - '.github/workflows/docbook.yml'
 
 jobs:
   select-dc-files:
@@ -77,9 +79,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [select-dc-files, validate]
     if: ${{ needs.select-dc-files.outputs.allow-build == 'true' }}
-    outputs:
-      artifact-name: ${{ steps.build-dc.outputs.artifact-name }}
-      artifact-dir: ${{ steps.build-dc.outputs.artifact-dir }}
     strategy:
       matrix:
         dc-files: ${{ fromJson(needs.select-dc-files.outputs.build-list) }}
@@ -90,30 +89,73 @@ jobs:
         uses: openSUSE/doc-ci@44a20400dc813c17b3683a3d445b726e77cc9d09 # gha-build
         with:
           dc-files: ${{ matrix.dc-files }}
+      # Derive a human-readable "flavor" from the DC file path so each
+      # matrix run produces a distinctly-named artifact (e.g. site-edge,
+      # site-telco). The upstream gha-build artifact-name is `build-<sha1>`,
+      # which is unique but opaque — no good for picking a publish layout.
+      - name: Compute flavor name
+        id: flavor
+        run: |
+          dc='${{ matrix.dc-files }}'
+          base=$(basename "$dc")
+          flavor="${base#DC-}"
+          echo "flavor=${flavor}" >> "$GITHUB_OUTPUT"
       - name: Uploading builds as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ${{ steps.build-dc.outputs.artifact-name }}
+          name: site-${{ steps.flavor.outputs.flavor }}
           path: ${{ steps.build-dc.outputs.artifact-dir }}/*
           retention-days: 3
 
 
   publish:
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    # Only publish on pushes to main — never from PRs (PR previews must not
+    # overwrite the live site, and the token is read-only on fork PRs anyway)
+    # and never from release-3.* pushes (those branches validate/build but
+    # are not the source of the published site).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [select-dc-files, build-html]
-    continue-on-error: true
     steps:
-      - name: Downloading all build artifacts
+      - name: Download all build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: artifact-dir
+          # Match the names produced by build-html. v4 places each artifact
+          # in <path>/<artifact-name>/, e.g. downloads/site-edge/index.html.
+          pattern: site-*
+          path: downloads
+      - name: Stage gh-pages site
+        # Each DC file produces a self-contained build with its own index.html,
+        # so flavors must live in separate subdirectories on gh-pages —
+        # otherwise their filenames would collide. Result:
+        #   site/edge/index.html  → https://suse-edge.github.io/edge/
+        #   site/telco/index.html → https://suse-edge.github.io/telco/
+        # Note: this changes URLs from the pre-split layout (HTML at root).
+        # Add a root index.html under asciidoc/ (or wherever the build pulls
+        # static assets) if you want a landing page at suse-edge.github.io/.
+        run: |
+          set -euo pipefail
+          mkdir -p site
+          shopt -s nullglob
+          found=0
+          for d in downloads/site-*; do
+            [ -d "$d" ] || continue
+            flavor=$(basename "$d")
+            flavor=${flavor#site-}
+            mv "$d" "site/${flavor}"
+            found=$((found + 1))
+            echo "Staged flavor: ${flavor}"
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No site-* artifacts found — nothing to publish." >&2
+            exit 1
+          fi
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: artifact-dir
+          publish_dir: site
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/.github/workflows/docbook.yml
+++ b/.github/workflows/docbook.yml
@@ -34,10 +34,14 @@ jobs:
   select-dc-files:
     runs-on: ubuntu-latest
     outputs:
-      validate-list: ${{ steps.select-dc-validate.outputs.dc-list }}
-      build-list: ${{ steps.select-dc-build.outputs.dc-list }}
-      allow-build: ${{ steps.select-dc-build.outputs.allow-build }}
-      relevant-branches: ${{ steps.select-dc-build.outputs.relevant-branches }}
+      # gha-select-dcs `mode: list-validate` enumerates every DC-* file in the
+      # repo (deduplicated by content hash). It does not depend on SUSE's
+      # central doc config — unlike `mode: list-build`, which queries
+      # SUSEdoc/susedoc.github.io's config.xml and disables building unless
+      # the repo+branch is registered there. suse-edge is not part of that
+      # central pipeline (it publishes via gh-pages from this repo), so
+      # we use the validate list as the build list too.
+      dc-list: ${{ steps.select-dcs.outputs.dc-list }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -46,18 +50,11 @@ jobs:
         with:
           mode: soundness
 
-      - name: Selecting DC files to validate
-        id: select-dc-validate
+      - name: Listing DC files
+        id: select-dcs
         uses: openSUSE/doc-ci@e349aced35306105cd981adfa9243836deb119ea # gha-select-dcs
         with:
           mode: list-validate
-
-      - name: Selecting DC files to build
-        id: select-dc-build
-        uses: openSUSE/doc-ci@e349aced35306105cd981adfa9243836deb119ea # gha-select-dcs
-        with:
-          mode: list-build
-          original-org: SUSE
 
   validate:
     runs-on: ubuntu-latest
@@ -66,7 +63,7 @@ jobs:
       # don't cancel all validation runners when one of them fails, we want full results
       fail-fast: false
       matrix:
-        dc-files: ${{ fromJson(needs.select-dc-files.outputs.validate-list) }}
+        dc-files: ${{ fromJson(needs.select-dc-files.outputs.dc-list) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Validating DC file(s) ${{ matrix.dc-files }}
@@ -78,10 +75,9 @@ jobs:
   build-html:
     runs-on: ubuntu-latest
     needs: [select-dc-files, validate]
-    if: ${{ needs.select-dc-files.outputs.allow-build == 'true' }}
     strategy:
       matrix:
-        dc-files: ${{ fromJson(needs.select-dc-files.outputs.build-list) }}
+        dc-files: ${{ fromJson(needs.select-dc-files.outputs.dc-list) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Building DC file(s) ${{ matrix.dc-files }}

--- a/asciidoc/DC-edge
+++ b/asciidoc/DC-edge
@@ -12,7 +12,7 @@ ADOC_POST=yes
 ADOC_TYPE=book
 
 # Set the flavor
-# ADOC_ATTRIBUTES="--attribute flavor=edge"
+ADOC_ATTRIBUTES="--attribute flavor=edge"
 
 # Stylesheets
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/asciidoc/DC-telco
+++ b/asciidoc/DC-telco
@@ -12,7 +12,7 @@ ADOC_POST=yes
 ADOC_TYPE=book
 
 # Set the flavor
-# ADOC_ATTRIBUTES="--attribute flavor=telco"
+ADOC_ATTRIBUTES="--attribute flavor=telco"
 
 # Stylesheets
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -1086,6 +1086,7 @@ pod/private-registry-harbor-registry-5648b9d89-wdswz      2/2     Running   0   
 pod/private-registry-harbor-trivy-0                       1/1     Running   0          4m30s
 ----
 
+ifeval::["{flavor}" == "telco"]
 == Metal^3^ Installation [[metal3-install]]
 
 When deploying Metal^3^ in an air-gapped environment using EIB and Hauler, special configuration is required for the Ironic Python Agent (IPA) image. The IPA image is used by Metal^3^ for bare-metal host inspection and provisioning.
@@ -1142,6 +1143,7 @@ EOF
 ====
 The `metal3-ironic.ipa.useHauler` value **must** be set to `true` (boolean value) when deploying in air-gapped environments using EIB/Hauler. This instructs Metal^3^ to retrieve the IPA image from the embedded artifact registry instead of attempting to download it from the internet.
 ====
+endif::[]
 
 == Troubleshooting
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SUSE Edge Documentation Preview</title>
+<style>
+  :root {
+    --suse-green: #30ba78;
+    --suse-dark: #0c322c;
+    --warn-bg: #fff8e1;
+    --warn-border: #f9a825;
+    --warn-text: #8a5a00;
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+    max-width: 720px;
+    margin: 3rem auto;
+    padding: 0 1.5rem;
+    line-height: 1.6;
+    color: #1a1a1a;
+  }
+  h1 { color: var(--suse-dark); margin-bottom: 0.25rem; }
+  h2 { color: var(--suse-dark); margin-top: 2.5rem; }
+  .subtitle { color: #666; margin-top: 0; }
+  .warning {
+    background: var(--warn-bg);
+    border-left: 4px solid var(--warn-border);
+    padding: 1rem 1.25rem;
+    margin: 1.5rem 0;
+    border-radius: 4px;
+  }
+  .warning strong { color: var(--warn-text); }
+  .warning p { margin: 0.5rem 0; }
+  ul.previews { padding-left: 0; list-style: none; }
+  ul.previews li {
+    margin: 0.75rem 0;
+    padding: 0.75rem 1rem;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    transition: border-color 0.15s ease;
+  }
+  ul.previews li:hover { border-color: var(--suse-green); }
+  ul.previews a {
+    color: var(--suse-green);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 1.05rem;
+  }
+  ul.previews a:hover { text-decoration: underline; }
+  ul.previews .desc { display: block; color: #555; font-weight: normal; font-size: 0.9rem; margin-top: 0.25rem; }
+  a { color: var(--suse-green); }
+  footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #eee; font-size: 0.85rem; color: #666; }
+</style>
+</head>
+<body>
+<h1>SUSE Edge Documentation</h1>
+<p class="subtitle">Preview builds from the development branch</p>
+
+<div class="warning">
+  <p><strong>Pre-release documentation under active development.</strong></p>
+  <p>This site hosts in-development documentation rendered automatically from the latest sources in <a href="https://github.com/suse-edge/suse-edge.github.io">suse-edge/suse-edge.github.io</a>. Content is incomplete, may be inaccurate, and can change without notice.</p>
+  <p>For official, released documentation, please refer to <a href="https://documentation.suse.com/">documentation.suse.com</a>.</p>
+</div>
+
+<h2>Available previews</h2>
+<ul class="previews">
+  <li>
+    <a href="edge/">SUSE Edge</a>
+    <span class="desc">Preview build of the SUSE Edge documentation set.</span>
+  </li>
+  <li>
+    <a href="telco/">SUSE Telco Cloud</a>
+    <span class="desc">Preview build of the SUSE Telco Cloud documentation set.</span>
+  </li>
+</ul>
+
+<footer>
+  Generated from <a href="https://github.com/suse-edge/suse-edge.github.io">suse-edge/suse-edge.github.io</a> &middot; Official docs: <a href="https://documentation.suse.com/">documentation.suse.com</a>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
Unfortunately it seems that publishing to https://suse-edge.github.io/ has been broken since #1083 merged - this aims to fix that, and also adjust the preview build to account for the recent changes in #1097

The output of these changes can be viewed at https://hardys.github.io/suse-edge.github.io/