### PR TITLE
Release Notes updates for 3.6

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -12,15 +12,15 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-SUSE Edge 3.6 is a tightly integrated and comprehensively validated end-to-end solution for addressing the unique challenges of the deployment of infrastructure and cloud-native applications at the edge. Its driving focus is to provide an opinionated, yet highly flexible, highly scalable, and secure platform that spans initial deployment image building, node provisioning and onboarding, application deployment, observability, and lifecycle management.
+{product} 3.6 is a tightly integrated and comprehensively validated end-to-end solution for addressing the unique challenges of the deployment of infrastructure and cloud-native applications at the edge. Its driving focus is to provide an opinionated, yet highly flexible, highly scalable, and secure platform that spans initial deployment image building, node provisioning and onboarding, application deployment, observability, and lifecycle management.
 
 The solution is designed with the notion that there is no "one-size-fits-all" edge platform due to our customers’ widely varying requirements and expectations. Edge deployments push us to solve, and continually evolve, some of the most challenging problems, including massive scalability, restricted network availability, physical space constraints, new security threats and attack vectors, variations in hardware architecture and system resources, the requirement to deploy and interface with legacy infrastructure and applications, and customer solutions that have extended lifespans.
 
-SUSE Edge is built on best-of-breed open source software from the ground up, consistent with both our 30-year history in delivering secure, stable, and certified SUSE Linux platforms and our experience in providing highly scalable and feature-rich Kubernetes management with our Rancher portfolio. SUSE Edge builds on-top of these capabilities to deliver functionality that can address a wide number of market segments, including retail, medical, transportation, logistics, telecommunications, smart manufacturing, and Industrial IoT.
+{product} is built on best-of-breed open source software from the ground up, consistent with both our 30-year history in delivering secure, stable, and certified SUSE Linux platforms and our experience in providing highly scalable and feature-rich Kubernetes management with our Rancher portfolio. {product} builds on-top of these capabilities to deliver functionality that can address a wide number of market segments, including retail, medical, transportation, logistics, telecommunications, smart manufacturing, and Industrial IoT.
 
-For more information on product support lifecycle updates for SUSE Edge, see link:https://www.suse.com/lifecycle/#suse-edge-36[Product Support Lifecycle].
+For more information on product support lifecycle updates for {product}, see link:https://www.suse.com/lifecycle/#suse-edge-36[Product Support Lifecycle].
 
-NOTE: SUSE Telco Cloud (formerly known as SUSE Edge for Telco) is a derivative of SUSE Edge, with additional optimizations and components that enable the platform to address the requirements found in telecommunications use-cases. Unless explicitly stated, all the release notes are applicable for both SUSE Edge 3.6, and SUSE Telco Cloud 3.6.
+NOTE: SUSE Telco Cloud is a derivative of SUSE Edge, with additional optimizations and components that enable the platform to address the requirements found in telecommunications use-cases.
 
 = About
 
@@ -28,9 +28,9 @@ These Release Notes are, unless explicitly specified and explained, identical ac
 
 Entries are only listed once, but they can be referenced in several places if they are important and belong to more than one section. Release notes usually only list changes that happened between two subsequent releases. Certain important entries from the release notes of previous product versions may be repeated. To make these entries easier to identify, they contain a note to that effect.
 
-However, repeated entries are provided as a courtesy only. Therefore, if you are skipping one or more releases, check the release notes of the skipped releases also. If you are only reading the release notes of the current release, you could miss important changes that may affect system behavior. SUSE Edge versions are defined as x.y.z, where 'x' denotes the major version, 'y' denotes the minor, and 'z' denotes the patch version, also known as the "z-stream". SUSE Edge product lifecycles are defined based around a given minor release, e.g. "3.6", but ship with subsequent patch updates through its lifecycle, e.g. "3.6.1".
+However, repeated entries are provided as a courtesy only. Therefore, if you are skipping one or more releases, check the release notes of the skipped releases also. If you are only reading the release notes of the current release, you could miss important changes that may affect system behavior. {product} versions are defined as x.y.z, where 'x' denotes the major version, 'y' denotes the minor, and 'z' denotes the patch version, also known as the "z-stream". {product} product lifecycles are defined based around a given minor release, e.g. "3.6", but ship with subsequent patch updates through its lifecycle, e.g. "3.6.1".
 
-NOTE: SUSE Edge z-stream releases are tightly integrated and thoroughly tested as a versioned stack. Upgrade of any individual components to a different versions to those listed above is likely to result in system downtime. While it's possible to run Edge clusters in untested configurations, it is not recommended, and it may take longer to provide resolution through the support channels.
+NOTE: {product} z-stream releases are tightly integrated and thoroughly tested as a versioned stack. Upgrade of any individual components to a different versions to those listed above is likely to result in system downtime. While it's possible to run Edge clusters in untested configurations, it is not recommended, and it may take longer to provide resolution through the support channels.
 
 [#release-notes-3-6-0]
 = Release 3.6.0
@@ -43,7 +43,7 @@ Maintenance Support End Date: 27th November 2027
 
 EOL: 28th November 2027
 
-Summary: SUSE Edge 3.6.0 is the first release in the SUSE Edge 3.6 release stream.
+Summary: {product} 3.6.0 is the first release in the {product} 3.6 release stream.
 
 == New Features
 
@@ -56,6 +56,9 @@ Summary: SUSE Edge 3.6.0 is the first release in the SUSE Edge 3.6 release strea
 * Updated to Elemental 1.9.0 https://elemental.docs.rancher.com/release-notes/[Elemental Release Notes]
 * Updated to Cert-Manager 1.20.1 https://cert-manager.io/docs/release-notes/[Upstream Release Notes]
 * Updated Metal3/Ironic to 0.15.0 with Ironic 35.0.0
+* BGP mode for MetalLB was a Technology Preview in {product} 3.5 and is now fully supported
+* Precision Time Protocol (PTP) on downstream deployments was a Technology Preview in {product} 3.5 and is now fully supported
+* Single-stack IPv6 downstream cluster deployments are now supported, however note this requires a dual-stack management cluster (single stack management clusters remain a Technology Preview)
 
 == Bug & Security Fixes
 
@@ -68,7 +71,7 @@ Summary: SUSE Edge 3.6.0 is the first release in the SUSE Edge 3.6 release strea
 
 [WARNING]
 ====
-If deploying new clusters, please follow <<guides-kiwi-builder-images>> to build fresh images first as this is now the first step required to create clusters for both {x86-64} and {aarch64} architectures as well as management and downstream clusters.
+If deploying new clusters, please follow <<guides-kiwi-builder-images>> to build fresh images first.  This is suggested for management and downstream clusters to ensure the images contain the latest security and bug fixes.
 ====
 
 * When deploying via Edge Image Builder, `HelmChartConfigs` manifests may fail if they are put in the `kubernetes/manifests` configuration directory. Instead it is recommended to place any `HelmChartConfigs` in `/var/lib/rancher/{rke2/k3s}/server/manifests/` using the EIB os-files interface.
@@ -185,15 +188,13 @@ Unless otherwise stated, these apply to the {version-edge}.0 release and all sub
 
 Unless otherwise stated, these apply to the 3.6.0 release and all subsequent z-stream versions.
 
-* Single-stack IPv6 deployments are a Technology Preview offering and are not subject to the standard scope of support.
-* Precision Time Protocol (PTP) on downstream deployments is a Technology Preview offering and is not subject to standard scope of support.
-* BGP mode for MetalLB is a Technology Preview offering and is not subject to standard scope of support.
+* Single-stack IPv6 management cluster deployments are a Technology Preview offering and are not subject to the standard scope of support.
 
 = Component Verification
 
 The components mentioned above may be verified using the Software Bill Of Materials (SBOM) data - for example, using `cosign` as outlined below:
 
-Download the SUSE Edge Container public key from the https://www.suse.com/support/security/keys/[SUSE Signing Keys source]:
+Download the {product} Container public key from the https://www.suse.com/support/security/keys/[SUSE Signing Keys source]:
 
 [,bash]
 ----
@@ -236,13 +237,13 @@ Refer to the <<day-2-operations>> for details around how to upgrade to a new rel
 
 = Product Support Lifecycle
 
-SUSE Edge is backed by award-winning support from SUSE, an established technology leader with a proven history of delivering enterprise-quality support services. For more information, see https://www.suse.com/lifecycle[https://www.suse.com/lifecycle] and the Support Policy page at https://www.suse.com/support/policy.html[https://www.suse.com/support/policy.html]. If you have any questions about raising a support case, how SUSE classifies severity levels, or the scope of support, please see the Technical Support Handbook at https://www.suse.com/support/handbook/[https://www.suse.com/support/handbook/].
+{product} is backed by award-winning support from SUSE, an established technology leader with a proven history of delivering enterprise-quality support services. For more information, see https://www.suse.com/lifecycle[https://www.suse.com/lifecycle] and the Support Policy page at https://www.suse.com/support/policy.html[https://www.suse.com/support/policy.html]. If you have any questions about raising a support case, how SUSE classifies severity levels, or the scope of support, please see the Technical Support Handbook at https://www.suse.com/support/handbook/[https://www.suse.com/support/handbook/].
 
-SUSE Edge "3.6" is supported for 18-months of production support, with an initial 6-months of "full support", followed by 12-months of "maintenance support".  After these support phases the product reaches "end of life" (EOL) and is no longer supported. More info about the lifecycle phases can be found in the table below:
+{product} "3.6" is supported for 24-months of production support, with an initial 6-months of "full support", followed by 18-months of "maintenance support".  After these support phases the product reaches "end of life" (EOL) and is no longer supported. More info about the lifecycle phases can be found in the table below:
 
 |======
 | *Full Support (6 months)* | Urgent and selected high-priority bug fixes will be released during the full support window, and all other patches (non-urgent, enhancements, new capabilities) will be released via the regular release schedule.
-| *Maintenance Support (12 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
+| *Maintenance Support (18 months)* | During this period, only critical fixes will be released via patches. Other bug fixes may be released at SUSE's discretion but should not be expected.
 | *End of Life (EOL)*  | Once a product release reaches its End of Life date, the customer may continue to use the product within the terms of product licensing agreement.
 Support Plans from SUSE do not apply to product releases past their EOL date.
 |======
@@ -251,11 +252,11 @@ Unless explicitly stated, all components listed are considered Generally Availab
 
 Please note that SUSE must occasionally deprecate features or change API specifications. Reasons for feature deprecation or API change could include a feature being updated or replaced by a new implementation, a new feature set, upstream technology is no longer available, or the upstream community has introduced incompatible changes. It is not intended that this will ever happen within a given minor release (x.z), and so all z-stream releases will maintain API compatibility and feature functionality. SUSE will endeavor to provide deprecation warnings with plenty of notice within the release notes, along with workarounds, suggestions, and mitigations to minimize service disruption.
 
-The SUSE Edge team also welcomes community feedback, where issues can be raised within the respective code repository within https://www.github.com/suse-edge[https://www.github.com/suse-edge].
+The {product} team also welcomes community feedback, where issues can be raised within the respective code repository within https://www.github.com/suse-edge[https://www.github.com/suse-edge].
 
 = Obtaining source code
 
-This SUSE product includes materials licensed to SUSE under the GNU General Public License (GPL) and various other open source licenses. The GPL requires SUSE to provide the source code that corresponds to the GPL-licensed material, and SUSE conforms to all other open-source license requirements. As such, SUSE makes all source code available, and can generally be found in the SUSE Edge GitHub repository (https://www.github.com/suse-edge[https://www.github.com/suse-edge]), the SUSE Rancher GitHub repository (https://www.github.com/rancher[https://www.github.com/rancher]) for dependent components, and specifically for SUSE Linux Micro, the source code is available for download at https://www.suse.com/download/sle-micro/[https://www.suse.com/download/sle-micro] on "Medium 2".
+This SUSE product includes materials licensed to SUSE under the GNU General Public License (GPL) and various other open source licenses. The GPL requires SUSE to provide the source code that corresponds to the GPL-licensed material, and SUSE conforms to all other open-source license requirements. As such, SUSE makes all source code available, and can generally be found in the {product} GitHub repository (https://www.github.com/suse-edge[https://www.github.com/suse-edge]), the SUSE Rancher GitHub repository (https://www.github.com/rancher[https://www.github.com/rancher]) for dependent components, and specifically for SUSE Linux Micro, the source code is available for download at https://www.suse.com/download/sle-micro/[https://www.suse.com/download/sle-micro] on "Medium 2".
 
 = Legal notices
 


### PR DESCRIPTION
Update to use the product name variable as defined in #1097

Also clarify the latest status for tech-previews and adjust the lifecycle since this is an LTS release.