### PR TITLE
Several doc issues solved

### DIFF
--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -269,7 +269,6 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/kuberlr-kubectl:v7.0.3
     - name: registry.rancher.com/rancher/local-path-provisioner:v0.0.35
     - name: registry.rancher.com/rancher/machine:v0.15.0-rancher142
-    - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.12.2
     - name: registry.rancher.com/rancher/nginx-ingress-controller:v1.14.5-hardened1
     - name: registry.rancher.com/rancher/prom-prometheus:v3.8.1
     - name: registry.rancher.com/rancher/prometheus-federator:v6.0.0

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -137,6 +137,7 @@ operatingSystem:
       encryptedPassword: $ROOT_PASSWORD
       sshKeys:
       - $USERKEY1
+      createHomeDir: true
   packages:
     packageList:
       - jq
@@ -251,6 +252,7 @@ operatingSystem:
       encryptedPassword: $ROOT_PASSWORD
       sshKeys:
       - $user1Key1
+      createHomeDir: true
   packages:
     packageList:
       - jq            # Non Telco specific - category: testing/utils

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1294,7 +1294,6 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/cluster-api-provider-rke2-controlplane:v0.24.3
     - name: registry.rancher.com/rancher/ip-address-manager:v1.12.3
     - name: registry.rancher.com/rancher/kubectl:v1.35.2
-    - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.12.2
     - name: registry.rancher.com/rancher/scc-operator:v0.4.0
     - name: registry.rancher.com/rancher/kubectl:v1.33.1
     - name: registry.suse.com/edge/{version-edge-registry}/ironic-python-agent:{version-ipa}

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -886,12 +886,11 @@ privateRegistry:
 global:
   ironicIP: ${METAL3_VIP}
   enable_vmedia_tls: false
+  predictableNicNames: "true"
   # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for additional trusted CAs
 metal3-ironic:
   ipa:
-    useHauler: true
-  global:
-    predictableNicNames: "true"
+    useHauler: false
   persistence:
     ironic:
       size: "5Gi"
@@ -900,7 +899,7 @@ metal3-ironic:
 +
 [IMPORTANT]
 ====
-The `metal3-ironic.ipa.useHauler` value **must** be set to `true` (boolean value) in air-gapped environments. This instructs Metal^3^ to retrieve the Ironic Python Agent (IPA) image from the embedded artifact registry instead of attempting to download it from the internet. The IPA image must also be included in the `embeddedArtifactRegistry.images` list as shown in the definition file example above.
+The `metal3-ironic.ipa.useHauler` Helm chart parameter **must** be set to `true` (boolean value) in air-gapped environments; this instructs Metal^3^ to retrieve the `ironic-python-agent` (IPA) container image from the embedded artifact registry instead of attempting to download it from the internet. This IPA container image must be additionally included in the `embeddedArtifactRegistry.images` list in the xref:mgmt-cluster-image-definition-file-airgap[EIB image definition file for air-gap environments].
 ====
 
 [#metal3-media-server]
@@ -1307,7 +1306,26 @@ embeddedArtifactRegistry:
 [#mgmt-cluster-kubernetes-folder-airgap]
 === Modifications in the kubernetes folder
 
-- You need to modify the `$\{MGMT_CLUSTER_REGISTRY_IP\}` with a reserved static IP for the SUSE Private Registry in the following file:
+- Update the `kubernetes/helm/values/metal3.yaml` file to set the `metal3-ironic.ipa.useHauler` Helm chart parameter to `true` (boolean value).
+
++
+[,yaml]
+----
+global:
+  ironicIP: ${METAL3_VIP}
+  enable_vmedia_tls: false
+  predictableNicNames: "true"
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name for additional trusted CAs
+metal3-ironic:
+  ipa:
+    useHauler: true
+  persistence:
+    ironic:
+      size: "5Gi"
+
+----
+
+- You need to modify the `$\{MGMT_CLUSTER_REGISTRY_IP\}` with a reserved static IP for the SUSE Private Registry in the following files:
 
 . `kubernetes/manifests/metallb-registry.yaml`
 +


### PR DESCRIPTION
This PR partially replaces the just cancelled #1162 PR

It includes 3 commits for the following updates:
- 1st commit removes the neither needed nor existing "mirrored-cluster-api-controller:v1.12.2" container image
- 2nd commit adds some few missing `createHomeDire:true` statements in EIB image definition (yaml) files that made them to fail the EIB parsing/validation
- 3rd commit covers the improvements around the metal3-ironic.ipa.useHauler Helm chart parameter (to be set to true only in case of air-gapped environments). NOTE: @ranjinimn I have added here your comment from the canceled #1162 PR (thanks for it ;-) 