### PR TITLE
[3.6] Fix a typo in trustedCAs value name (Backport #1152)

### DIFF
--- a/asciidoc/day2/migration.adoc
+++ b/asciidoc/day2/migration.adoc
@@ -95,7 +95,7 @@ endif::[]
 Applies only to Metal^3^ deployments that use additional trusted CAs for external media servers with TLS.
 ====
 
-The Metal^3^ Helm chart has changed how trusted CA certificates are configured. Previously, additional CAs were provided via a Secret (`tls-ca-additional`) with the `additionalTrustedCAs` boolean flag. The new version uses a ConfigMap containing the complete CA bundle referenced by the `global.trustedCA` value.
+The Metal^3^ Helm chart has changed how trusted CA certificates are configured. Previously, additional CAs were provided via a Secret (`tls-ca-additional`) with the `additionalTrustedCAs` boolean flag. The new version uses a ConfigMap containing the complete CA bundle referenced by the `global.trustedCAs` value.
 
 If you have configured additional trusted CAs for Metal^3^, you need to migrate from the Secret-based approach to the ConfigMap-based approach:
 
@@ -149,7 +149,7 @@ To:
 [,yaml]
 ----
 global:
-  trustedCA: tls-ca-bundle
+  trustedCAs: tls-ca-bundle
 ----
 
 . After upgrading the Metal^3^ Helm chart with the new configuration, you can delete the old Secret:

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -886,7 +886,7 @@ privateRegistry:
 global:
   ironicIP: ${METAL3_VIP}
   enable_vmedia_tls: false
-  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for additional trusted CAs
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for additional trusted CAs
 metal3-ironic:
   ipa:
     useHauler: true
@@ -1006,12 +1006,12 @@ EOF
 kubectl -n metal3-system create configmap tls-ca-bundle --from-file=ca-bundle.pem=./ca-bundle.pem
 ----
 
-- Set the `global.trustedCA` value in the `metal3.yaml` file to reference the ConfigMap name:
+- Set the `global.trustedCAs` value in the `metal3.yaml` file to reference the ConfigMap name:
 +
 [,yaml]
 ----
 global:
-  trustedCA: tls-ca-bundle
+  trustedCAs: tls-ca-bundle
 ----
 ====
 
@@ -1509,7 +1509,7 @@ We can now define the remaining files for a single node configuration, starting 
 global:
   ironicIP: ${MGMT_CLUSTER_IP_V4}
   enable_vmedia_tls: false
-  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for trusted CA bundle
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for trusted CA bundle
 metal3-ironic:
   global:
     predictableNicNames: true
@@ -1545,7 +1545,7 @@ Alternatively, to use the hostname in place of the IP addresses, modify `kuberne
 global:
   provisioningHostname: `${MGMT_CLUSTER_HOSTNAME}`
   enable_vmedia_tls: false
-  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for trusted CA bundle
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for trusted CA bundle
 metal3-ironic:
   global:
     predictableNicNames: true


### PR DESCRIPTION
Backport of #1152 to 3.6 branch