### PR TITLE
Add instructions for configuring Rancher hostname in air-gapped env

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1325,6 +1325,45 @@ metal3-ironic:
 
 ----
 
+- Update the `kubernetes/helm/values/rancher.yaml` file to modify the `hostname` parameter. In air-gapped environments, external DNS resolution services like sslip.io are not accessible. You have two options:
+
+.. *Option 1: Use internal DNS* (Recommended): Configure your internal DNS server to resolve the Rancher hostname and update the file accordingly:
++
+[,yaml,subs="attributes"]
+----
+hostname: rancher.yourdomain.internal
+bootstrapPassword: "foobar"
+replicas: 1
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"
+----
+
+.. *Option 2: Use /etc/hosts injection*: If you don't have an internal DNS server, you can inject a static `/etc/hosts` entry via EIB. Create a file at `eib/os-files/etc/hosts` in your EIB directory structure with content like:
++
+[,shell,subs="attributes"]
+----
+# Static DNS resolution for Rancher in air-gapped environment
+$\{INGRESS_VIP} rancher-$\{INGRESS_VIP}.sslip.io
+----
++
+Then update the `rancher.yaml` file to use this hostname:
++
+[,yaml,subs="attributes"]
+----
+hostname: rancher-$\{INGRESS_VIP}.sslip.io
+bootstrapPassword: "foobar"
+replicas: 1
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"
+----
++
+[IMPORTANT]
+====
+When using Option 2, remember that the `/etc/hosts` file will need to be present on any system that needs to access the Rancher UI, not just the management cluster nodes.
+====
+
 - You need to modify the `$\{MGMT_CLUSTER_REGISTRY_IP\}` with a reserved static IP for the SUSE Private Registry in the following files:
 
 . `kubernetes/manifests/metallb-registry.yaml`

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1325,7 +1325,7 @@ metal3-ironic:
 
 ----
 
-- Update the `kubernetes/helm/values/rancher.yaml` file to modify the `hostname` parameter. In air-gapped environments, external DNS resolution services like sslip.io are not accessible. You have two options:
+- Update the `kubernetes/helm/values/rancher.yaml` file to modify the `hostname` parameter. In air-gapped environments, external DNS resolution services like `sslip.io` are not accessible. You have two options:
 
 .. *Option 1: Use internal DNS* (Recommended): Configure your internal DNS server to resolve the Rancher hostname and update the file accordingly:
 +
@@ -1339,7 +1339,7 @@ global:
     systemDefaultRegistry: "registry.rancher.com"
 ----
 
-.. *Option 2: Use /etc/hosts injection*: If you don't have an internal DNS server, you can inject a static `/etc/hosts` entry via EIB. Create a file at `eib/os-files/etc/hosts` in your EIB directory structure with content like:
+.. *Option 2: Use /etc/hosts injection*: If you do not have an internal DNS server, you can inject a static `/etc/hosts` entry via EIB. Create a file at `eib/os-files/etc/hosts` in your EIB directory structure with content like:
 +
 [,shell,subs="attributes"]
 ----


### PR DESCRIPTION
Fix issue #1176 
This pull request updates the documentation for configuring Rancher in air-gapped environments, specifically providing guidance on how to set the `hostname` parameter in the `rancher.yaml` file. The new instructions offer two alternatives for DNS resolution when external services like sslip.io are not available.

**Documentation updates for Rancher hostname configuration in air-gapped environments:**

* Added a recommended option to use internal DNS by configuring your DNS server and updating the `hostname` in `kubernetes/helm/values/rancher.yaml` accordingly.
* Provided an alternative to inject a static `/etc/hosts` entry via EIB if internal DNS is not available, including instructions for creating the file and updating the `rancher.yaml` hostname.
* Included an important note reminding users that the `/etc/hosts` entry must be present on any system accessing the Rancher UI when using the hosts injection method.