### PR TITLE
Pending capi v1beta2 updates

### DIFF
--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -269,7 +269,6 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/kuberlr-kubectl:v7.0.3
     - name: registry.rancher.com/rancher/local-path-provisioner:v0.0.35
     - name: registry.rancher.com/rancher/machine:v0.15.0-rancher142
-    - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.12.2
     - name: registry.rancher.com/rancher/nginx-ingress-controller:v1.14.5-hardened1
     - name: registry.rancher.com/rancher/prom-prometheus:v3.8.1
     - name: registry.rancher.com/rancher/prometheus-federator:v6.0.0

--- a/asciidoc/guides/clusterclass.adoc
+++ b/asciidoc/guides/clusterclass.adoc
@@ -68,15 +68,15 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: emea-spa-cluster-3
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: emea-spa-cluster-3
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: emea-spa-cluster-3
@@ -93,10 +93,12 @@ metadata:
   name: emea-spa-cluster-3
   namespace: emea-spa
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-    kind: Metal3MachineTemplate
-    name: emea-spa-cluster-3
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
+        name: emea-spa-cluster-3
   replicas: 1
   version: {version-kubernetes-rke2}
   rolloutStrategy:
@@ -147,7 +149,6 @@ spec:
                     targetNamespace: metallb-system
                     version: {version-metallb-chart}
                     createNamespace: true
-
             - path: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml
               overwrite: true
               contents:
@@ -214,15 +215,17 @@ spec:
                 ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
                 ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                 ExecStartPost=/bin/sh -c "umount /mnt"
                 [Install]
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-3
@@ -245,7 +248,7 @@ spec:
         format: raw
         url: http://fileserver.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-3
@@ -254,12 +257,12 @@ spec:
   clusterName: emea-spa-cluster-3
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
 
 ----
 
@@ -297,33 +300,33 @@ spec:
   template:
     spec:
       machineTemplate:
-        infrastructureRef:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-          kind: Metal3MachineTemplate
-          name: example-controlplane    # This will be replaced by the patch applied in each cluster instances
-          namespace: emea-spa
+        spec:
+          infrastructureRef:
+            apiGroup: infrastructure.cluster.x-k8s.io
+            kind: Metal3MachineTemplate
+            name: example-controlplane    # To be replaced by the patch applied in each Cluster instance
       rolloutStrategy:
         type: "RollingUpdate"
         rollingUpdate:
           maxSurge: 1
       registrationMethod: "control-plane-endpoint"
-      registrationAddress: "default"  # This will be replaced by the patch applied in each cluster instances
+      registrationAddress: "TO_BE_REPLACED"  # To be replaced by the patch applied in each Cluster instance
       serverConfig:
         cni: cilium
         cniMultusEnable: true
         tlsSan:
-          - "default"  # This will be replaced by the patch applied in each cluster instances
+        - "TO_BE_REPLACED"  # To be replaced by the patch applied in each Cluster instance
       agentConfig:
         format: ignition
         additionalUserData:
-          config: |
-            default
+          config: |   
+            TO_BE_REPLACED  # To be replaced by the patch applied in each Cluster instance
         kubelet:
           extraArgs:
-            - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://BAREMETALHOST_UUID
         nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3ClusterTemplate
 metadata:
   name: example-cluster-template-type2
@@ -332,7 +335,7 @@ spec:
   template:
     spec:
       controlPlaneEndpoint:
-        host: "default"  # This will be replaced by the patch applied in each cluster instances
+        host: "TO_BE_REPLACED"  # To be replaced by the patch applied in each Cluster instance
         port: 6443
       noCloudProvider: true
 ---
@@ -342,199 +345,200 @@ metadata:
   name: example-clusterclass-type2
   namespace: emea-spa
 spec:
-  variables:
-    - name: controlPlaneMachineTemplate
-      required: true
-      schema:
-        openAPIV3Schema:
-          type: string
-    - name: controlPlaneEndpointHost
-      required: true
-      schema:
-        openAPIV3Schema:
-          type: string
-    - name: tlsSan
-      required: true
-      schema:
-        openAPIV3Schema:
-          type: array
-          items:
-            type: string
   infrastructure:
     templateRef:
       kind: Metal3ClusterTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       name: example-cluster-template-type2
   controlPlane:
     templateRef:
       kind: RKE2ControlPlaneTemplate
       apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       name: example-controlplane-type2
+  variables:
+  - name: controlPlaneMachineTemplate  # Used by the "setControlPlaneMachineTemplate" patch
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: string
+  - name: controlPlaneEndpointHost  # Used by "setControlPlaneEndpoint" and "setRegistrationAddress" patches
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: string
+  - name: tlsSan  # Used by the "setTlsSan" patch
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: string
   patches:
-    - name: setControlPlaneMachineTemplate
-      definitions:
-        - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
-            kind: RKE2ControlPlaneTemplate
-            matchResources:
-              controlPlane: true
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/infrastructureRef/name"
-              valueFrom:
-                variable: controlPlaneMachineTemplate
-    - name: setControlPlaneEndpoint
-      definitions:
-        - selector:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-            kind: Metal3ClusterTemplate
-            matchResources:
-              infrastructureCluster: true  # Added to select InfraCluster
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/controlPlaneEndpoint/host"
-              valueFrom:
-                variable: controlPlaneEndpointHost
-    - name: setRegistrationAddress
-      definitions:
-        - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
-            kind: RKE2ControlPlaneTemplate
-            matchResources:
-              controlPlane: true  # Added to select ControlPlane
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/registrationAddress"
-              valueFrom:
-                variable: controlPlaneEndpointHost
-    - name: setTlsSan
-      definitions:
-        - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
-            kind: RKE2ControlPlaneTemplate
-            matchResources:
-              controlPlane: true  # Added to select ControlPlane
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/serverConfig/tlsSan"
-              valueFrom:
-                variable: tlsSan
-    - name: updateAdditionalUserData
-      definitions:
-        - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
-            kind: RKE2ControlPlaneTemplate
-            matchResources:
-              controlPlane: true
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/agentConfig/additionalUserData"
-              valueFrom:
-                template: |
-                  config: |
-                    variant: fcos
-                    version: 1.4.0
-                    storage:
-                      files:
-                        - path: /var/lib/rancher/rke2/server/manifests/endpoint-copier-operator.yaml
-                          overwrite: true
-                          contents:
-                            inline: |
-                              apiVersion: helm.cattle.io/v1
-                              kind: HelmChart
-                              metadata:
-                                name: endpoint-copier-operator
-                                namespace: kube-system
-                              spec:
-                                chart: oci://registry.suse.com/edge/charts/endpoint-copier-operator
-                                targetNamespace: endpoint-copier-operator
-                                version: {version-endpoint-copier-operator-chart}
-                                createNamespace: true
-                        - path: /var/lib/rancher/rke2/server/manifests/metallb.yaml
-                          overwrite: true
-                          contents:
-                            inline: |
-                              apiVersion: helm.cattle.io/v1
-                              kind: HelmChart
-                              metadata:
-                                name: metallb
-                                namespace: kube-system
-                              spec:
-                                chart: oci://registry.suse.com/edge/charts/metallb
-                                targetNamespace: metallb-system
-                                version: {version-metallb-chart}
-                                createNamespace: true
-                        - path: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml
-                          overwrite: true
-                          contents:
-                            inline: |
-                              apiVersion: metallb.io/v1beta1
-                              kind: IPAddressPool
-                              metadata:
-                                name: kubernetes-vip-ip-pool
-                                namespace: metallb-system
-                              spec:
-                                addresses:
-                                  - {{ .controlPlaneEndpointHost }}/32
-                                serviceAllocation:
-                                  priority: 100
-                                  namespaces:
-                                    - default
-                                  serviceSelectors:
-                                    - matchExpressions:
-                                      - {key: "serviceType", operator: In, values: [kubernetes-vip]}
-                              ---
-                              apiVersion: metallb.io/v1beta1
-                              kind: L2Advertisement
-                              metadata:
-                                name: ip-pool-l2-adv
-                                namespace: metallb-system
-                              spec:
-                                ipAddressPools:
-                                  - kubernetes-vip-ip-pool
-                        - path: /var/lib/rancher/rke2/server/manifests/endpoint-svc.yaml
-                          overwrite: true
-                          contents:
-                            inline: |
-                              apiVersion: v1
-                              kind: Service
-                              metadata:
-                                name: kubernetes-vip
-                                namespace: default
-                                labels:
-                                  serviceType: kubernetes-vip
-                              spec:
-                                ports:
-                                - name: rke2-api
-                                  port: 9345
-                                  protocol: TCP
-                                  targetPort: 9345
-                                - name: k8s-api
-                                  port: 6443
-                                  protocol: TCP
-                                  targetPort: 6443
-                                type: LoadBalancer
-                    systemd:
-                      units:
-                        - name: rke2-preinstall.service
-                          enabled: true
-                          contents: |
-                            [Unit]
-                            Description=rke2-preinstall
-                            Wants=network-online.target
-                            Before=rke2-install.service
-                            ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                            [Service]
-                            Type=oneshot
-                            User=root
-                            ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                            ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                            ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                            ExecStartPost=/bin/sh -c "umount /mnt"
-                            [Install]
-                            WantedBy=multi-user.target
+  - name: setControlPlaneMachineTemplate
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+        kind: RKE2ControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/machineTemplate/spec/infrastructureRef/name"
+        valueFrom:
+          variable: controlPlaneMachineTemplate
+  - name: setControlPlaneEndpoint
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: Metal3ClusterTemplate
+        matchResources:
+          infrastructureCluster: true  # Added to select InfraCluster
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/controlPlaneEndpoint/host"
+        valueFrom:
+          variable: controlPlaneEndpointHost
 
-
+  - name: setRegistrationAddress
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+        kind: RKE2ControlPlaneTemplate
+        matchResources:
+          controlPlane: true         # Added to select ControlPlane
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/registrationAddress"
+        valueFrom:
+          variable: controlPlaneEndpointHost
+  - name: setTlsSan
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+        kind: RKE2ControlPlaneTemplate
+        matchResources:
+          controlPlane: true      # Added to select ControlPlane
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/serverConfig/tlsSan"
+        valueFrom:
+          variable: tlsSan
+  - name: updateAdditionalUserData
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+        kind: RKE2ControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/agentConfig/additionalUserData"
+        valueFrom:
+          template: |
+            config: |
+              variant: fcos
+              version: 1.4.0
+              storage:
+                files:
+                - path: /var/lib/rancher/rke2/server/manifests/endpoint-copier-operator.yaml
+                  overwrite: true
+                  contents:
+                    inline: |
+                      apiVersion: helm.cattle.io/v1
+                      kind: HelmChart
+                      metadata:
+                        name: endpoint-copier-operator
+                        namespace: kube-system
+                      spec:
+                        chart: oci://registry.suse.com/edge/charts/endpoint-copier-operator
+                        targetNamespace: endpoint-copier-operator
+                        version: {version-endpoint-copier-operator-chart}
+                        createNamespace: true
+                - path: /var/lib/rancher/rke2/server/manifests/metallb.yaml
+                  overwrite: true
+                  contents:
+                    inline: |
+                      apiVersion: helm.cattle.io/v1
+                      kind: HelmChart
+                      metadata:
+                        name: metallb
+                        namespace: kube-system
+                      spec:
+                        chart: oci://registry.suse.com/edge/charts/metallb
+                        targetNamespace: metallb-system
+                        version: {version-metallb-chart}
+                        createNamespace: true
+                - path: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml
+                  overwrite: true
+                  contents:
+                    inline: |
+                      apiVersion: metallb.io/v1beta1
+                      kind: IPAddressPool
+                      metadata:
+                        name: kubernetes-vip-ip-pool
+                        namespace: metallb-system
+                      spec:
+                        addresses:
+                          - {{ .controlPlaneEndpointHost }}/32
+                        serviceAllocation:
+                          priority: 100
+                          namespaces:
+                            - default
+                          serviceSelectors:
+                            - matchExpressions:
+                              - {key: "serviceType", operator: In, values: [kubernetes-vip]}
+                      ---
+                      apiVersion: metallb.io/v1beta1
+                      kind: L2Advertisement
+                      metadata:
+                        name: ip-pool-l2-adv
+                        namespace: metallb-system
+                      spec:
+                        ipAddressPools:
+                          - kubernetes-vip-ip-pool
+                - path: /var/lib/rancher/rke2/server/manifests/endpoint-svc.yaml
+                  overwrite: true
+                  contents:
+                    inline: |
+                      apiVersion: v1
+                      kind: Service
+                      metadata:
+                        name: kubernetes-vip
+                        namespace: default
+                        labels:
+                          serviceType: kubernetes-vip
+                      spec:
+                        ports:
+                        - name: rke2-api
+                          port: 9345
+                          protocol: TCP
+                          targetPort: 9345
+                        - name: k8s-api
+                          port: 6443
+                          protocol: TCP
+                          targetPort: 6443
+                        type: LoadBalancer
+              systemd:
+                units:
+                - name: rke2-preinstall.service
+                  enabled: true
+                  contents: |
+                    [Unit]
+                    Description=rke2-preinstall
+                    Wants=network-online.target
+                    Before=rke2-install.service
+                    ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                    [Service]
+                    Type=oneshot
+                    User=root
+                    ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                    ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                    ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                    ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+                    ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                    ExecStartPost=/bin/sh -c "umount /mnt"
+                    [Install]
+                    WantedBy=multi-user.target
 ----
 
 === Cluster instance definition
@@ -564,24 +568,22 @@ metadata:
     cluster-api.cattle.io/rancher-auto-import: "true"
 spec:
   topology:
-
     classRef:
-
       name: example-clusterclass-type2  # Correct way to reference ClusterClass
     version: {version-kubernetes-rke2}
     controlPlane:
       replicas: 1
     variables:                         # Variables to be replaced for this cluster instance
-      - name: controlPlaneMachineTemplate
-        value: emea-spa-cluster-3-machinetemplate
-      - name: controlPlaneEndpointHost
-        value: 192.168.122.203
-      - name: tlsSan
-        value:
-          - 192.168.122.203
-          - https://192.168.122.203.sslip.io
+    - name: controlPlaneMachineTemplate
+      value: emea-spa-cluster-3-machinetemplate
+    - name: controlPlaneEndpointHost
+      value: 192.168.122.203
+    - name: tlsSan
+      value:
+      - 192.168.122.203
+      - https://192.168.122.203.sslip.io
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-3-machinetemplate
@@ -604,7 +606,7 @@ spec:
         format: raw
         url: http://fileserver.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-3
@@ -613,10 +615,10 @@ spec:
   clusterName: emea-spa-cluster-3
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
 
 ----
 

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -745,11 +745,11 @@ spec:
         - 10.96.0.0/12
         - fd00:bad:bad:cafe::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ----
@@ -767,7 +767,7 @@ The `Metal3Cluster` object specifies the control-plane endpoint (replacing the `
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -798,7 +798,7 @@ metadata:
 spec:
   machineTemplate:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
@@ -920,7 +920,7 @@ The `Metal3MachineTemplate` object specifies the following information:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -944,7 +944,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -953,12 +953,12 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
 ----
 
 Once the file is created by joining the previous blocks, the following command must be executed in the management cluster to start provisioning the new bare-metal host:
@@ -1098,11 +1098,11 @@ spec:
         - 10.96.0.0/12
         - fd00:5678:8765:4321::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ----
@@ -1118,7 +1118,7 @@ See the https://documentation.suse.com/cloudnative/cluster-api/latest/en/tutoria
 The `Metal3Cluster` object specifies the control-plane endpoint that uses the `VIP` address already reserved (replacing the `$\{EDGE_VIP_ADDRESS_IPV4\}`) to be configured and the `noCloudProvider` because the three bare-metal nodes are used.
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -1158,7 +1158,7 @@ metadata:
   }
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3MachineTemplate
     name: multinode-cluster-controlplane
   replicas: 3
@@ -1368,7 +1368,7 @@ The `Metal3MachineTemplate` object specifies the following information:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -1392,7 +1392,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -1438,16 +1438,15 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: RKE2ConfigTemplate
           name: multinode-cluster-workers
       clusterName: multinode-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-workers
       deletion:
-
         nodeDrainTimeoutSeconds: 0
       version: ${RKE2_VERSION}
 ----
@@ -1467,7 +1466,7 @@ spec:
         format: ignition
         kubelet:
           extraArgs:
-            - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://BAREMETALHOST_UUID
         nodeName: "Node-multinode-cluster-worker"
         additionalUserData:
           config: |
@@ -1501,7 +1500,7 @@ The `Metal3MachineTemplate` object contain references to `dataTemplate`, `hostSe
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-workers
@@ -1525,7 +1524,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-workers-template
@@ -1801,7 +1800,7 @@ metadata:
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
@@ -1917,6 +1916,8 @@ spec:
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
               ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStartPost=/bin/sh -c "umount /mnt"
               [Install]
               WantedBy=multi-user.target
@@ -2042,7 +2043,7 @@ metadata:
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
@@ -2184,7 +2185,7 @@ metadata:
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -2034,7 +2034,7 @@ metadata:
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
@@ -2069,6 +2069,8 @@ spec:
                 ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
                 ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                 ExecStartPost=/bin/sh -c "umount /mnt"
                 [Install]
                 WantedBy=multi-user.target

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -101,7 +101,7 @@ metadata:
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   version: ${RKE2_NEW_VERSION}
@@ -265,7 +265,7 @@ spec:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1294,7 +1294,6 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/cluster-api-provider-rke2-controlplane:v0.24.3
     - name: registry.rancher.com/rancher/ip-address-manager:v1.12.3
     - name: registry.rancher.com/rancher/kubectl:v1.35.2
-    - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.12.2
     - name: registry.rancher.com/rancher/scc-operator:v0.4.0
     - name: registry.rancher.com/rancher/kubectl:v1.33.1
     - name: registry.suse.com/edge/{version-edge-registry}/ironic-python-agent:{version-ipa}

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -886,12 +886,11 @@ privateRegistry:
 global:
   ironicIP: ${METAL3_VIP}
   enable_vmedia_tls: false
+  predictableNicNames: "true"
   # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for additional trusted CAs
 metal3-ironic:
   ipa:
-    useHauler: true
-  global:
-    predictableNicNames: "true"
+    useHauler: false
   persistence:
     ironic:
       size: "5Gi"
@@ -900,7 +899,7 @@ metal3-ironic:
 +
 [IMPORTANT]
 ====
-The `metal3-ironic.ipa.useHauler` value **must** be set to `true` (boolean value) in air-gapped environments. This instructs Metal^3^ to retrieve the Ironic Python Agent (IPA) image from the embedded artifact registry instead of attempting to download it from the internet. The IPA image must also be included in the `embeddedArtifactRegistry.images` list as shown in the definition file example above.
+The `metal3-ironic.ipa.useHauler` Helm chart parameter **must** be set to `true` (boolean value) in air-gapped environments; this instructs Metal^3^ to retrieve the `ironic-python-agent` (IPA) container image from the embedded artifact registry instead of attempting to download it from the internet. This IPA container image must be additionally included in the `embeddedArtifactRegistry.images` list in the xref:mgmt-cluster-image-definition-file-airgap[EIB image definition file for air-gap environments].
 ====
 
 [#metal3-media-server]
@@ -1307,7 +1306,25 @@ embeddedArtifactRegistry:
 [#mgmt-cluster-kubernetes-folder-airgap]
 === Modifications in the kubernetes folder
 
-- You need to modify the `$\{MGMT_CLUSTER_REGISTRY_IP\}` with a reserved static IP for the SUSE Private Registry in the following file:
+- The `kubernetes/helm/values/metal3.yaml` file must be updated to now set the `metal3-ironic.ipa.useHauler` Helm chart parameter to `true` (boolean value).
++
+[,yaml]
+----
+global:
+  ironicIP: ${METAL3_VIP}
+  enable_vmedia_tls: false
+  predictableNicNames: "true"
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for additional trusted CAs
+metal3-ironic:
+  ipa:
+    useHauler: true
+  persistence:
+    ironic:
+      size: "5Gi"
+
+----
+
+- You need to modify the `$\{MGMT_CLUSTER_REGISTRY_IP\}` with a reserved static IP for the SUSE Private Registry in the following files:
 
 . `kubernetes/manifests/metallb-registry.yaml`
 +

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -510,15 +510,15 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: sample-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: sample-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: sample-cluster
@@ -536,7 +536,7 @@ metadata:
   namespace: default
 spec:
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3MachineTemplate
     name: sample-cluster-controlplane
   replicas: 1
@@ -570,6 +570,8 @@ spec:
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
               ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+              ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStartPost=/bin/sh -c "umount /mnt"
               [Install]
               WantedBy=multi-user.target
@@ -625,7 +627,7 @@ spec:
             group:
               name: root
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: sample-cluster-controlplane
@@ -644,7 +646,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/SLE-Micro-eib-output.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: sample-cluster-controlplane-template
@@ -712,19 +714,19 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: RKE2ConfigTemplate
           name: sample-cluster-workers
       clusterName: sample-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: sample-cluster-workers
       deletion:
         nodeDrainTimeoutSeconds: 0
       version: {version-kubernetes-rke2}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: sample-cluster-workers
@@ -758,11 +760,13 @@ spec:
                   ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
                   ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
                   ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                  ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+                  ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                   ExecStartPost=/bin/sh -c "umount /mnt"
                   [Install]
                   WantedBy=multi-user.target
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: sample-cluster-workers
@@ -781,7 +785,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/SLE-Micro-eib-output.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: sample-cluster-workers-template


### PR DESCRIPTION
This PR includes 3 commits for the following groups of updates:

- first commit cover all the missing v1beta1 -> v1beta2 updates for "Core", "CAPRKE2 control plain" and "CAPRKE2 bootstrap" yamls, including the ClusterClass related one (NOTE: setting back the CAPM3 resources to v1beta1)
- 2nd commit removes the neither needed nor existing "mirrored-cluster-api-controller:v1.12.2" container image
- 3rd commit covers the improvements around the ``metal3-ironic.ipa.useHauler`` Helm chart parameter (to be set to ``true`` only in case of air-gapped environments)