### PR TITLE
[release-3.6] Add 3.6.1 release note CVE references

### DIFF
--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -51,7 +51,7 @@ Summary: {product} 3.6.1 is the first z-stream release in the {product} 3.6 rele
 * Updated to SUSE Security (NeuVector) 5.5.2 https://open-docs.neuvector.com/releasenotes/5x[NeuVector Release Notes]
 * Updated to SUSE Storage (Longhorn) 1.11.2 https://longhorn.io/docs/1.11.1/[Upstream Longhorn Release Notes]
 * Updated to Rancher Turtles (CAPI) 0.26.2 https://turtles.docs.rancher.com/[Rancher Turtles Documentation]
-* Updated Metal3/Ironic to 0.15.0 with Ironic 35.0.0.2
+* Updated Metal^3^/Ironic to 0.15.0 with Ironic 35.0.0.2
 
 == Bug & Security Fixes
 
@@ -59,6 +59,13 @@ Summary: {product} 3.6.1 is the first z-stream release in the {product} 3.6 rele
 * Rancher Prime 2.14.2 contains several bugfixes https://github.com/rancher/rancher/releases/tag/v2.14.1[Upstream Rancher Release Notes]
 * SUSE Storage (Longhorn) 1.11.2 contains several bugfixes https://github.com/longhorn/longhorn/releases/tag/v1.11.1[Upstream Longhorn Bug Fixes]
 * NeuVector 5.5.2 contains new features and several bugfixes https://open-docs.neuvector.com/releasenotes/5x[NeuVector Release Notes]
+* The Metal^3^/Ironic updates fix several bugs and security issues, including the following:
+** https://www.cve.org/CVERecord?id=CVE-2026-44919[CVE-2026-44919]
+** https://www.cve.org/CVERecord?id=CVE-2026-46447[CVE-2026-46447]
+** https://www.cve.org/CVERecord?id=CVE-2026-48681[CVE-2026-48681]
+** https://www.cve.org/CVERecord?id=CVE-2026-44917[CVE-2026-44917]
+** https://www.cve.org/CVERecord?id=CVE-2026-43003[CVE-2026-43003]
+** https://www.cve.org/CVERecord?id=CVE-2026-50589[CVE-2026-50589]
 
 == Known Issues
 


### PR DESCRIPTION
These are derived from https://build.opensuse.org/package/rdiff/isv:SUSE:Edge:Ironic:2026.1/openstack-ironic?linkrev=base&rev=3