### PR TITLE
Improves tree printouts in downstream EIB folder

### DIFF
--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -101,13 +101,13 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
 │       └── 03-sriov.sh
 ├── network
 │   └── configure-network.sh
-├── os-files
-│   └── etc
-│       ├── modprobe.d
-│       │   └── vfio-pci-options.conf
-│       └── modules-load.d
-│           ├── sctp.conf
-│           └── vfio-pci.conf
+└── os-files
+    └── etc
+        ├── modprobe.d
+        │   └── vfio-pci-options.conf
+        └── modules-load.d
+            ├── sctp.conf
+            └── vfio-pci.conf
 ----
 
 ==== Downstream cluster image definition file
@@ -434,13 +434,13 @@ When running Edge Image Builder, a directory is mounted from the host, so it is 
 │       └── 04-sriov.sh
 ├── network
 │   └── configure-network.sh
-├── os-files
-│   └── etc
-│       ├── modprobe.d
-│       │   └── vfio-pci-options.conf
-│       └── modules-load.d
-│           ├── sctp.conf
-│           └── vfio-pci.conf
+└── os-files
+    └── etc
+        ├── modprobe.d
+        │   └── vfio-pci-options.conf
+        └── modules-load.d
+            ├── sctp.conf
+            └── vfio-pci.conf
 ----
 
 ==== Downstream cluster image definition file


### PR DESCRIPTION
Solve some formatting mistakes in the "tree" output git from the downstream EIB folder content (for both non air-gapped and air-gapped sections); introduced as part of the updates applied to that "tree" output in the scope of the doc updates for STC 3.6.0 release.
NOTE: It has been already solved in "release-3.6" branch (as part of backpoting recent changes in "main" that were also required in "release-3.6" branch); this PR solves it also in "main" branch