### PR TITLE
[release-3.6] Clarifications for SyncE, GNSS and IPv6 (Backport #1147)

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -102,6 +102,8 @@ echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab
 
 * No official documentation or examples to configure SyncE via synce4l and GNSS via gpsd are available at this stage, these topics will be covered by future releases.
 
+* Some container repositories are currently reachable via IPv4 only, for this this reason a local registry on the Management Cluster is required for an IPv6 only downstream cluster.
+
 == Component Versions
 
 The following table describes the individual components that make up the 3.6.0 release, including the version, the Helm chart version (if applicable), and from where the released artifact can be pulled in the binary format. Please follow the associated documentation for usage and deployment examples.

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -57,7 +57,7 @@ Summary: {product} 3.6.0 is the first release in the {product} 3.6 release strea
 * Updated to Cert-Manager 1.20.1 https://cert-manager.io/docs/release-notes/[Upstream Release Notes]
 * Updated Metal3/Ironic to 0.15.0 with Ironic 35.0.0
 * BGP mode for MetalLB was a Technology Preview in {product} 3.5 and is now fully supported
-* Precision Time Protocol (PTP) on downstream deployments was a Technology Preview in {product} 3.5 and is now fully supported
+* Precision Time Protocol (PTP) on downstream deployments was a Technology Preview in {product} 3.5 and is now fully supported, along with SyncE and GNSS support
 * Single-stack IPv6 downstream cluster deployments are now supported, however note this requires a dual-stack management cluster (single stack management clusters remain a Technology Preview)
 
 == Bug & Security Fixes
@@ -99,6 +99,8 @@ mkdir -p /etc/cni
 mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
 echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab
 ----
+
+* No official documentation or examples to configure SyncE via synce4l and GNSS via gpsd are available at this stage, these topics will be covered by future releases.
 
 == Component Versions
 


### PR DESCRIPTION
Add a couple more details to the release notes about the above topics.

Backport of #1147 to branch release-3.6