### PR TITLE
Edge1984 2086 2113

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -78,28 +78,36 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
 
 * `downstream-cluster-config.yaml` is the image definition file, see <<quickstart-eib>> for more details.
 * The base image folder will contain the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base` (or `Base-RT` for the Real-Time kernel) must be copied/moved under the `base-images` folder.
-* The `network` folder is optional, see <<add-network-eib>> for more details.
+* The `custom/files` directory contains the `performance-settings.sh` and `sriov-auto-filler.sh` files to be copied to the image during the image creation process.
 * The `custom/scripts` directory contains scripts to be run on first-boot:
     1. `01-fix-growfs.sh` script is required to resize the OS root partition on deployment
     2. `02-performance.sh` script is optional and can be used to configure the system for performance tuning.
     3. `03-sriov.sh` script is optional and can be used to configure the system for SR-IOV.
-* The `custom/files` directory contains the `performance-settings.sh` and `sriov-auto-filler.sh` files to be copied to the image during the image creation process.
+* The `network` folder is optional, see <<add-network-eib>> for more details.
+* The `os-files` folder contains the necessary configuration files to load, at each node boot, the `sctp` and `vfio-pci` kernel modules with the required options.
 
 [,console,subs="attributes"]
 ----
 ├── downstream-cluster-config.yaml
-├── base-images/
-│   └ {micro-base-image-raw}
-├── network/
-|   └ configure-network.sh
-└── custom/
-    └ scripts/
-    |   └ 01-fix-growfs.sh
-    |   └ 02-performance.sh
-    |   └ 03-sriov.sh
-    └ files/
-        └ performance-settings.sh
-        └ sriov-auto-filler.sh
+├── base-images
+│   └── {micro-base-image-raw}
+├── custom
+│   ├── files
+│   │   ├── performance-settings.sh
+│   │   └── sriov-auto-filler.sh
+│   └── scripts
+│       ├── 01-fix-growfs.sh
+│       ├── 02-performance.sh
+│       └── 03-sriov.sh
+├── network
+│   └── configure-network.sh
+├── os-files
+│   └── etc
+│       ├── modprobe.d
+│       │   └── vfio-pci-options.conf
+│       └── modules-load.d
+│           ├── sctp.conf
+│           └── vfio-pci.conf
 ----
 
 ==== Downstream cluster image definition file
@@ -270,7 +278,6 @@ Where `$SCC_REGISTRATION_CODE` is the registration code copied from https://scc.
 
 [#add-network-eib]
 ==== Additional script for Advanced Network Configuration
-
 If you need to configure static IPs or more advanced networking scenarios as described in <<advanced-network-configuration>>, the following additional configuration is required.
 
 In the `network` folder, create the following `configure-network.sh` file - this consumes configuration drive data on first-boot, and configures the
@@ -317,6 +324,41 @@ umount /mnt
 
 ./nmc generate --config-dir /tmp/nmc/desired --output-dir /tmp/nmc/generated
 ./nmc apply --config-dir /tmp/nmc/generated
+----
+
+[#add-kernel-modules-eib]
+==== Telco required kernel modules
+To ensure that the kernel modules required for telecom workloads are loaded on each node boot, the following configuration files must be added to the `os-files` EIB folder:
+
+===== sctp.conf
+To be placed in the `os-files/etc/modules-load.d/` path, instructing the https://www.freedesktop.org/software/systemd/man/latest/modules-load.d.html[systemd-modules-load.service] to load the `sctp` kernel module at node boot.
+
+[,shell]
+----
+$ cat os-files/etc/modules-load.d/sctp.conf 
+# Request "systemd-modules-load.service" to load sctp module at boot time
+sctp
+----
+
+===== vfio-pci.conf
+To be placed in the `os-files/etc/modules-load.d/` path, instructing the https://www.freedesktop.org/software/systemd/man/latest/modules-load.d.html[systemd-modules-load.service] to load the `vfio-pci` kernel module at node boot.
+
+[,shell]
+----
+$ cat os-files/etc/modules-load.d/vfio-pci.conf 
+# Request "systemd-modules-load.service" to load vfio-pci module at boot time
+# NOTE: The (SRIOV & DPDK related) required load-module options settings are defined in related "/etc/modprobe.d/vfio-pci-options.conf" file
+vfio_pci
+----
+
+===== vfio-pci-options.conf
+To be placed in the `os-files/etc/modprobe.d/` path, setting the required `vfio-pci` kernel module parameters to be applied when the kernel module is loaded.
+
+[,shell]
+----
+$ cat os-files/etc/modprobe.d/vfio-pci-options.conf 
+# Enable SR-IOV and disable idle D3 state for vfio-pci driver
+options vfio_pci enable_sriov=1 disable_idle_d3=1
 ----
 
 === Image creation
@@ -366,31 +408,39 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
     3. `03-performance.sh` script is optional and can be used to configure the system for performance tuning.
     4. `04-sriov.sh` script is optional and can be used to configure the system for SR-IOV.
 * The `custom/files` directory contains the `rke2` and the `cni` images to be copied to the image during the image creation process. Also, the optional `performance-settings.sh` and `sriov-auto-filler.sh` files can be included.
+* The `os-files` folder contains the necessary configuration files to load, at each node boot, the `sctp` and `vfio-pci` kernel modules with the required options.
 
 [,console,subs="attributes"]
 ----
 ├── downstream-cluster-airgap-config.yaml
-├── base-images/
-│   └ {micro-base-image-raw}
-├── network/
-|   └ configure-network.sh
-└── custom/
-    └ files/
-    |   └ install.sh
-    |   └ rke2-images-cilium.linux-amd64.tar.zst
-    |   └ rke2-images-core.linux-amd64.tar.zst
-    |   └ rke2-images-multus.linux-amd64.tar.zst
-    |   └ rke2-images.linux-amd64.tar.zst
-    |   └ rke2-images-traefik.linux-amd64.tar.zst
-    |   └ rke2.linux-amd64.tar.zst
-    |   └ sha256sum-amd64.txt
-    |   └ performance-settings.sh
-    |   └ sriov-auto-filler.sh
-    └ scripts/
-        └ 01-fix-growfs.sh
-        └ 02-airgap.sh
-        └ 03-performance.sh
-        └ 04-sriov.sh
+├── base-images
+│   └── {micro-base-image-raw}
+├── custom
+│   ├── files
+│   │   ├── install.sh
+│   │   ├── rke2-images-cilium.linux-amd64.tar.zst
+│   │   ├── rke2-images-core.linux-amd64.tar.zst
+│   │   ├── rke2-images-multus.linux-amd64.tar.zst
+│   │   ├── rke2-images.linux-amd64.tar.zst
+│   │   ├── rke2-images-traefik.linux-amd64.tar.zst
+│   │   ├── rke2.linux-amd64.tar.zst
+│   │   ├── sha256sum-amd64.txt
+│   │   ├── performance-settings.sh
+│   │   └── sriov-auto-filler.sh
+│   └── scripts
+│       ├── 01-fix-growfs.sh
+│       ├── 02-airgap.sh
+│       ├── 03-performance.sh
+│       └── 04-sriov.sh
+├── network
+│   └── configure-network.sh
+├── os-files
+│   └── etc
+│       ├── modprobe.d
+│       │   └── vfio-pci-options.conf
+│       └── modules-load.d
+│           ├── sctp.conf
+│           └── vfio-pci.conf
 ----
 
 ==== Downstream cluster image definition file
@@ -470,6 +520,10 @@ cp sriov-auto-filler.sh /opt/sriov/sriov-auto-filler.sh
 ----
 
 The content of `custom/files/sriov-auto-filler.sh` is a script that can be used to configure the system for SR-IOV and can be downloaded from the following https://github.com/suse-edge/telco-cloud-examples/blob/{release-tag-telco-cloud}/telco-examples/downstream-clusters/dhcp/eib/custom/files/sriov-auto-filler.sh[link].
+
+[#add-kernel-modules-eib-airgap]
+==== Telco required kernel modules
+As described for the non-airgap scenario in xref:add-kernel-modules-eib[section].
 
 ==== Preparing the air-gap artifacts
 
@@ -1700,7 +1754,6 @@ The changes required to enable the Telco features shown above are all inside the
 
 To make the process clear, the changes required on that block (`RKE2ControlPlane`) to enable the Telco features are the following:
 
-* The `preRKE2Commands` to be used to execute the commands before the `RKE2` installation process. In this case, use the `modprobe` command to enable the `vfio-pci` and the `SR-IOV` kernel modules.
 * The ignition file `/var/lib/rancher/rke2/server/manifests/configmap-sriov-custom-auto.yaml` to be used to define the interfaces, drivers and the number of `VFs` to be created and exposed to the workloads.
     ** The values inside the config map `sriov-custom-auto-config` are the only values to be replaced with real values.
         *** `$\{RESOURCE_NAME1\}` — The resource name to be used for the first `PF` interface (for example, `sriov-resource-du1`). It is added to the prefix `rancher.io` to be used as a label to be used by the workloads (for example, `rancher.io/sriov-resource-du1`).
@@ -1760,8 +1813,6 @@ spec:
   serverConfig:
     cni: calico
     cniMultusEnable: true
-  preRKE2Commands:
-  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:
@@ -2186,8 +2237,6 @@ spec:
   serverConfig:
     cni: calico
     cniMultusEnable: true
-  preRKE2Commands:
-    - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     airGapped: true       # Airgap true to enable airgap mode
     format: ignition

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -65,7 +65,7 @@ Much of the configuration via Edge Image Builder is possible, but in this guide,
 === Prerequisites for connected scenarios
 
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop] is required to run Edge Image Builder.
-* The base image will be built using the following guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel). The process is the same for both architectures (x86-64 and aarch64).
+* The base image will be built using the following guide <<guides-kiwi-builder-images>> with the profile `Base` (or `Base-RT` for the Real-Time kernel). The process is the same for both architectures (x86-64 and aarch64).
 
 [NOTE]
 ====
@@ -77,7 +77,7 @@ It is required to use a build host with the same architecture of the images bein
 When running Edge Image Builder, a directory is mounted from the host, so it is necessary to create a directory structure to store the configuration files used to define the target image.
 
 * `downstream-cluster-config.yaml` is the image definition file, see <<quickstart-eib>> for more details.
-* The base image folder will contain the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel) must be copied/moved under the `base-images` folder.
+* The base image folder will contain the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base` (or `Base-RT` for the Real-Time kernel) must be copied/moved under the `base-images` folder.
 * The `network` folder is optional, see <<add-network-eib>> for more details.
 * The `custom/scripts` directory contains scripts to be run on first-boot:
     1. `01-fix-growfs.sh` script is required to resize the OS root partition on deployment
@@ -345,7 +345,7 @@ Much of the configuration is possible with Edge Image Builder, but in this guide
 === Prerequisites for air-gap scenarios
 
 * A container runtime such as https://podman.io[Podman] or https://rancherdesktop.io[Rancher Desktop] is required to run Edge Image Builder.
-* The base image will be built using the following guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel). The process is the same for both architectures (x86-64 and aarch64).
+* The base image will be built using the following guide <<guides-kiwi-builder-images>> with the profile `Base` (or `Base-RT` for the Real-Time kernel). The process is the same for both architectures (x86-64 and aarch64).
 * If you want to use SR-IOV or any other workload which require a container image, a local private registry must be deployed and already configured (with/without TLS and/or authentication). This registry will be used to store the images and the helm chart OCI images.
 
 [NOTE]
@@ -358,7 +358,7 @@ It is required to use a build host with the same architecture of the images bein
 When running Edge Image Builder, a directory is mounted from the host, so it is necessary to create a directory structure to store the configuration files used to define the target image.
 
 * `downstream-cluster-airgap-config.yaml` is the image definition file, see <<quickstart-eib>> for more details.
-* The base image folder will contain the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base-SelfInstall` (or `Base-RT-SelfInstall` for the Real-Time kernel) must be copied/moved under the `base-images` folder.
+* The base image folder will contain the output raw image generated following the guide <<guides-kiwi-builder-images>> with the profile `Base` (or `Base-RT` for the Real-Time kernel) must be copied/moved under the `base-images` folder.
 * The `network` folder is optional, see <<add-network-eib>> for more details.
 * The `custom/scripts` directory contains scripts to be run on first-boot:
     1. `01-fix-growfs.sh` script is required to resize the OS root partition on deployment.

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -707,7 +707,24 @@ We need to create a config map that defines SR-IOV resource pools. Run `lspci` c
 [,shell]
 ----
 $ lspci | grep -i acc
-8a:00.0 Processing accelerators: Intel Corporation Device 0d5c
+07:00.0 Processing accelerators: Intel Corporation Device 57c2
+07:00.1 Processing accelerators: Intel Corporation Device 57c3
+07:00.2 Processing accelerators: Intel Corporation Device 57c3
+07:00.3 Processing accelerators: Intel Corporation Device 57c3
+07:00.4 Processing accelerators: Intel Corporation Device 57c3
+07:00.5 Processing accelerators: Intel Corporation Device 57c3
+07:00.6 Processing accelerators: Intel Corporation Device 57c3
+07:00.7 Processing accelerators: Intel Corporation Device 57c3
+07:01.0 Processing accelerators: Intel Corporation Device 57c3
+07:01.1 Processing accelerators: Intel Corporation Device 57c3
+07:01.2 Processing accelerators: Intel Corporation Device 57c3
+07:01.3 Processing accelerators: Intel Corporation Device 57c3
+07:01.4 Processing accelerators: Intel Corporation Device 57c3
+07:01.5 Processing accelerators: Intel Corporation Device 57c3
+07:01.6 Processing accelerators: Intel Corporation Device 57c3
+07:01.7 Processing accelerators: Intel Corporation Device 57c3
+07:02.0 Processing accelerators: Intel Corporation Device 57c3
+0a:00.0 Processing accelerators: Intel Corporation Device 57c2
 
 $ lspci | grep -i net
 19:00.0 Ethernet controller: Broadcom Inc. and subsidiaries BCM57504 NetXtreme-E 10Gb/25Gb/40Gb/50Gb/100Gb/200Gb Ethernet (rev 11)
@@ -736,7 +753,7 @@ A `resource` is the named entity that pods consume (e.g. `rancher.io/intel_fec_5
 You define the target devices using `selectors` to filter the hardware on the node:
 
 * `vendors`: `8086` (Intel)
-* `devices`: `0d5d` (FEC card), `1889` (NIC)
+* `devices`: `57c3` (FEC VF), `1889` (NIC VF)
 * `drivers`: `vfio-pci`
 * `pfNames`: `p2p1` (physical interface name)
 
@@ -777,7 +794,7 @@ data:
                 "deviceType": "accelerator",
                 "selectors": {
                     "vendors": ["8086"],
-                    "devices": ["0d5d"]
+                    "devices": ["57c3"]
                 },
         		"additionalInfo": {
           			"*": {
@@ -1275,13 +1292,13 @@ Network devices using kernel driver
 
 
 [#acceleration]
-== vRAN Acceleration (`Intel ACC100/ACC200`)
+== vRAN Acceleration (`Intel ACC100/VRB1/VRB2`)
 
 As communications service providers move from 4G to 5G networks, many are adopting virtualized radio access network (vRAN) architectures for higher channel capacity and easier deployment of edge-based services and applications. vRAN solutions are ideally located to deliver low-latency services with the flexibility to increase or decrease capacity based on the volume of real-time traffic and demand on the network.
 
 One of the most compute-intensive 4G and 5G workloads is RAN layer 1 (`L1`) `FEC`, which resolves data transmission errors over unreliable or noisy communication channels. `FEC` technology detects and corrects a limited number of errors in 4G or 5G data, eliminating the need for retransmission. Since the `FEC` acceleration transaction does not contain cell state information, it can be easily virtualized, enabling pooling benefits and easy cell migration.
 
-Historically, Intel provided the ACC100 vRAN Accelerator card to rapidly execute Layer 1 FEC algorithms, freeing up host processing power for the main CPU. Intel has since integrated this technology directly into newer CPUs, starting with Sapphire Rapids, under the name `Intel vRAN Boost` (also known as ACC200). Intel vRAN Boost act as an offload accelerator on the CPU itself, eliminating the need for a separate hardware card. This section details configuration of SUSE Telco Cloud for workloads to leverage ACC100 or Intel vRAN Boost.
+Historically, Intel provided the ACC100 vRAN Accelerator card to rapidly execute Layer 1 FEC algorithms, freeing up host processing power for the main CPU. Intel has since integrated this technology directly into newer CPUs, starting with Sapphire Rapids, under the name `Intel vRAN Boost` (VRB). Intel vRAN Boost acts as an offload accelerator on the CPU itself, eliminating the need for a separate hardware card. This section details configuration of SUSE Telco Cloud for workloads to leverage ACC100 or Intel vRAN Boost.
 
 
 === Kernel parameters
@@ -1335,15 +1352,17 @@ $ modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
 
 [,shell]
 ----
-$ lspci | grep -i acc
-8a:00.0 Processing accelerators: Intel Corporation Device 0d5c
+$ lspci -DPPnn | grep -i acc
+0000:07:00.0 Processing accelerators [1200]: Intel Corporation Device [8086:57c2]
+0000:0a:00.0 Processing accelerators [1200]: Intel Corporation Device [8086:57c2]
+
 ----
 
 * Bind the physical interface (`PF`) with `vfio-pci` driver:
 
 [,shell]
 ----
-$ dpdk-devbind.py -b vfio-pci 0000:8a:00.0
+$ dpdk-devbind.py -b vfio-pci 0000:07:00.0
 ----
 
 * Create the virtual functions (`VFs`) from the physical interface (`PF`).
@@ -1352,37 +1371,70 @@ Check the maximum `VF` capacity of the accelerator card. Next, configure the car
 
 [,shell]
 ----
-$ cat /sys/bus/pci/devices/0000:8a:00.0/sriov_totalvfs
-16
-$ echo 16 > /sys/bus/pci/devices/0000:8a:00.0/sriov_numvfs
+$ cat /sys/bus/pci/devices/0000:07:00.0/sriov_totalvfs
+64
+$ echo 16 > /sys/bus/pci/devices/0000:07:00.0/sriov_numvfs
 ----
 
-* Configure the accelerator card and its virtual functions with a 4G or 5G profile. A unique VF token (UUID) must be provided. The workload would consume this VF token to utilize the card's FEC acceleration capabilities:
+* Configure the accelerator card and its virtual functions with a 4G or 5G profile, selecting the right `vRAN Boost` device type depending on the exact Intel processor generation: `VRB1` (formerly known as ACC200) if Sapphire Rapids Edge Enhanced (SPR-EE), `VRB2` for Granite Rapids-D (GNR-D). A unique VF token (UUID) must be provided (the workload will consume this VF token to utilize the card's FEC acceleration capabilities).
+
+[WARNING]
+====
+Deprecation from `pf-bb-config`: new rpm release supporting VRB2 device type is now installing the configuration example files in `/usr/share/pf-bb-config/examples` location; the old `/opt/pf-bb-config/` path is still supported but to be removed in future releases. Please, update your scripts and documentation to reflect the new path (as done in the example below).
+====
 
 [,shell]
 ----
-$ pf_bb_config ACC200 -c /opt/pf-bb-config/acc200_config_vf_5g.cfg -v 00112233-4455-6677-8899-aabbccddeeff
-Tue Jun  6 10:49:20 2023:INFO:Queue Groups: 2 5GUL, 2 5GDL, 2 4GUL, 2 4GDL
-Tue Jun  6 10:49:20 2023:INFO:Configuration in VF mode
-Tue Jun  6 10:49:21 2023:INFO: ROM version MM 99AD92
-Tue Jun  6 10:49:21 2023:WARN:* Note: Not on DDR PRQ version  1302020 != 10092020
-Tue Jun  6 10:49:21 2023:INFO:PF ACC200 configuration complete
-Tue Jun  6 10:49:21 2023:INFO:ACC200 PF [0000:8a:00.0] configuration complete!
+$ pf_bb_config VRB2 -c /usr/share/pf-bb-config/examples/vrb2/vrb2_config_vf_5g.cfg -f /usr/share/pf-bb-config/examples/vrb2/srs_fft_windows_coefficient.bin -v 00112233-4455-6677-8899-aabbccddeeff -p 0000:07:00.0
+== pf_bb_config Version 25.11 ==
+VRB2 PF [0000:07:00.0] configuration complete!
+Log file = /var/log/pf_bb_cfg_0000:07:00.0.log
 ----
 
 * Verify the new VFs created from the FEC PF. Note that the VFs got `0d5d` device ID. This information is required in next step to expose these VFs as Kubernetes resource:
 
 [,shell]
 ----
-$ dpdk-devbind.py -s
+$ # dpdk-devbind.py -s | grep -A18 Baseband 
 Baseband devices using DPDK-compatible driver
 =============================================
-0000:8a:00.0 'Device 0d5c' drv=vfio-pci unused=
-0000:8b:00.0 'Device 0d5d' drv=vfio-pci unused=
-
+0000:07:00.0 'Device 57c2' numa_node=0 drv=vfio-pci unused=
+0000:07:00.1 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:00.2 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:00.3 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:00.4 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:00.5 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:00.6 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:00.7 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:01.0 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:01.1 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:01.2 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:01.3 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:01.4 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:01.5 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:01.6 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:01.7 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+0000:07:02.0 'Device 57c3' numa_node=0 drv=vfio-pci unused=
+--
 Other Baseband devices
 ======================
-0000:8b:00.1 'Device 0d5d' unused=
+0000:0a:00.0 'Device 57c2' numa_node=0 unused=vfio-pci
+
+Other Crypto devices
+====================
+0000:01:00.0 '420xx Series QAT 4946' numa_node=0 unused=vfio-pci
+0000:03:00.0 'Device 2714' numa_node=0 unused=vfio-pci
+
+DMA devices using kernel driver
+===============================
+0000:00:01.0 'Device 11fb' numa_node=0 drv=idxd unused=vfio-pci 
+
+Other Eventdev devices
+======================
+0000:03:00.0 'Device 2714' numa_node=0 unused=vfio-pci
+
+No 'Mempool' devices detected
+=============================
 ----
 
 === Configure Kubernetes for FEC Acceleration


### PR DESCRIPTION
Latest updates required for SUSE 3.6.0 docs, three different commits for each:

- 1st commit: Updates "ACC100/ACC200" section in SUSE Telco Cloud doc, adding the new VRB2 support (for GNR-D) and the now needed "-f" setting when invoking the "pf_bb_config" command (required from the latest "pf-bb-config" rpm supporting the VRB2 device type needed for GNR-D support). Old "ACC200" term now replaced by the new "VRB1" one
- 2nd commit: Updates the name of the kiwi profiles referred to generate the downstream EIB base "raw" images, using now "Base" and "Base-RT·(instead of "Base-SelfInstall" and "Base-RT-SelfInstall"  which are used to generate "iso" and not "raw" images)
- 3rd commit: Adds the sctp and vfio-pci config files to downstream EIB folder (in the os-folder path) & then removes the not needed anymore "modprobe vfio-pci" command from .spec.preRKE2Commands stanza from RKE2ControlPlane and RKEConfigTemplate manifests