### PR TITLE
[Backport 3.6] Add instructions for configuring Rancher hostname in air-gapped env

### DIFF
--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1325,6 +1325,45 @@ metal3-ironic:
 
 ----
 
+- Update the `kubernetes/helm/values/rancher.yaml` file to modify the `hostname` parameter. In air-gapped environments, external DNS resolution services like `sslip.io` are not accessible. You have two options:
+
+.. *Option 1: Use internal DNS* (Recommended): Configure your internal DNS server to resolve the Rancher hostname and update the file accordingly:
++
+[,yaml,subs="attributes"]
+----
+hostname: rancher.yourdomain.internal
+bootstrapPassword: "foobar"
+replicas: 1
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"
+----
+
+.. *Option 2: Use /etc/hosts injection*: If you do not have an internal DNS server, you can inject a static `/etc/hosts` entry via EIB. Create a file at `eib/os-files/etc/hosts` in your EIB directory structure with content like:
++
+[,shell,subs="attributes"]
+----
+# Static DNS resolution for Rancher in air-gapped environment
+$\{INGRESS_VIP} rancher-$\{INGRESS_VIP}.sslip.io
+----
++
+Then update the `rancher.yaml` file to use this hostname:
++
+[,yaml,subs="attributes"]
+----
+hostname: rancher-$\{INGRESS_VIP}.sslip.io
+bootstrapPassword: "foobar"
+replicas: 1
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"
+----
++
+[IMPORTANT]
+====
+When using Option 2, remember that the `/etc/hosts` file will need to be present on any system that needs to access the Rancher UI, not just the management cluster nodes.
+====
+
 - You need to modify the `$\{MGMT_CLUSTER_REGISTRY_IP\}` with a reserved static IP for the SUSE Private Registry in the following files:
 
 . `kubernetes/manifests/metallb-registry.yaml`


### PR DESCRIPTION
## Summary

This is a backport of #1177 to the `release-3.6` branch.

## Changes

- Adds documentation for configuring Rancher hostname in air-gapped environments where sslip.io is not accessible
- Provides two options:
  1. Using internal DNS (recommended)
  2. Using /etc/hosts injection via EIB custom files

## Original PR

#1177 (merged to main)

## Testing

- [x] Cherry-pick applied cleanly from main
- [x] Documentation changes are relevant to release-3.6

---
🤖 Generated backport PR