### PR TITLE
Adds the ingress migration details

### DIFF
--- a/asciidoc/components/virtualization.adoc
+++ b/asciidoc/components/virtualization.adoc
@@ -448,7 +448,7 @@ virtualmachine.kubevirt.io "virtctl-example" deleted
 
 == Simple ingress networking
 
-In this section, we show how you can expose virtual machines as standard Kubernetes services and make them available via the Kubernetes ingress service, for example, https://docs.rke2.io/networking/networking_services#nginx-ingress-controller[NGINX with RKE2] or https://docs.k3s.io/networking/networking-services#traefik-ingress-controller[Traefik with K3s]. This document assumes that these components are already configured appropriately and that you have an appropriate DNS pointer, for example, via a wild card, to point at your Kubernetes server nodes or your ingress virtual IP for proper ingress resolution.
+In this section, we show how you can expose virtual machines as standard Kubernetes services and make them available via the Kubernetes ingress service, for example, https://docs.rke2.io/networking/networking_services#ingress-controller[Traefik with RKE2] or https://docs.k3s.io/networking/networking-services#traefik-ingress-controller[Traefik with K3s]. This document assumes that these components are already configured appropriately and that you have an appropriate DNS pointer, for example, via a wild card, to point at your Kubernetes server nodes or your ingress virtual IP for proper ingress resolution.
 
 > NOTE: In {product} 3.1+, if you are using K3s in a multi-server node configuration, you might have needed to configure a MetalLB-based VIP for Ingress; this is not required for RKE2.
 

--- a/asciidoc/day2/migration.adoc
+++ b/asciidoc/day2/migration.adoc
@@ -17,13 +17,13 @@ endif::[]
 :static-edge-version: 3.6.0
 :static-fleet-examples-tag: release-3.6.0
 
-This section explains how to migrate your `management` and `downstream` clusters from `Edge {previous-edge-version}` to `Edge {static-edge-version}`.
+This section explains how to migrate your `management` and `downstream` clusters from `{product} {previous-edge-version}` to `{product} {static-edge-version}`.
 
 [IMPORTANT]
 ====
-Always perform cluster migrations from the `latest Z-stream` release of `Edge {previous-edge-version}`.
+Always perform cluster migrations from the `latest Z-stream` release of `{product} {previous-edge-version}`.
 
-Always migrate to the `Edge {static-edge-version}` release. For subsequent post-migration upgrades, refer to the <<day2-mgmt-cluster, management>>
+Always migrate to the `{product} {static-edge-version}` release. For subsequent post-migration upgrades, refer to the <<day2-mgmt-cluster, management>>
 ifeval::["{flavor}" == "edge"]
 and <<day2-downstream-clusters, downstream>> cluster
 endif::[]
@@ -76,7 +76,7 @@ The `Metal^3^` Helm chart includes the link:https://book.metal3.io/bmo/introduct
 
 However, this approach has certain limitations, particularly the inability to upgrade CRDs in this directory using Helm. For more information, refer to the link:https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations[Helm documentation].
 
-As a result, before upgrading Metal^3^ to an `Edge {static-edge-version}` compatible version, users must manually upgrade the underlying BMO CRDs.
+As a result, before upgrading Metal^3^ to an `{product} {static-edge-version}` compatible version, users must manually upgrade the underlying BMO CRDs.
 
 On a machine with `Helm` installed and `kubectl` configured to point to your `{cluster-type}` cluster:
 
@@ -164,25 +164,25 @@ kubectl delete secret tls-ca-additional -n metal3-system
 
 [IMPORTANT]
 ====
-The `Upgrade Controller` currently supports Edge release migrations only for *non air-gapped management* clusters.
+The `Upgrade Controller` currently supports `{product}` release migrations only for *non air-gapped management* clusters.
 ====
 
 The following topics are covered as part of this section:
 
 <<day2-migration-mgmt-upgrade-controller-prereq>> - prerequisites specific to the `Upgrade Controller`.
 
-<<day2-migration-mgmt-upgrade-controller-migration>> - steps for migrating a `{cluster-type}` cluster to a new Edge version using the `Upgrade Controller`.
+<<day2-migration-mgmt-upgrade-controller-migration>> - steps for migrating a `{cluster-type}` cluster to a new `{product}` version using the `Upgrade Controller`.
 
 [#day2-migration-mgmt-upgrade-controller-prereq]
 ==== Prerequisites
 
-===== Edge {version-edge} Upgrade Controller
+===== {product} {version} Upgrade Controller
 
-Before using the `Upgrade Controller`, you must first ensure that it is running a version that is capable of migrating to the desired Edge release.
+Before using the `Upgrade Controller`, you must first ensure that it is running a version that is capable of migrating to the desired `{product}` release.
 
 To do this:
 
-. If you already have `Upgrade Controller` deployed from a previous Edge release, upgrade its chart:
+. If you already have `Upgrade Controller` deployed from a previous `{product}` release, upgrade its chart:
 +
 [,bash,subs="attributes"]
 ----
@@ -228,11 +228,11 @@ The *key* differences being that:
 
 . The fleets *must be used* from the link:https://github.com/suse-edge/fleet-examples/releases/tag/{static-fleet-examples-tag}[{static-fleet-examples-tag}] release of the `suse-edge/fleet-examples` repository.
 
-. Charts scheduled for an upgrade *must* be upgraded to versions compatible with the `Edge {static-edge-version}` release. For a list of the `Edge {static-edge-version}` components, refer to <<release-notes-3-6-0>>.
+. Charts scheduled for an upgrade *must* be upgraded to versions compatible with the `{product} {static-edge-version}` release. For a list of the `{product} {static-edge-version}` components, refer to <<release-notes-3-6-0>>.
 
 [IMPORTANT]
 ====
-To ensure a successful `Edge {static-edge-version}` migration, it is important that users comply with the points outlined above.
+To ensure a successful `{product} {static-edge-version}` migration, it is important that users comply with the points outlined above.
 ====
 
 ifeval::["{flavor}" == "edge"]
@@ -254,11 +254,11 @@ The *key* differences being that:
 
 . The fleets *must be used* from the link:https://github.com/suse-edge/fleet-examples/releases/tag/{static-fleet-examples-tag}[{static-fleet-examples-tag}] release of the `suse-edge/fleet-examples` repository.
 
-. Charts scheduled for an upgrade *must* be upgraded to versions compatible with the `Edge {static-edge-version}` release. For a list of the `Edge {static-edge-version}` components, refer to <<release-notes-3-6-0>>.
+. Charts scheduled for an upgrade *must* be upgraded to versions compatible with the `{product} {static-edge-version}` release. For a list of the `{product} {static-edge-version}` components, refer to <<release-notes-3-6-0>>.
 
 [IMPORTANT]
 ====
-To ensure a successful `Edge {static-edge-version}` migration, it is important that users comply with the points outlined above.
+To ensure a successful `{product} {static-edge-version}` migration, it is important that users comply with the points outlined above.
 ====
 
 ifeval::["{flavor}" == "edge"]

--- a/asciidoc/day2/upgrade-controller.adoc
+++ b/asciidoc/day2/upgrade-controller.adoc
@@ -18,7 +18,7 @@ endif::[]
 The `Upgrade Controller` currently only supports `Day 2` operations for *non air-gapped management* clusters.
 ====
 
-This section covers how to perform the various `Day 2` operations related to upgrading your `management` cluster from one Edge platform version to another.
+This section covers how to perform the various `Day 2` operations related to upgrading your `management` cluster from one `{product}` platform version to another.
 
 The `Day 2` operations are automated by the <<components-upgrade-controller, Upgrade Controller>> and include:
 
@@ -35,13 +35,13 @@ endif::[]
 
 Before upgrading your `management` cluster, the following prerequisites must be met:
 
-. `SCC registered nodes` - ensure your cluster nodes' OS are registered with a subscription key that supports the OS version specified in the Edge <<release-notes,release>> you intend to upgrade to.
+. `SCC registered nodes` - ensure your cluster nodes' OS are registered with a subscription key that supports the OS version specified in the `{product}` <<release-notes,release>> you intend to upgrade to.
 
 . `Upgrade Controller` - make sure that the `Upgrade Controller` has been deployed on your `management` cluster. For installation steps, refer to <<components-upgrade-controller-installation>>.
 
 === Upgrade
 
-. Determine the Edge <<release-notes,release>> version that you wish to upgrade your `management` cluster to.
+. Determine the `{product}` <<release-notes,release>> version that you wish to upgrade your `management` cluster to.
 
 . In the `management` cluster, deploy an `UpgradePlan` that specifies the desired `release version`. The `UpgradePlan` must be deployed in the namespace of the `Upgrade Controller`.
 +
@@ -70,4 +70,154 @@ There may be use-cases where you would want to make additional configurations ov
 For more information on the actual `upgrade process`, refer to <<components-upgrade-controller-how>>.
 
 For information on how to track the `upgrade process`, refer to <<components-upgrade-controller-how-track>>.
+====
+
+=== Post-Upgrade Steps
+`{product}` upgrades from latest `{previous-edge-version}` z-stream to `{static-edge-version}` can require some final manual steps to be performed after the `Upgrade Controller` has completed the upgrade process. Those are related to the replacement of Ingress-NGINX with Traefik as the single supported ingress controller in `{product}` from `{version}` release.
+
+[NOTE]
+====
+The `Traefik` ingress provider integrated into RKE2/K3s is the only ingress controller supported in `{product} {version}` release, being still possible to temporarily run `Ingress-NGINX` alongside `Traefik` in order to support complex ingress migration scenarios, but only after `{product}` Management and/or Downstream clusters have been upgraded to version `{version}` and for the time required to perform that migration.
+
+RKE2 https://docs.rke2.io/reference/ingress_migration[Ingress NGINX to Traefik Migration] guide provides details on the ingress migration paths available
+once the `Traefik` ingress controller replaces the discontinued `Ingress-NGINX`.
+====
+
+In case the just upgraded Management cluster was not running the `Traefik` ingress controller (but the default Ingress-NGINX one) before triggering the upgrade, it is now then needed to manually deploy `Traefik`.
+
+First we are going to assure the deployed ingress-NGINX instance is properly configured (e.g., to avoid unnecessary hostPort collisions between the pods from the
+two ingress controllers):
+
+[,shell]
+----
+kubectl apply -f - <<- EOF
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-ingress-nginx
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    controller:
+      hostPort:
+        enabled: false  # not needed when exposing through a type:LoadBalancer service
+      config:
+        use-forwarded-headers: "true"
+        enable-real-ip: "true"
+      publishService:
+        enabled: true
+      service:
+        enabled: true
+        type: LoadBalancer
+        externalTrafficPolicy: Local
+EOF
+----
+
+Now we can proceed with the deployment of `Traefik`, through the installation of both `rke2-traefik-crd` and `rke2-traefik` Helm charts.
+[NOTE]
+====
+Deploy these Helm chats through `HelmChart` manifests, as shown below, to assure the `Upgrade Controller` will take care of also upgrading these Helm charts
+in future Management cluster upgrades.
+====
+
+[,shell]
+----
+kubectl apply -f - <<- EOF
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: rke2-traefik-crd
+  namespace: kube-system
+spec:
+  chart: rke2-traefik-crd
+  version: {rke2-traefik-crd Helm chart version}
+  repo: https://rke2-charts.rancher.io
+  bootstrap: false
+  failurePolicy: reinstall
+  backOffLimit: 20
+  targetNamespace: kube-system
+  set:
+    global.cattle.systemDefaultRegistry: registry.rancher.com
+    global.rke2DataDir: /var/lib/rancher/rke2
+    global.systemDefaultRegistry: registry.rancher.com
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: rke2-traefik
+  namespace: kube-system
+spec:
+  chart: rke2-traefik
+  version: {rke2-traefik Helm chart version}
+  repo: https://rke2-charts.rancher.io
+  bootstrap: false
+  failurePolicy: reinstall
+  backOffLimit: 20
+  targetNamespace: kube-system
+  set:
+    global.cattle.systemDefaultRegistry: registry.rancher.com
+    global.rke2DataDir: /var/lib/rancher/rke2
+    global.systemDefaultRegistry: registry.rancher.com
+  valuesContent: |-
+    ingressClass:
+      isDefaultClass: false  # if traefik deployed alongside ingress-nginx
+    ports:
+      web:
+        hostPort: null    # disallow hostPort
+        exposedPort: 80
+      websecure:
+        hostPort: null    # disallow hostPort
+        exposedPort: 443
+    service:
+      enabled: true
+      type: LoadBalancer
+      spec:
+        externalTrafficPolicy: Local
+        allocateLoadBalancerNodePorts: false  # k8s GA from 1.24; supported by MetalLB
+    providers:
+      kubernetesIngressNginx:  # this provider allows traefik to "understand" most of the ingress-nginx annotations
+        enabled: true
+        ingressClass: "rke2-ingress-nginx-migration"
+        controllerClass: "rke2.​cattle.​io/ingress-nginx-migration"
+EOF
+----
+
+The `{rke2-traefik-crd Helm chart version}` and `{rke2-traefik-crd Helm chart version}` are the ones dictated by the RKE2/k3s version
+we have upgraded to.
+
+In the last step, we finally create the MetalLB required objects to expose the `Traefik` service through a LoadBalancer type service:
+
+[,shell]
+----
+kubectl apply -f - <<- EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ingress-ippool-traefik
+  namespace: metallb-system
+spec:
+  addresses:
+  - {EXTERNAL_IP_FOR_TRAEFIK_SERVICE}/32
+  serviceAllocation:
+    priority: 100
+    serviceSelectors:
+    - matchExpressions:
+      - {key: app.kubernetes.io/name, operator: In, values: [rke2-traefik]}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ingress-l2-adv-traefik
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - ingress-ippool-traefik
+EOF
+----
+
+Now both `Traefik` and `Ingress-NGINX` are running side by side, allowing you to safely perform the necessary migration of your ingresses from one to the other.
+
+[IMPORTANT]
+====
+Once all ingresses have been migrated and you no longer need `Ingress-NGINX`, make sure to uninstall it and clean up all related resources to avoid any unnecessary resource consumption on your cluster.
 ====

--- a/asciidoc/guides/metallb-kube-api.adoc
+++ b/asciidoc/guides/metallb-kube-api.adoc
@@ -23,7 +23,7 @@ Since the managed Service is of type `LoadBalancer`, MetalLB assigns it a static
 * Three hosts to deploy RKE2/K3s on top. 
  ** Ensure the hosts have different host names.
  ** For testing, these could be virtual machines
-* At least 2 available IPs in the network (one for the Traefik/Nginx and one for the managed service).
+* At least 2 available IPs in the network (one for the Traefik ingress-controller exposed service and one for the managed service).
 * Helm
 
 == Installing RKE2/K3s
@@ -46,6 +46,7 @@ mkdir -p /etc/rancher/rke2/
 cat <<EOF > /etc/rancher/rke2/config.yaml
 # An example of the config.yaml file for a server node: 
 write-kubeconfig-mode: "0644"
+ingress-controller: traefik
 tls-san:
   - "${VIP_SERVICE_IP}"
   - "https://${VIP_SERVICE_IP}.sslip.io"
@@ -301,9 +302,10 @@ For RKE2:
 
 mkdir -p /etc/rancher/rke2/
 cat <<EOF > /etc/rancher/rke2/config.yaml
-# An example of the config.yaml file for an agent node: 
+# An example of the config.yaml file for an additional server node: 
 server: https://${VIP_SERVICE_IP}:9345
 write-kubeconfig-mode: "0644"
+ingress-controller: traefik
 tls-san:
   - "${VIP_SERVICE_IP}"
   - "https://${VIP_SERVICE_IP}.sslip.io"

--- a/asciidoc/integrations/nvidia-slemicro.adoc
+++ b/asciidoc/integrations/nvidia-slemicro.adoc
@@ -497,6 +497,7 @@ Let us now set up the (optional) Kubernetes configuration by choosing a CNI (whi
 ----
 cat << EOF > kubernetes/config/server.yaml
 cni: cilium
+ingress-controller: traefik
 selinux: true
 EOF
 ----

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -261,7 +261,7 @@ operatingSystem:
       - linuxptp      # TelCo RAN; time sync (gNB: DU) - category: runtime
       - synce4l       # TelCo RAN; time sync (gNN: DU) - category: runtime
       - pciutils      # Non Telco specific (provides "lspci" command) - category: testing/utils
-      - numactl       # Non Telco specific (provides "numatcl" command) - category: testing/utils
+      - numactl       # Non Telco specific (provides "numactl" command) - category: testing/utils
     sccRegistrationCode: $SCC_REGISTRATION_CODE
 ----
 
@@ -385,6 +385,7 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
     |   └ rke2-images-core.linux-amd64.tar.zst
     |   └ rke2-images-multus.linux-amd64.tar.zst
     |   └ rke2-images.linux-amd64.tar.zst
+    |   └ rke2-images-traefik.linux-amd64.tar.zst
     |   └ rke2.linux-amd64.tar.zst
     |   └ sha256sum-amd64.txt
     |   └ performance-settings.sh
@@ -744,13 +745,12 @@ metadata:
   annotations: {
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
   }
-
 spec:
   machineTemplate:
   infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: Metal3MachineTemplate
+    name: single-node-cluster-controlplane
   replicas: 1
   version: $\{RKE2_VERSION}
   rolloutStrategy:
@@ -767,47 +767,98 @@ spec:
         version: 1.4.0
         systemd:
           units:
-            - name: rke2-preinstall.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=rke2-preinstall
-                Wants=network-online.target
-                Before=rke2-install.service
-                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                ExecStartPost=/bin/sh -c "umount /mnt"
-                [Install]
-                WantedBy=multi-user.target
+          - name: rke2-preinstall.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-preinstall
+              Wants=network-online.target
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStartPost=/bin/sh -c "umount /mnt"
+              [Install]
+              WantedBy=multi-user.target
+          # rke2-traefik-deployment.service unit to be removed once "traefik" being the default ingress controller (starting with RKE2 v1.36)
+          - name: rke2-traefik-deployment.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-traefik-deployment
+              Wants=rke2-preinstall.service
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "echo \"ingress-controller: traefik\" >> /etc/rancher/rke2/config.yaml"
+              [Install]
+              WantedBy=multi-user.target
         storage:
+          directories:
+          - path: /var/lib/rancher/rke2/server/manifests
+            overwrite: true
           files:
-            # https://docs.rke2.io/networking/multus_sriov#using-multus-with-cilium
-            - path: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
-              overwrite: true
-              contents:
-                inline: |
-                  apiVersion: helm.cattle.io/v1
-                  kind: HelmChartConfig
-                  metadata:
-                    name: rke2-cilium
-                    namespace: kube-system
-                  spec:
-                    valuesContent: |-
-                      cni:
-                        exclusive: false
-              mode: 0644
-              user:
-                name: root
-              group:
-                name: root
+          # https://docs.rke2.io/networking/multus_sriov#using-multus-with-cilium
+          - path: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChartConfig
+                metadata:
+                  name: rke2-cilium
+                  namespace: kube-system
+                spec:
+                  valuesContent: |-
+                    cni:
+                      exclusive: false
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
+          - path: /var/lib/rancher/rke2/server/manifests/rke2-traefik-config.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChartConfig
+                metadata:
+                  name: rke2-traefik
+                  namespace: kube-system
+                spec:
+                  valuesContent: |-
+                    ingressClass:
+                      isDefaultClass: true
+                    ports:
+                      web:
+                        hostPort: null    # disallow hostPort
+                        exposedPort: 80
+                      websecure:
+                        hostPort: null    # disallow hostPort
+                        exposedPort: 443
+                    service:
+                      enabled: true
+                      type: LoadBalancer
+                      spec:
+                        externalTrafficPolicy: Local
+                        allocateLoadBalancerNodePorts: false  # k8s GA from 1.24; supported by MetalLB
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ----
 
@@ -1038,7 +1089,8 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
 * The advertisement mode to be used by the Load Balancer (`address` uses the L2 implementation), as well as the address to be used (replacing the `$\{EDGE_VIP_ADDRESS\}` with the `VIP` address).
 * The `serverConfig` with the `CNI` plug-in to be used (in this case, `Cilium`), and the additional `VIP` address(es) and name(s) to be listed under `tlsSan`.
 * The agentConfig block contains the `Ignition` format to be used and the `additionalUserData` to be used to configure the `RKE2` node with information like:
-    ** The systemd service named `rke2-preinstall.service` to replace automatically the `BAREMETALHOST_UUID` and `node-name` during the provisioning process using the Ironic information.
+    ** The systemd service named `rke2-preinstall.service` to replace automatically the `BAREMETALHOST_UUID` and `node-name` during the provisioning process using the Ironic information plus adding the `metal3.io/uuid` label to Node objects with the `BareMetalHost` UUID.
+    ** The systemd service named `rke2-traefik-deployment.service` to set the RKE2 `ingress-controller` config. server option in `/etc/rancher/rke2/config.yaml` file to `traefik`.
     ** The `storage` block which contains the Helm charts to be used to install the `MetalLB` and the `endpoint-copier-operator`.
     ** The `metalLB` custom resource file with the `IPaddressPool` and the `L2Advertisement` to be used (replacing `$\{EDGE_VIP_ADDRESS_IPV4\}` with the `VIP` address).
     ** The `endpoint-svc.yaml` file to be used to configure the `kubernetes-vip` service to be used by the `MetalLB` to manage the `VIP` address.
@@ -1082,24 +1134,44 @@ spec:
         version: 1.4.0
         systemd:
           units:
-            - name: rke2-preinstall.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=rke2-preinstall
-                Wants=network-online.target
-                Before=rke2-install.service
-                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                ExecStartPost=/bin/sh -c "umount /mnt"
-                [Install]
-                WantedBy=multi-user.target
+          - name: rke2-preinstall.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-preinstall
+              Wants=network-online.target
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStartPost=/bin/sh -c "umount /mnt"
+              [Install]
+              WantedBy=multi-user.target
+          # rke2-traefik-deployment.service unit to be removed once "traefik" being the default ingress controller (starting with RKE2 v1.36)
+          - name: rke2-traefik-deployment.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-traefik-deployment
+              Wants=rke2-preinstall.service
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "echo \"ingress-controller: traefik\" >> /etc/rancher/rke2/config.yaml"
+              [Install]
+              WantedBy=multi-user.target
         storage:
+          directories:
+          - path: /var/lib/rancher/rke2/server/manifests
+            overwrite: true
           files:
             # https://docs.rke2.io/networking/multus_sriov#using-multus-with-cilium
             - path: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
@@ -1201,9 +1273,40 @@ spec:
                       protocol: TCP
                       targetPort: 6443
                     type: LoadBalancer
+          - path: /var/lib/rancher/rke2/server/manifests/rke2-traefik-config.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChartConfig
+                metadata:
+                  name: rke2-traefik
+                  namespace: kube-system
+                spec:
+                  valuesContent: |-
+                    ingressClass:
+                      isDefaultClass: true
+                    ports:
+                      web:
+                        hostPort: null    # disallow hostPort
+                        exposedPort: 80
+                      websecure:
+                        hostPort: null    # disallow hostPort
+                        exposedPort: 443
+                    service:
+                      enabled: true
+                      type: LoadBalancer
+                      spec:
+                        externalTrafficPolicy: Local
+                        allocateLoadBalancerNodePorts: false  # k8s GA from 1.24; supported by MetalLB
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ----
 
@@ -1248,12 +1351,12 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
 ----
 
 The following yaml files are an example configuration for the worker nodes.
@@ -1322,23 +1425,26 @@ spec:
             version: 1.4.0
             systemd:
               units:
-                - name: rke2-preinstall.service
-                  enabled: true
-                  contents: |
-                    [Unit]
-                    Description=rke2-preinstall
-                    Wants=network-online.target
-                    Before=rke2-install.service
-                    ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                    [Service]
-                    Type=oneshot
-                    User=root
-                    ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                    ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                    ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                    ExecStartPost=/bin/sh -c "umount /mnt"
-                    [Install]
-                    WantedBy=multi-user.target
+              - name: rke2-preinstall.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=rke2-preinstall
+                  Wants=network-online.target
+                  Before=rke2-install.service
+                  ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                  [Service]
+                  Type=oneshot
+                  User=root
+                  ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                  ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                  ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                  ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+                  ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                  ExecStartPost=/bin/sh -c "umount /mnt"
+                  [Install]
+                  WantedBy=multi-user.target
+
 ----
 
 The `Metal3MachineTemplate` object contain references to `dataTemplate`, `hostSelector`, and `image` for the worker nodes:
@@ -1378,12 +1484,12 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
 ----
 
 Once the file is created by joining the previous blocks, run the following command in the management cluster to start provisioning the new three bare-metal hosts:
@@ -1659,7 +1765,7 @@ spec:
     cni: calico
     cniMultusEnable: true
   preRKE2Commands:
-    - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
+  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:
@@ -1668,66 +1774,66 @@ spec:
         version: 1.4.0
         storage:
           files:
-            - path: /var/lib/rancher/rke2/server/manifests/configmap-sriov-custom-auto.yaml
-              overwrite: true
-              contents:
-                inline: |
-                  apiVersion: v1
-                  kind: ConfigMap
-                  metadata:
-                    name: sriov-custom-auto-config
-                    namespace: kube-system
-                  data:
-                    config.json: |
-                      [
-                         {
-                           "resourceName": "$\{RESOURCE_NAME1}",
-                           "interface": "$\{SRIOV-NIC-NAME1}",
-                           "pfname": "$\{PF_NAME1}",
-                           "driver": "$\{DRIVER_NAME1}",
-                           "numVFsToCreate": $\{NUM_VFS1}
-                         },
-                         {
-                           "resourceName": "$\{RESOURCE_NAME2}",
-                           "interface": "$\{SRIOV-NIC-NAME2}",
-                           "pfname": "$\{PF_NAME2}",
-                           "driver": "$\{DRIVER_NAME2}",
-                           "numVFsToCreate": $\{NUM_VFS2}
-                         }
-                      ]
-              mode: 0644
-              user:
-                name: root
-              group:
-                name: root
-            - path: /var/lib/rancher/rke2/server/manifests/sriov-crd.yaml
-              overwrite: true
-              contents:
-                inline: |
-                  apiVersion: helm.cattle.io/v1
-                  kind: HelmChart
-                  metadata:
-                    name: sriov-crd
-                    namespace: kube-system
-                  spec:
-                    chart: oci://registry.suse.com/edge/charts/sriov-crd
-                    targetNamespace: sriov-network-operator
-                    version: {version-sriov-crd-chart}
-                    createNamespace: true
-            - path: /var/lib/rancher/rke2/server/manifests/sriov-network-operator.yaml
-              overwrite: true
-              contents:
-                inline: |
-                  apiVersion: helm.cattle.io/v1
-                  kind: HelmChart
-                  metadata:
-                    name: sriov-network-operator
-                    namespace: kube-system
-                  spec:
-                    chart: oci://registry.suse.com/edge/charts/sriov-network-operator
-                    targetNamespace: sriov-network-operator
-                    version: {version-sriov-network-operator-chart}
-                    createNamespace: true
+          - path: /var/lib/rancher/rke2/server/manifests/configmap-sriov-custom-auto.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: sriov-custom-auto-config
+                  namespace: kube-system
+                data:
+                  config.json: |
+                    [
+                        {
+                          "resourceName": "$\{RESOURCE_NAME1}",
+                          "interface": "$\{SRIOV-NIC-NAME1}",
+                          "pfname": "$\{PF_NAME1}",
+                          "driver": "$\{DRIVER_NAME1}",
+                          "numVFsToCreate": $\{NUM_VFS1}
+                        },
+                        {
+                          "resourceName": "$\{RESOURCE_NAME2}",
+                          "interface": "$\{SRIOV-NIC-NAME2}",
+                          "pfname": "$\{PF_NAME2}",
+                          "driver": "$\{DRIVER_NAME2}",
+                          "numVFsToCreate": $\{NUM_VFS2}
+                        }
+                    ]
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
+          - path: /var/lib/rancher/rke2/server/manifests/sriov-crd.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChart
+                metadata:
+                  name: sriov-crd
+                  namespace: kube-system
+                spec:
+                  chart: oci://registry.suse.com/edge/charts/sriov-crd
+                  targetNamespace: sriov-network-operator
+                  version: {version-sriov-crd-chart}
+                  createNamespace: true
+          - path: /var/lib/rancher/rke2/server/manifests/sriov-network-operator.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChart
+                metadata:
+                  name: sriov-network-operator
+                  namespace: kube-system
+                spec:
+                  chart: oci://registry.suse.com/edge/charts/sriov-network-operator
+                  targetNamespace: sriov-network-operator
+                  version: {version-sriov-network-operator-chart}
+                  createNamespace: true
         kernel_arguments:
           should_exist:
             - intel_iommu=on
@@ -1750,72 +1856,87 @@ spec:
             - quiet
         systemd:
           units:
-            - name: rke2-preinstall.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=rke2-preinstall
-                Wants=network-online.target
-                Before=rke2-install.service
-                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                ExecStartPost=/bin/sh -c "umount /mnt"
-                [Install]
-                WantedBy=multi-user.target
-            - name: cpu-partitioning.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=cpu-partitioning
-                Wants=network-online.target
-                After=network.target network-online.target
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStart=/bin/sh -c "echo isolated_cores=$\{ISOLATED_CPU_CORES} > /etc/tuned/cpu-partitioning-variables.conf"
-                ExecStartPost=/bin/sh -c "tuned-adm profile cpu-partitioning"
-                ExecStartPost=/bin/sh -c "systemctl enable tuned.service"
-                [Install]
-                WantedBy=multi-user.target
-            - name: performance-settings.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=performance-settings
-                Wants=network-online.target
-                After=network.target network-online.target cpu-partitioning.service
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStart=/bin/sh -c "/opt/performance-settings/performance-settings.sh"
-                [Install]
-                WantedBy=multi-user.target
-            - name: sriov-custom-auto-vfs.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=SRIOV Custom Auto VF Creation
-                Wants=network-online.target  rke2-server.target
-                After=network.target network-online.target rke2-server.target
-                [Service]
-                User=root
-                Type=forking
-                TimeoutStartSec=900
-                ExecStart=/bin/sh -c "while ! /var/lib/rancher/rke2/bin/kubectl --kubeconfig=/etc/rancher/rke2/rke2.yaml wait --for condition=ready nodes --all ; do sleep 2 ; done"
-                ExecStartPost=/bin/sh -c "while [ $(/var/lib/rancher/rke2/bin/kubectl --kubeconfig=/etc/rancher/rke2/rke2.yaml get sriovnetworknodestates.sriovnetwork.openshift.io --ignore-not-found --no-headers -A | wc -l) -eq 0 ]; do sleep 1; done"
-                ExecStartPost=/bin/sh -c "/opt/sriov/sriov-auto-filler.sh"
-                RemainAfterExit=yes
-                KillMode=process
-                [Install]
-                WantedBy=multi-user.target
+          - name: rke2-preinstall.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-preinstall
+              Wants=network-online.target
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStartPost=/bin/sh -c "umount /mnt"
+              [Install]
+              WantedBy=multi-user.target
+          # rke2-traefik-deployment.service unit to be removed once "traefik" being the default ingress controller (starting with RKE2 v1.36)
+          - name: rke2-traefik-deployment.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-traefik-deployment
+              Wants=rke2-preinstall.service
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "echo \"ingress-controller: traefik\" >> /etc/rancher/rke2/config.yaml"
+              [Install]
+              WantedBy=multi-user.target
+          - name: cpu-partitioning.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=cpu-partitioning
+              Wants=network-online.target
+              After=network.target network-online.target
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "echo isolated_cores=$\{ISOLATED_CPU_CORES} > /etc/tuned/cpu-partitioning-variables.conf"
+              ExecStartPost=/bin/sh -c "tuned-adm profile cpu-partitioning"
+              ExecStartPost=/bin/sh -c "systemctl enable tuned.service"
+              [Install]
+              WantedBy=multi-user.target
+          - name: performance-settings.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=performance-settings
+              Wants=network-online.target
+              After=network.target network-online.target cpu-partitioning.service
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "/opt/performance-settings/performance-settings.sh"
+              [Install]
+              WantedBy=multi-user.target
+          - name: sriov-custom-auto-vfs.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=SRIOV Custom Auto VF Creation
+              Wants=network-online.target  rke2-server.target
+              After=network.target network-online.target rke2-server.target
+              [Service]
+              User=root
+              Type=forking
+              TimeoutStartSec=900
+              ExecStart=/bin/sh -c "while ! /var/lib/rancher/rke2/bin/kubectl --kubeconfig=/etc/rancher/rke2/rke2.yaml wait --for condition=ready nodes --all ; do sleep 2 ; done"
+              ExecStartPost=/bin/sh -c "while [ $(/var/lib/rancher/rke2/bin/kubectl --kubeconfig=/etc/rancher/rke2/rke2.yaml get sriovnetworknodestates.sriovnetwork.openshift.io --ignore-not-found --no-headers -A | wc -l) -eq 0 ]; do sleep 1; done"
+              ExecStartPost=/bin/sh -c "/opt/sriov/sriov-auto-filler.sh"
+              RemainAfterExit=yes
+              KillMode=process
+              [Install]
+              WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ----
 
@@ -1912,26 +2033,43 @@ spec:
         version: 1.4.0
         systemd:
           units:
-            - name: rke2-preinstall.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=rke2-preinstall
-                Wants=network-online.target
-                Before=rke2-install.service
-                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                ExecStartPost=/bin/sh -c "umount /mnt"
-                [Install]
-                WantedBy=multi-user.target
+          - name: rke2-preinstall.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-preinstall
+              Wants=network-online.target
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStartPost=/bin/sh -c "umount /mnt"
+              [Install]
+              WantedBy=multi-user.target
+          # rke2-traefik-deployment.service unit to be removed once "traefik" being the default ingress controller (starting with RKE2 v1.36)
+          - name: rke2-traefik-deployment.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-traefik-deployment
+              Wants=rke2-preinstall.service
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "echo \"ingress-controller: traefik\" >> /etc/rancher/rke2/config.yaml"
+              [Install]
+              WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ----
 
@@ -2063,110 +2201,110 @@ spec:
         version: 1.4.0
         storage:
           files:
-            - path: /var/lib/rancher/rke2/server/manifests/configmap-sriov-custom-auto.yaml
-              overwrite: true
-              contents:
-                inline: |
-                  apiVersion: v1
-                  kind: ConfigMap
-                  metadata:
-                    name: sriov-custom-auto-config
-                    namespace: sriov-network-operator
-                  data:
-                    config.json: |
-                      [
-                         {
-                           "resourceName": "$\{RESOURCE_NAME1}",
-                           "interface": "$\{SRIOV-NIC-NAME1}",
-                           "pfname": "$\{PF_NAME1}",
-                           "driver": "$\{DRIVER_NAME1}",
-                           "numVFsToCreate": $\{NUM_VFS1}
-                         },
-                         {
-                           "resourceName": "$\{RESOURCE_NAME2}",
-                           "interface": "$\{SRIOV-NIC-NAME2}",
-                           "pfname": "$\{PF_NAME2}",
-                           "driver": "$\{DRIVER_NAME2}",
-                           "numVFsToCreate": $\{NUM_VFS2}
-                         }
-                      ]
-              mode: 0644
-              user:
-                name: root
-              group:
-                name: root
-            - path: /var/lib/rancher/rke2/server/manifests/sriov.yaml
-              overwrite: true
-              contents:
-                inline: |
-                  apiVersion: v1
-                  data:
-                    .dockerconfigjson: $\{REGISTRY_AUTH_DOCKERCONFIGJSON}
-                  kind: Secret
-                  metadata:
+          - path: /var/lib/rancher/rke2/server/manifests/configmap-sriov-custom-auto.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: sriov-custom-auto-config
+                  namespace: sriov-network-operator
+                data:
+                  config.json: |
+                    [
+                        {
+                          "resourceName": "$\{RESOURCE_NAME1}",
+                          "interface": "$\{SRIOV-NIC-NAME1}",
+                          "pfname": "$\{PF_NAME1}",
+                          "driver": "$\{DRIVER_NAME1}",
+                          "numVFsToCreate": $\{NUM_VFS1}
+                        },
+                        {
+                          "resourceName": "$\{RESOURCE_NAME2}",
+                          "interface": "$\{SRIOV-NIC-NAME2}",
+                          "pfname": "$\{PF_NAME2}",
+                          "driver": "$\{DRIVER_NAME2}",
+                          "numVFsToCreate": $\{NUM_VFS2}
+                        }
+                    ]
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
+          - path: /var/lib/rancher/rke2/server/manifests/sriov.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: v1
+                data:
+                  .dockerconfigjson: $\{REGISTRY_AUTH_DOCKERCONFIGJSON}
+                kind: Secret
+                metadata:
+                  name: privregauth
+                  namespace: kube-system
+                type: kubernetes.io/dockerconfigjson
+                ---
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  namespace: kube-system
+                  name: example-repo-ca
+                data:
+                  ca.crt: |-
+                    -----BEGIN CERTIFICATE-----
+                    $\{CA_BASE64_CERT}
+                    -----END CERTIFICATE-----
+                ---
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChart
+                metadata:
+                  name: sriov-crd
+                  namespace: kube-system
+                spec:
+                  chart: oci://$\{PRIVATE_REGISTRY_URL}/mirror/sriov-crd
+                  dockerRegistrySecret:
                     name: privregauth
-                    namespace: kube-system
-                  type: kubernetes.io/dockerconfigjson
-                  ---
-                  apiVersion: v1
-                  kind: ConfigMap
-                  metadata:
-                    namespace: kube-system
+                  repoCAConfigMap:
                     name: example-repo-ca
-                  data:
-                    ca.crt: |-
-                      -----BEGIN CERTIFICATE-----
-                      $\{CA_BASE64_CERT}
-                      -----END CERTIFICATE-----
-                  ---
-                  apiVersion: helm.cattle.io/v1
-                  kind: HelmChart
-                  metadata:
-                    name: sriov-crd
-                    namespace: kube-system
-                  spec:
-                    chart: oci://$\{PRIVATE_REGISTRY_URL}/mirror/sriov-crd
-                    dockerRegistrySecret:
-                      name: privregauth
-                    repoCAConfigMap:
-                      name: example-repo-ca
-                    createNamespace: true
-                    set:
-                      global.clusterCIDR: 192.168.0.0/18
-                      global.clusterCIDRv4: 192.168.0.0/18
-                      global.clusterDNS: 10.96.0.10
-                      global.clusterDomain: cluster.local
-                      global.rke2DataDir: /var/lib/rancher/rke2
-                      global.serviceCIDR: 10.96.0.0/12
-                    targetNamespace: sriov-network-operator
-                    version: {version-sriov-crd-chart}
-                  ---
-                  apiVersion: helm.cattle.io/v1
-                  kind: HelmChart
-                  metadata:
-                    name: sriov-network-operator
-                    namespace: kube-system
-                  spec:
-                    chart: oci://$\{PRIVATE_REGISTRY_URL\}/mirror/sriov-network-operator
-                    dockerRegistrySecret:
-                      name: privregauth
-                    repoCAConfigMap:
-                      name: example-repo-ca
-                    createNamespace: true
-                    set:
-                      global.clusterCIDR: 192.168.0.0/18
-                      global.clusterCIDRv4: 192.168.0.0/18
-                      global.clusterDNS: 10.96.0.10
-                      global.clusterDomain: cluster.local
-                      global.rke2DataDir: /var/lib/rancher/rke2
-                      global.serviceCIDR: 10.96.0.0/12
-                    targetNamespace: sriov-network-operator
-                    version: {version-sriov-network-operator-chart}
-              mode: 0644
-              user:
-                name: root
-              group:
-                name: root
+                  createNamespace: true
+                  set:
+                    global.clusterCIDR: 192.168.0.0/18
+                    global.clusterCIDRv4: 192.168.0.0/18
+                    global.clusterDNS: 10.96.0.10
+                    global.clusterDomain: cluster.local
+                    global.rke2DataDir: /var/lib/rancher/rke2
+                    global.serviceCIDR: 10.96.0.0/12
+                  targetNamespace: sriov-network-operator
+                  version: {version-sriov-crd-chart}
+                ---
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChart
+                metadata:
+                  name: sriov-network-operator
+                  namespace: kube-system
+                spec:
+                  chart: oci://$\{PRIVATE_REGISTRY_URL\}/mirror/sriov-network-operator
+                  dockerRegistrySecret:
+                    name: privregauth
+                  repoCAConfigMap:
+                    name: example-repo-ca
+                  createNamespace: true
+                  set:
+                    global.clusterCIDR: 192.168.0.0/18
+                    global.clusterCIDRv4: 192.168.0.0/18
+                    global.clusterDNS: 10.96.0.10
+                    global.clusterDomain: cluster.local
+                    global.rke2DataDir: /var/lib/rancher/rke2
+                    global.serviceCIDR: 10.96.0.0/12
+                  targetNamespace: sriov-network-operator
+                  version: {version-sriov-network-operator-chart}
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
         kernel_arguments:
           should_exist:
             - intel_iommu=on
@@ -2189,71 +2327,88 @@ spec:
             - quiet
         systemd:
           units:
-            - name: rke2-preinstall.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=rke2-preinstall
-                Wants=network-online.target
-                Before=rke2-install.service
-                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                ExecStartPost=/bin/sh -c "umount /mnt"
-                [Install]
-                WantedBy=multi-user.target
-            - name: cpu-partitioning.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=cpu-partitioning
-                Wants=network-online.target
-                After=network.target network-online.target
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStart=/bin/sh -c "echo isolated_cores=$\{ISOLATED_CPU_CORES} > /etc/tuned/cpu-partitioning-variables.conf"
-                ExecStartPost=/bin/sh -c "tuned-adm profile cpu-partitioning"
-                ExecStartPost=/bin/sh -c "systemctl enable tuned.service"
-                [Install]
-                WantedBy=multi-user.target
-            - name: performance-settings.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=performance-settings
-                Wants=network-online.target
-                After=network.target network-online.target cpu-partitioning.service
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStart=/bin/sh -c "/opt/performance-settings/performance-settings.sh"
-                [Install]
-                WantedBy=multi-user.target
-            - name: sriov-custom-auto-vfs.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=SRIOV Custom Auto VF Creation
-                Wants=network-online.target  rke2-server.target
-                After=network.target network-online.target rke2-server.target
-                [Service]
-                User=root
-                Type=forking
-                TimeoutStartSec=1800
-                ExecStart=/bin/sh -c "while ! /var/lib/rancher/rke2/bin/kubectl --kubeconfig=/etc/rancher/rke2/rke2.yaml wait --for condition=ready nodes --timeout=30m --all ; do sleep 10 ; done"
-                ExecStartPost=/bin/sh -c "/opt/sriov/sriov-auto-filler.sh"
-                RemainAfterExit=yes
-                KillMode=process
-                [Install]
-                WantedBy=multi-user.target
+          - name: rke2-preinstall.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-preinstall
+              Wants=network-online.target
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStartPost=/bin/sh -c "umount /mnt"
+              [Install]
+              WantedBy=multi-user.target
+          # rke2-traefik-deployment.service unit to be removed once "traefik" being the default ingress controller (starting with RKE2 v1.36)
+          - name: rke2-traefik-deployment.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-traefik-deployment
+              Wants=rke2-preinstall.service
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "echo \"ingress-controller: traefik\" >> /etc/rancher/rke2/config.yaml"
+              [Install]
+              WantedBy=multi-user.target
+          - name: cpu-partitioning.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=cpu-partitioning
+              Wants=network-online.target
+              After=network.target network-online.target
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "echo isolated_cores=$\{ISOLATED_CPU_CORES} > /etc/tuned/cpu-partitioning-variables.conf"
+              ExecStartPost=/bin/sh -c "tuned-adm profile cpu-partitioning"
+              ExecStartPost=/bin/sh -c "systemctl enable tuned.service"
+              [Install]
+              WantedBy=multi-user.target
+          - name: performance-settings.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=performance-settings
+              Wants=network-online.target
+              After=network.target network-online.target cpu-partitioning.service
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "/opt/performance-settings/performance-settings.sh"
+              [Install]
+              WantedBy=multi-user.target
+          - name: sriov-custom-auto-vfs.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=SRIOV Custom Auto VF Creation
+              Wants=network-online.target  rke2-server.target
+              After=network.target network-online.target rke2-server.target
+              [Service]
+              User=root
+              Type=forking
+              TimeoutStartSec=1800
+              ExecStart=/bin/sh -c "while ! /var/lib/rancher/rke2/bin/kubectl --kubeconfig=/etc/rancher/rke2/rke2.yaml wait --for condition=ready nodes --timeout=30m --all ; do sleep 10 ; done"
+              ExecStartPost=/bin/sh -c "/opt/sriov/sriov-auto-filler.sh"
+              RemainAfterExit=yes
+              KillMode=process
+              [Install]
+              WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ----
 

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -78,6 +78,19 @@ The changes required to upgrade the `RKE2` cluster using the automated workflow 
 
   ** Specify the desired `rolloutStrategy`.
   ** Change the version of the `RKE2` cluster to the new version replacing `$\{RKE2_NEW_VERSION\}`.
+  ** Decide if an ingress controller is to be deployed in the downstream cluster:
+  *** [Option 0]: Do not deploy any ingress controller
+  *** [Option 1]: Deploy only `Traefik`
+  *** [Option 2]: Deploy both `Ingress-NGINX` and `Traefik` (to be used for complex ingress migration scenarios)
+
+[NOTE]
+====
+The `Traefik` ingress provider integrated into RKE2/K3s is the only ingress controller supported in `{product} {version}` release, being still possible to temporarily run `Ingress-NGINX` alongside `Traefik` in order to support complex ingress migration scenarios, but only after `{product}` Management and/or Downstream clusters have been upgraded to version `{version}` and for the time required to perform that migration. Since `Traefik` is not yet the default ingress controller in RKE2 (it will be
+from RKE2 v1.36 onwards), it must be explicitly "requested" from the RKE2 server configuration file.
+
+RKE2 https://docs.rke2.io/reference/ingress_migration[Ingress NGINX to Traefik Migration] guide provides details on the ingress migration paths available
+once the `Traefik` ingress controller replaces the discontinued `Ingress-NGINX`.
+====
 
 [,yaml]
 ----
@@ -99,6 +112,14 @@ spec:
       maxSurge: 0
   serverConfig:
     cni: cilium
+  #===========================================================================
+  # Uncomment the following lines if selecting [Option 0]: Do not deploy
+  # any ingress controller
+  #===========================================================================
+    #disableComponents:
+    #  pluginComponents:
+    #  - "rke2-ingress-nginx"
+  #---------------------------------------------------------------------------
   rolloutStrategy:
     rollingUpdate:
       maxSurge: 0
@@ -111,26 +132,128 @@ spec:
         version: 1.4.0
         systemd:
           units:
-            - name: rke2-preinstall.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=rke2-preinstall
-                Wants=network-online.target
-                Before=rke2-install.service
-                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                ExecStartPost=/bin/sh -c "umount /mnt"
-                [Install]
-                WantedBy=multi-user.target
+          - name: rke2-preinstall.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-preinstall
+              Wants=network-online.target
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStartPost=/bin/sh -c "umount /mnt"
+              [Install]
+              WantedBy=multi-user.target
+          # rke2-ingress-deployment.service unit
+          - name: rke2-ingress-deployment.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-ingress-deployment
+              Wants=rke2-preinstall.service
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              #===============================================================================================================================
+              # Leave one (and only one) of the two following ExecStart lines uncommented, depending on the desired ingress-controller(s):
+              #   [Option 1]: Deploy only "Traefik"
+              #   [Option 2]: Deploy both "Ingress-NGINX" and "Traefik"
+              #
+              # Keep both commented ONLY in case of seleting [Option 0]: "Do not deploy any ingress controller"
+              #===============================================================================================================================
+              #ExecStart=/bin/sh -c "echo \"ingress-controller: traefik\" >> /etc/rancher/rke2/config.yaml"                       # [Option 1]
+              ExecStart=/bin/sh -c "echo -e \"ingress-controller:\n- ingress-nginx\n- traefik\" >> /etc/rancher/rke2/config.yaml" # [Option 2]
+              #-------------------------------------------------------------------------------------------------------------------------------
+              [Install]
+              WantedBy=multi-user.target
+        storage:
+          directories:
+          - path: /var/lib/rancher/rke2/server/manifests
+            overwrite: true
+          files:
+          #############################################################################    
+          # if [Option 2]: "Deploy both `Ingress-NGINX` and `Traefik`" is selected
+          #############################################################################
+          - path: /var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChartConfig
+                metadata:
+                  name: rke2-ingress-nginx
+                  namespace: kube-system
+                spec:
+                  valuesContent: |-
+                    controller:
+                      hostPort:
+                        enabled: false  # not needed when exposing through a type:LoadBalancer service
+                      config:
+                        use-forwarded-headers: "true"
+                        enable-real-ip: "true"
+                      publishService:
+                        enabled: true
+                      service:
+                        enabled: true
+                        type: LoadBalancer
+                        externalTrafficPolicy: Local
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
+          #############################################################################    
+          # if [Option 1]: "Deploy only `Traefik`" OR  [Option 2]: "Deploy both
+          #`Ingress-NGINX` and `Traefik`" is selected
+          #############################################################################
+          - path: /var/lib/rancher/rke2/server/manifests/rke2-traefik-config.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChartConfig
+                metadata:
+                  name: rke2-traefik
+                  namespace: kube-system
+                spec:
+                  valuesContent: |-
+                    ingressClass:
+                      isDefaultClass: false  # Assumes [Option 2]; set to true if [Option 1]: "only deploying `Traefik`"
+                    ports:
+                      web:
+                        hostPort: null    # disallow hostPort
+                        exposedPort: 80
+                      websecure:
+                        hostPort: null    # disallow hostPort
+                        exposedPort: 443
+                    service:
+                      enabled: true
+                      type: LoadBalancer
+                      spec:
+                        externalTrafficPolicy: Local
+                        allocateLoadBalancerNodePorts: false  # k8s GA from 1.24; supported by MetalLB
+                    providers:
+                      kubernetesIngressNginx:  # this provider allows Traefik to "understand" most of the Ingress-NGINX annotations
+                        enabled: true
+                        ingressClass: "rke2-ingress-nginx-migration"
+                        controllerClass: "rke2.​cattle.​io/ingress-nginx-migration"
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ----
 

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -715,13 +715,14 @@ The `kubernetes` folder contains the following subfolders:
 
 The `kubernetes/config` folder contains the following files:
 
-- `server.yaml`: By default, the `CNI` plug-in installed by default is `Cilium`, so you do not need to create this folder and file. Just in case you need to customize the `CNI` plug-in, you can use the `server.yaml` file under the `kubernetes/config` folder. It contains the following information:
+- `server.yaml`: The `CNI` plug-in installed by default is `Cilium`, so you do not need to create this folder and file to set that. Just in case you need to customize the `CNI` plug-in, you can use the `server.yaml` file under the `kubernetes/config` folder. It contains the following information:
 +
 [,yaml]
 ----
 cni:
 - multus
 - cilium
+ingress-controller: traefik
 write-kubeconfig-mode: '0644'
 selinux: true
 system-default-registry: registry.rancher.com
@@ -730,6 +731,15 @@ system-default-registry: registry.rancher.com
 [NOTE]
 ====
 This is an optional file to define certain Kubernetes customization, like the CNI plug-ins to be used or many options you can check in the https://docs.rke2.io/install/configuration[official documentation].
+====
+
+[WARNING]
+====
+The `Traefik` ingress provider integrated into RKE2/K3s is the only ingress controller supported in `{product} {version}` release, being still possible to temporarily run `Ingress-NGINX` alongside `Traefik` in order to support complex ingress migration scenarios, but only after `{product}` Management and/or Downstream clusters have been upgraded to version `{version}` and for the time required to perform that migration. Since `Traefik` is not yet the default ingress controller in RKE2 (it will be
+from RKE2 v1.36 onwards), it must be explicitly "requested" from the RKE2 server configuration file, resulting in the need to include the `kubernetes/config/server.yaml` file in  all the EIB self-install iso images generated to provision `{product} {version}` Management clusters' nodes.
+
+RKE2 https://docs.rke2.io/reference/ingress_migration[Ingress NGINX to Traefik Migration] guide provides details on the ingress migration paths available
+once the `Traefik` ingress controller replaces the discontinued `Ingress-NGINX`.
 ====
 
 The `os-files/var/lib/rancher/rke2/server/manifests` folder contains the following file:
@@ -741,20 +751,30 @@ The `os-files/var/lib/rancher/rke2/server/manifests` folder contains the followi
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
-  name: rke2-ingress-nginx
+  name: rke2-traefik
   namespace: kube-system
 spec:
   valuesContent: |-
-    controller:
-      config:
-        use-forwarded-headers: "true"
-        enable-real-ip: "true"
-      publishService:
-        enabled: true
-      service:
-        enabled: true
-        type: LoadBalancer
+    ingressClass:
+      isDefaultClass: true
+    ports:
+      web:
+        hostPort: null    # disallow hostPort
+        exposedPort: 80
+      websecure:
+        hostPort: null    # disallow hostPort
+        exposedPort: 443
+    service:
+      enabled: true
+      type: LoadBalancer
+      spec:
         externalTrafficPolicy: Local
+        allocateLoadBalancerNodePorts: false  # k8s GA from 1.24; supported by MetalLB
+    providers:
+      kubernetesIngressNginx:  # this provider allows traefik to "understand" most of the ingress-nginx annotations
+        enabled: true
+        ingressClass: "rke2-ingress-nginx-migration"
+        controllerClass: "rke2.​cattle.​io/ingress-nginx-migration"
 ----
 
 [NOTE]
@@ -790,7 +810,7 @@ spec:
     - ingress-ippool
 ----
 
-- `ingress-ippool.yaml`: contains the configuration to create the `IPAddressPool` for the `rke2-ingress-nginx` component. The `$\{INGRESS_VIP\}` has to be set properly to define the IP address reserved to be used by the `rke2-ingress-nginx` component.
+- `ingress-ippool.yaml`: contains the configuration to create the MetalLB `IPAddressPool` object for the `rke2-traefik` component. The `$\{INGRESS_VIP\}` has to be set properly to define the exposed IP address reserved to be used to reach the (internal) `rke2-traefik` service.
 +
 [,yaml]
 ----
@@ -806,7 +826,7 @@ spec:
     priority: 100
     serviceSelectors:
       - matchExpressions:
-          - {key: app.kubernetes.io/name, operator: In, values: [rke2-ingress-nginx]}
+          - {key: app.kubernetes.io/name, operator: In, values: [rke2-traefik]}
 ----
 
 The `kubernetes/helm/values` folder contains the following files:
@@ -1238,6 +1258,7 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/hardened-coredns:v1.14.2-build20260310
     - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.8.1-build20260206
     - name: registry.rancher.com/rancher/hardened-multus-cni:v4.2.4-build20260310
+    - name: registry.rancher.com/rancher/hardened-traefik:v3.6.10-build20260309
     - name: registry.rancher.com/rancher/klipper-helm:v0.9.14-build20260309
     - name: registry.rancher.com/rancher/mirrored-cilium-cilium:v1.19.1
     - name: registry.rancher.com/rancher/mirrored-cilium-operator-generic:v1.19.1

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -549,30 +549,81 @@ spec:
     format: ignition
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     additionalUserData:
       config: |
         variant: fcos
         version: 1.4.0
         systemd:
           units:
-            - name: rke2-preinstall.service
-              enabled: true
-              contents: |
-                [Unit]
-                Description=rke2-preinstall
-                Wants=network-online.target
-                Before=rke2-install.service
-                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                [Service]
-                Type=oneshot
-                User=root
-                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                ExecStartPost=/bin/sh -c "umount /mnt"
-                [Install]
-                WantedBy=multi-user.target
+          - name: rke2-preinstall.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-preinstall
+              Wants=network-online.target
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStartPost=/bin/sh -c "umount /mnt"
+              [Install]
+              WantedBy=multi-user.target
+          # rke2-traefik-deployment.service unit to be removed once "traefik" being the default ingress controller (starting with RKE2 v1.36)
+          - name: rke2-traefik-deployment.service
+            enabled: true
+            contents: |
+              [Unit]
+              Description=rke2-traefik-deployment
+              Wants=rke2-preinstall.service
+              Before=rke2-install.service
+              ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+              [Service]
+              Type=oneshot
+              User=root
+              ExecStart=/bin/sh -c "echo \"ingress-controller: traefik\" >> /etc/rancher/rke2/config.yaml"
+              [Install]
+              WantedBy=multi-user.target
+        storage:
+          directories:
+          - path: /var/lib/rancher/rke2/server/manifests
+            overwrite: true
+          files:
+          - path: /var/lib/rancher/rke2/server/manifests/rke2-traefik-config.yaml
+            overwrite: true
+            contents:
+              inline: |
+                apiVersion: helm.cattle.io/v1
+                kind: HelmChartConfig
+                metadata:
+                  name: rke2-traefik
+                  namespace: kube-system
+                spec:
+                  valuesContent: |-
+                    ingressClass:
+                      isDefaultClass: true
+                    ports:
+                      web:
+                        hostPort: null    # disallow hostPort
+                        exposedPort: 80
+                      websecure:
+                        hostPort: null    # disallow hostPort
+                        exposedPort: 443
+                    service:
+                      enabled: true
+                      type: LoadBalancer
+                      spec:
+                        externalTrafficPolicy: Local
+                        allocateLoadBalancerNodePorts: false  # k8s GA from 1.24; supported by MetalLB
+            mode: 0644
+            user:
+              name: root
+            group:
+              name: root
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
@@ -602,12 +653,12 @@ spec:
   clusterName: sample-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
 ----
 
 NOTE: Adding the label `cluster-api.cattle.io/rancher-auto-import: "true"` to the `cluster.x-k8s.io` objects will import the cluster
@@ -670,7 +721,6 @@ spec:
         kind: Metal3MachineTemplate
         name: sample-cluster-workers
       deletion:
-
         nodeDrainTimeoutSeconds: 0
       version: {version-kubernetes-rke2}
 ---
@@ -687,30 +737,30 @@ spec:
         version: {version-kubernetes-rke2}
         kubelet:
           extraArgs:
-            - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://BAREMETALHOST_UUID
         additionalUserData:
           config: |
             variant: fcos
             version: 1.4.0
             systemd:
               units:
-                - name: rke2-preinstall.service
-                  enabled: true
-                  contents: |
-                    [Unit]
-                    Description=rke2-preinstall
-                    Wants=network-online.target
-                    Before=rke2-install.service
-                    ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                    [Service]
-                    Type=oneshot
-                    User=root
-                    ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                    ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                    ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                    ExecStartPost=/bin/sh -c "umount /mnt"
-                    [Install]
-                    WantedBy=multi-user.target
+              - name: rke2-preinstall.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=rke2-preinstall
+                  Wants=network-online.target
+                  Before=rke2-install.service
+                  ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                  [Service]
+                  Type=oneshot
+                  User=root
+                  ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                  ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                  ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                  ExecStartPost=/bin/sh -c "umount /mnt"
+                  [Install]
+                  WantedBy=multi-user.target
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
@@ -740,12 +790,12 @@ spec:
   clusterName: sample-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
 ----
 
 

--- a/asciidoc/tips/elemental.adoc
+++ b/asciidoc/tips/elemental.adoc
@@ -20,7 +20,7 @@ endif::[]
 === Expose Rancher service
 
 When using RKE2 or K3s we need to expose services (Rancher in this context) from the management cluster as they are not exposed by default.
-In RKE2 there is an NGINX Ingress controller, whilst k3s is using Traefik.
+In both RKE2 and k3s there is a Traefik Ingress controller.
 The current workflow suggests using MetalLB for announcing a service (via L2 or BGP Advertisement) and the respective Ingress Controller
 to create an Ingress via `HelmChartConfig` since creating a new Ingress object would override the existing setup.
 
@@ -45,20 +45,25 @@ kubectl apply -f - <<EOF
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
-  name: rke2-ingress-nginx
+  name: rke2-traefik
   namespace: kube-system
 spec:
   valuesContent: |-
-    controller:
-      config:
-        use-forwarded-headers: "true"
-        enable-real-ip: "true"
-      publishService:
-        enabled: true
-      service:
-        enabled: true
-        type: LoadBalancer
+    ingressClass:
+      isDefaultClass: true
+    ports:
+      web:
+        hostPort: null    # disallow hostPort
+        exposedPort: 80
+      websecure:
+        hostPort: null    # disallow hostPort
+        exposedPort: 443
+    service:
+      enabled: true
+      type: LoadBalancer
+      spec:
         externalTrafficPolicy: Local
+        allocateLoadBalancerNodePorts: false  # k8s GA from 1.24; supported by MetalLB
 EOF
 ----
 +
@@ -80,7 +85,7 @@ spec:
     priority: 100
     serviceSelectors:
     - matchExpressions:
-      - {key: app.kubernetes.io/name, operator: In, values: [rke2-ingress-nginx]}
+      - {key: app.kubernetes.io/name, operator: In, values: [rke2-traefik]}
 EOF
 ----
 +


### PR DESCRIPTION
This PR includes all introduced updates related to the replacement of Ingress-NGINX with Traefik for SUSE Edge & Telco Cloud 3.6.0.
The resulting doc has been built locally (before raising this PR) to solve asciidoc-2-html formatting issues.
Some additional minor updates have been introduced (in the updated files):

- to solve some mistakes related to the SUSE Edge vs SUSE Telco Cloud split
- some last-minute-detected mistakes in the updated CAPI yamls (that were preventing them to be valid to provisiong Downstream clusters)