### PR TITLE
Sets the right SCTP header level

### DIFF
--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -2477,7 +2477,7 @@ The script must run every time the GM changes.
 ====
 
 [#sctp]
-=== SCTP - Stream Control Transmission Protocol
+== SCTP - Stream Control Transmission Protocol
 From https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol[Stream Control Transmission Protocol - Wikipedia]
 
 [quote]


### PR DESCRIPTION
SCTP chapter was created one level below it should be (and so it appears inside the PTP chapter). This PR solves this doc bug.