### PR TITLE
Add Longhorn improvements

### DIFF
--- a/asciidoc/day2/longhorn-engine-image-cleanup.adoc
+++ b/asciidoc/day2/longhorn-engine-image-cleanup.adoc
@@ -1,0 +1,372 @@
+[#{cluster-type}-day2-longhorn-engine-cleanup]
+== Longhorn Engine Image Cleanup
+:revdate: 2026-07-03
+:page-revdate: {revdate}
+:experimental:
+
+ifdef::env-github[]
+:imagesdir: ../images/
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+This section describes how to implement automated cleanup of obsolete Longhorn engine images that accumulate after cluster upgrades.
+
+=== Problem statement
+
+Longhorn does not automatically remove old engine images after upgrades. This is an intentional design decision to prevent accidental data loss — Longhorn retains previous engine image versions as a safety measure in case rollback is required.
+
+However, in production environments with frequent upgrades, these unused engine images accumulate over time, resulting in:
+
+* **Storage consumption**: Each engine image consumes disk space on cluster nodes
+* **Resource overhead**: Kubernetes manages additional image resources unnecessarily
+* **Operational complexity**: Manual identification and cleanup of obsolete images
+
+
+=== When to implement cleanup
+
+Engine image cleanup is recommended in the following scenarios:
+
+* **Regular cluster upgrades**: Environments that perform frequent Longhorn version upgrades
+* **Storage-constrained deployments**: Clusters with limited node storage capacity
+* **Operational hygiene**: As part of routine Day 2 maintenance procedures
+
+[NOTE]
+====
+This cleanup procedure is classified as **low risk** because it only removes engine images with zero active references (`refCount == 0`). Images currently in use by volumes are protected and will not be deleted.
+====
+
+=== Solution architecture
+
+The cleanup solution uses a Kubernetes CronJob that executes periodic maintenance tasks:
+
+. **Discovery**: Identifies the latest Longhorn engine image version deployed in the cluster
+. **Candidate selection**: Locates all older engine image versions with no active volume references
+. **Cleanup execution**: Deletes obsolete engine images that meet safety criteria
+. **Audit logging**: Records cleanup operations for operational visibility
+
+The implementation requires:
+
+* **ServiceAccount**: For authentication to the Kubernetes API
+* **RBAC permissions**: Read and delete access to `engineimages.longhorn.io` resources
+* **CronJob**: Scheduled execution container with cleanup logic
+
+=== Implementation
+
+The complete cleanup solution consists of four Kubernetes manifests deployed to the `longhorn-system` namespace.
+
+==== Step 1: Create ServiceAccount
+
+Create a dedicated ServiceAccount for the cleanup CronJob:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-engineimage-cleanup
+  namespace: longhorn-system
+  labels:
+    app: longhorn-engineimage-cleanup
+----
+
+==== Step 2: Configure RBAC permissions
+
+Define a Role with minimal required permissions:
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: longhorn-engineimage-cleanup
+  namespace: longhorn-system
+  labels:
+    app: longhorn-engineimage-cleanup
+rules:
+- apiGroups: [longhorn.io]
+  resources: [engineimages]
+  verbs: [get, list, delete]
+----
+
+Bind the Role to the ServiceAccount:
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-engineimage-cleanup
+  namespace: longhorn-system
+  labels:
+    app: longhorn-engineimage-cleanup
+subjects:
+- kind: ServiceAccount
+  name: longhorn-engineimage-cleanup
+  namespace: longhorn-system
+roleRef:
+  kind: Role
+  name: longhorn-engineimage-cleanup
+  apiGroup: rbac.authorization.k8s.io
+----
+
+==== Step 3: Deploy cleanup CronJob
+
+Deploy the automated cleanup CronJob:
+
+[source,yaml]
+----
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: longhorn-engineimage-cleanup
+  namespace: longhorn-system
+  labels:
+    app: longhorn-engineimage-cleanup
+  annotations:
+    description: "Cleanup old Longhorn engine images left over after upgrades"
+    source: "SUSE Edge Telco Cloud - Day 2 Operations"
+spec:
+  # Execute weekly on Sunday at 2:00 AM
+  schedule: "0 2 * * 0"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app: longhorn-engineimage-cleanup
+        spec:
+          serviceAccountName: longhorn-engineimage-cleanup
+          restartPolicy: Never
+          automountServiceAccountToken: true
+          containers:
+          - name: cleanup
+            image: registry.suse.com/bci/bci-base:15.6
+            command:
+            - sh
+            - -c
+            - |
+              set -e
+
+              # Install required tools
+              zypper --non-interactive install curl jq
+
+              # Install kubectl from official Kubernetes
+              curl -LO "https://dl.k8s.io/release/v1.28.0/bin/linux/amd64/kubectl"
+              chmod +x kubectl
+              mv kubectl /usr/local/bin/
+
+              echo "=== Longhorn Engine Image Cleanup ==="
+              echo "Automated maintenance - Day 2 Operations"
+              echo ""
+
+              echo "Step 1: Discovering latest engine image version..."
+
+              ENGINE_IMAGES=$(kubectl get engineimages.longhorn.io -n longhorn-system -o json)
+
+              LATEST_VERSION=$(echo "$ENGINE_IMAGES" | jq -r '
+                .items[]
+                | select(.status.version != null)
+                | .status.version' |
+                sed 's/^v//' |
+                sort -V |
+                tail -1)
+
+              if [ -z "$LATEST_VERSION" ]; then
+                echo "No engine images found. Nothing to cleanup."
+                exit 0
+              fi
+
+              echo "Latest version detected: v${LATEST_VERSION}"
+              echo ""
+
+              echo "Step 2: Identifying obsolete engine images..."
+
+              TO_DELETE=$(echo "$ENGINE_IMAGES" | jq -r --arg latest "v${LATEST_VERSION}" '
+                .items[]
+                | select(.status.version != $latest)
+                | select(.status.refCount == 0)
+                | .metadata.name')
+
+              if [ -z "$TO_DELETE" ]; then
+                echo "No obsolete engine images found"
+                echo "All engine images are either:"
+                echo "  - Latest version (v${LATEST_VERSION})"
+                echo "  - Still in use (refCount > 0)"
+                exit 0
+              fi
+
+              DELETE_COUNT=$(echo "$TO_DELETE" | wc -l | tr -d ' ')
+              echo "Found $DELETE_COUNT obsolete engine image(s) for deletion:"
+              echo "$TO_DELETE"
+              echo ""
+
+              COUNT=0
+              FAILED=0
+              for IMAGE_NAME in $TO_DELETE; do
+                VERSION=$(echo "$ENGINE_IMAGES" | jq -r --arg name "$IMAGE_NAME" \
+                  '.items[] | select(.metadata.name == $name) | .status.version')
+                REFCOUNT=$(echo "$ENGINE_IMAGES" | jq -r --arg name "$IMAGE_NAME" \
+                  '.items[] | select(.metadata.name == $name) | .status.refCount')
+
+                echo "Deleting: $IMAGE_NAME (version: $VERSION, refCount: $REFCOUNT)"
+
+                if kubectl delete engineimages.longhorn.io "$IMAGE_NAME" -n longhorn-system; then
+                  COUNT=$((COUNT + 1))
+                  echo "  ✓ Deleted successfully"
+                else
+                  FAILED=$((FAILED + 1))
+                  echo "  ✗ Failed to delete"
+                fi
+              done
+
+              echo ""
+              echo "=== Cleanup Summary ==="
+              echo "Latest version: v${LATEST_VERSION}"
+              echo "Successfully deleted: $COUNT obsolete engine images"
+              echo "Failed deletions: $FAILED engine images"
+
+              if [ $FAILED -gt 0 ]; then
+                exit 1
+              fi
+
+              echo ""
+              echo "Cleanup completed successfully"
+----
+
+==== Step 4: Apply the configuration
+
+Deploy all manifests to the cluster:
+
+[source,bash]
+----
+# Save all four manifests to a single file
+kubectl apply -f longhorn-engine-cleanup.yaml
+----
+
+Verify the CronJob was created:
+
+[source,bash]
+----
+kubectl get cronjob -n longhorn-system longhorn-engineimage-cleanup
+----
+
+Expected output:
+[source,text]
+----
+NAME                            SCHEDULE     SUSPEND   ACTIVE   LAST SCHEDULE   AGE
+longhorn-engineimage-cleanup    0 2 * * 0    False     0        <none>          5s
+----
+
+=== Operational procedures
+
+==== Manual execution
+
+To execute cleanup immediately without waiting for the scheduled time:
+
+[source,bash]
+----
+kubectl create job --from=cronjob/longhorn-engineimage-cleanup \
+  longhorn-engineimage-cleanup-manual-$(date +%Y%m%d-%H%M%S) \
+  -n longhorn-system
+----
+
+Monitor manual execution:
+
+[source,bash]
+----
+# Watch job status
+kubectl get jobs -n longhorn-system -w
+
+# View job logs
+kubectl logs -n longhorn-system -l app=longhorn-engineimage-cleanup --tail=100
+----
+
+==== Schedule configuration
+
+The default schedule executes cleanup weekly on Sunday at 2:00 AM:
+
+[source,yaml]
+----
+schedule: "0 2 * * 0"
+----
+
+Common schedule alternatives:
+
+* **Daily at 3:00 AM**: `"0 3 * * *"`
+* **Monthly on the 1st at 4:00 AM**: `"0 4 1 * *"`
+* **Every 6 hours**: `"0 */6 * * *"`
+
+Modify the schedule using:
+
+[source,bash]
+----
+kubectl patch cronjob longhorn-engineimage-cleanup \
+  -n longhorn-system \
+  --type='merge' \
+  -p '{"spec":{"schedule":"0 3 * * *"}}'
+----
+
+==== Monitoring and logs
+
+View cleanup history:
+
+[source,bash]
+----
+# List completed jobs
+kubectl get jobs -n longhorn-system -l app=longhorn-engineimage-cleanup
+
+# View logs from last successful run
+kubectl logs -n longhorn-system \
+  -l app=longhorn-engineimage-cleanup \
+  --tail=200 \
+  | grep -A 50 "Cleanup Summary"
+----
+
+Inspect specific job execution:
+
+[source,bash]
+----
+# Get job name
+JOB_NAME=$(kubectl get jobs -n longhorn-system \
+  -l app=longhorn-engineimage-cleanup \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath='{.items[-1].metadata.name}')
+
+# View job details
+kubectl describe job $JOB_NAME -n longhorn-system
+
+# View job logs
+kubectl logs job/$JOB_NAME -n longhorn-system
+----
+
+==== Verification
+
+After cleanup execution, verify that only current engine images remain:
+
+[source,bash]
+----
+# List all engine images
+kubectl get engineimages.longhorn.io -n longhorn-system
+
+# Check reference counts
+kubectl get engineimages.longhorn.io -n longhorn-system \
+  -o custom-columns=NAME:.metadata.name,VERSION:.status.version,REFCOUNT:.status.refCount
+----
+
+Expected output showing only the latest version with active references:
+
+[source,text]
+----
+NAME                                VERSION     REFCOUNT
+ei-acba2c08                         v1.11.1     3
+----
+

--- a/asciidoc/day2/longhorn-engine-image-cleanup.adoc
+++ b/asciidoc/day2/longhorn-engine-image-cleanup.adoc
@@ -75,7 +75,7 @@ metadata:
 
 . **Configure RBAC permissions**
 +
-Define a Role with minimal required permissions:
+.. Define a Role with minimal required permissions:
 +
 [source,yaml]
 ----
@@ -92,7 +92,7 @@ rules:
   verbs: [get, list, delete]
 ----
 +
-Bind the Role to the ServiceAccount:
+.. Bind the Role to the ServiceAccount:
 +
 [source,yaml]
 ----
@@ -244,14 +244,14 @@ spec:
 
 . **Apply the configuration**
 +
-Save all four manifests to a single file (e.g. `longhorn-engine-cleanup.yaml`), then deploy them to the cluster:
+.. Save all four manifests to a single file (e.g. `longhorn-engine-cleanup.yaml`), then deploy them to the cluster:
 +
 [source,bash]
 ----
 kubectl apply -f longhorn-engine-cleanup.yaml
 ----
 +
-Verify the CronJob was created:
+.. Verify the CronJob was created:
 +
 [source,bash]
 ----

--- a/asciidoc/day2/longhorn-engine-image-cleanup.adoc
+++ b/asciidoc/day2/longhorn-engine-image-cleanup.adoc
@@ -58,10 +58,10 @@ The implementation requires:
 
 The complete cleanup solution consists of four Kubernetes manifests deployed to the `longhorn-system` namespace.
 
-==== Step 1: Create ServiceAccount
-
+. **Create ServiceAccount**
++
 Create a dedicated ServiceAccount for the cleanup CronJob:
-
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -73,10 +73,10 @@ metadata:
     app: longhorn-engineimage-cleanup
 ----
 
-==== Step 2: Configure RBAC permissions
-
+. **Configure RBAC permissions**
++
 Define a Role with minimal required permissions:
-
++
 [source,yaml]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -91,9 +91,9 @@ rules:
   resources: [engineimages]
   verbs: [get, list, delete]
 ----
-
++
 Bind the Role to the ServiceAccount:
-
++
 [source,yaml]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -113,10 +113,10 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ----
 
-==== Step 3: Deploy cleanup CronJob
-
+. **Deploy cleanup CronJob**
++
 Deploy the automated cleanup CronJob:
-
++
 [source,yaml]
 ----
 apiVersion: batch/v1
@@ -130,7 +130,7 @@ metadata:
     description: "Cleanup old Longhorn engine images left over after upgrades"
     source: "SUSE Edge Telco Cloud - Day 2 Operations"
 spec:
-  # Execute weekly on Sunday at 2:00 AM
+  # Execute weekly on Sunday at 2:00 AM UTC
   schedule: "0 2 * * 0"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -242,24 +242,24 @@ spec:
               echo "Cleanup completed successfully"
 ----
 
-==== Step 4: Apply the configuration
-
-Deploy all manifests to the cluster:
-
+. **Apply the configuration**
++
+Save all four manifests to a single file (e.g. `longhorn-engine-cleanup.yaml`), then deploy them to the cluster:
++
 [source,bash]
 ----
-# Save all four manifests to a single file
 kubectl apply -f longhorn-engine-cleanup.yaml
 ----
-
++
 Verify the CronJob was created:
-
++
 [source,bash]
 ----
 kubectl get cronjob -n longhorn-system longhorn-engineimage-cleanup
 ----
-
++
 Expected output:
++
 [source,text]
 ----
 NAME                            SCHEDULE     SUSPEND   ACTIVE   LAST SCHEDULE   AGE
@@ -268,9 +268,11 @@ longhorn-engineimage-cleanup    0 2 * * 0    False     0        <none>          
 
 === Operational procedures
 
+This section describes the day-to-day operational tasks for managing the Longhorn engine image cleanup CronJob, including manual execution, schedule customization, monitoring, and verification.
+
 ==== Manual execution
 
-To execute cleanup immediately without waiting for the scheduled time:
+To execute cleanup immediately without waiting for the scheduled time, run the following command:
 
 [source,bash]
 ----
@@ -281,18 +283,23 @@ kubectl create job --from=cronjob/longhorn-engineimage-cleanup \
 
 Monitor manual execution:
 
+. Watch job status:
++
 [source,bash]
 ----
-# Watch job status
 kubectl get jobs -n longhorn-system -w
+----
 
-# View job logs
+. View job logs:
++
+[source,bash]
+----
 kubectl logs -n longhorn-system -l app=longhorn-engineimage-cleanup --tail=100
 ----
 
 ==== Schedule configuration
 
-The default schedule executes cleanup weekly on Sunday at 2:00 AM:
+The default schedule executes cleanup weekly on Sunday at 2:00 AM UTC:
 
 [source,yaml]
 ----
@@ -305,7 +312,7 @@ Common schedule alternatives:
 * **Monthly on the 1st at 4:00 AM**: `"0 4 1 * *"`
 * **Every 6 hours**: `"0 */6 * * *"`
 
-Modify the schedule using:
+Modify the schedule:
 
 [source,bash]
 ----
@@ -319,12 +326,17 @@ kubectl patch cronjob longhorn-engineimage-cleanup \
 
 View cleanup history:
 
+* List completed jobs:
++
 [source,bash]
 ----
-# List completed jobs
 kubectl get jobs -n longhorn-system -l app=longhorn-engineimage-cleanup
+----
 
-# View logs from last successful run
+* View logs from last successful run:
++
+[source,bash]
+----
 kubectl logs -n longhorn-system \
   -l app=longhorn-engineimage-cleanup \
   --tail=200 \
@@ -352,12 +364,17 @@ kubectl logs job/$JOB_NAME -n longhorn-system
 
 After cleanup execution, verify that only current engine images remain:
 
+. List all engine images:
++
 [source,bash]
 ----
-# List all engine images
 kubectl get engineimages.longhorn.io -n longhorn-system
+----
 
-# Check reference counts
+. Check reference counts:
++
+[source,bash]
+----
 kubectl get engineimages.longhorn.io -n longhorn-system \
   -o custom-columns=NAME:.metadata.name,VERSION:.status.version,REFCOUNT:.status.refCount
 ----

--- a/asciidoc/edge-book/telco.adoc
+++ b/asciidoc/edge-book/telco.adoc
@@ -163,6 +163,8 @@ include::../guides/kiwi-builder-images.adoc[leveloffset=+1]
 
 include::../guides/clusterclass.adoc[leveloffset=+1]
 
+include::../guides/longhorn-encryption.adoc[leveloffset=+1]
+
 //--------------------------------------------
 // Tips and Tricks
 //--------------------------------------------

--- a/asciidoc/edge-book/telco.adoc
+++ b/asciidoc/edge-book/telco.adoc
@@ -142,6 +142,8 @@ include::../day2/mgmt-cluster.adoc[leveloffset=+1]
 
 include::../product/atip-lifecycle.adoc[leveloffset=+1]
 
+include::../day2/longhorn-engine-image-cleanup.adoc[leveloffset=+1]
+
 //--------------------------------------------
 // IX. How-To Guides
 //--------------------------------------------

--- a/asciidoc/guides/longhorn-encryption.adoc
+++ b/asciidoc/guides/longhorn-encryption.adoc
@@ -116,7 +116,7 @@ In production environments, consider using external secret management solutions 
 
 . **Configure the encrypted StorageClass**
 +
-Define a `StorageClass` that specifies encryption parameters for the Longhorn CSI driver:
+.. Define a `StorageClass` that specifies encryption parameters for the Longhorn CSI driver:
 +
 [source,yaml]
 ----
@@ -149,14 +149,14 @@ The encryption-specific parameters configure CSI secret references:
 * `csi.storage.k8s.io/node-publish-secret-name` - Identifies the Secret used when mounting volumes to pods
 * `csi.storage.k8s.io/node-stage-secret-name` - References the Secret used during volume staging operations
 +
-Apply the StorageClass definition:
+.. Apply the StorageClass definition:
 +
 [source,bash]
 ----
 kubectl apply -f longhorn-encrypted-storageclass.yaml
 ----
 +
-Verify StorageClass creation and configuration:
+.. Verify StorageClass creation and configuration:
 +
 [source,bash]
 ----
@@ -168,7 +168,7 @@ kubectl get storageclass longhorn-encrypted -o yaml
 +
 To validate the encryption implementation, deploy a test pod that writes data to an encrypted volume.
 +
-Create the following manifest (`test-encryption.yaml`):
+.. Create the following manifest (`test-encryption.yaml`):
 +
 [source,yaml]
 ----
@@ -228,17 +228,17 @@ spec:
 +
 This manifest defines:
 +
-. A `PersistentVolumeClaim` requesting 1Gi of storage from the `longhorn-encrypted` StorageClass
-. A Pod that writes test data to the encrypted volume and remains running for verification
+* A `PersistentVolumeClaim` requesting 1Gi of storage from the `longhorn-encrypted` StorageClass
+* A Pod that writes test data to the encrypted volume and remains running for verification
 +
-Deploy the test workload:
+.. Deploy the test workload:
 +
 [source,bash]
 ----
 kubectl apply -f test-encryption.yaml
 ----
 +
-Monitor pod startup:
+.. Monitor pod startup:
 +
 [source,bash]
 ----

--- a/asciidoc/guides/longhorn-encryption.adoc
+++ b/asciidoc/guides/longhorn-encryption.adoc
@@ -28,10 +28,10 @@ Longhorn implements volume-level encryption using industry-standard cryptographi
 
 Volume encryption addresses several security and compliance requirements:
 
-. **Data Protection at Rest**: Encrypted data on physical storage media remains protected against unauthorized access, even if disks are physically removed or stolen.
-. **Regulatory Compliance**: Industry regulations such as GDPR, HIPAA, and PCI-DSS mandate encryption for sensitive data, making volume encryption essential for compliance.
-. **Defense in Depth**: Encryption provides an additional security layer that complements Kubernetes RBAC and network policies.
-. **Secure Data Disposal**: Encrypted volumes can be securely decommissioned by simply destroying the encryption keys, ensuring data is rendered permanently inaccessible.
+* **Data Protection at Rest**: Encrypted data on physical storage media remains protected against unauthorized access, even if disks are physically removed or stolen.
+* **Regulatory Compliance**: Industry regulations such as GDPR, HIPAA, and PCI-DSS mandate encryption for sensitive data, making volume encryption essential for compliance.
+* **Defense in Depth**: Encryption provides an additional security layer that complements Kubernetes RBAC and network policies.
+* **Secure Data Disposal**: Encrypted volumes can be securely decommissioned by simply destroying the encryption keys, ensuring data is rendered permanently inaccessible.
 
 [NOTE]
 ====
@@ -63,23 +63,24 @@ Before implementing Longhorn volume encryption, ensure the following prerequisit
 * `kubectl` command-line tool configured for cluster access
 * `openssl` utility for cryptographic key generation
 
-== Implementation guide
+== Implementation
 
-=== Step 1: Generate the encryption key
-
-Encryption key generation must be performed using cryptographically secure random number generation. Execute the following command to generate a 256-bit encryption key encoded in base64 format:
-
+. **Generate the encryption key**
++
+Encryption key generation must be performed using cryptographically secure random number generation. Run the following command to generate a 256-bit encryption key encoded in `base64` format:
++
 [source,bash]
 ----
 openssl rand -base64 32
 ----
-
++
 Example output:
++
 [source,text]
 ----
 Kq8Xh2vN9pL3mZ1wR4tY6uI0oP5aS7dF8gH9jK1lM2n=
 ----
-
++
 [WARNING]
 ====
 **Key Management Critical Requirements**
@@ -88,10 +89,10 @@ Kq8Xh2vN9pL3mZ1wR4tY6uI0oP5aS7dF8gH9jK1lM2n=
 * Loss of the encryption key results in **permanent and irreversible data loss**
 ====
 
-=== Step 2: Create the encryption key Secret
-
+. **Create the encryption key Secret**
++
 Once generated, the encryption key must be stored as a Kubernetes Secret in the `longhorn-system` namespace:
-
++
 [source,bash]
 ----
 CRYPTO_KEY_VALUE="Kq8Xh2vN9pL3mZ1wR4tY6uI0oP5aS7dF8gH9jK1lM2n="
@@ -100,23 +101,23 @@ kubectl create secret generic longhorn-crypto \
   --from-literal=CRYPTO_KEY_VALUE="${CRYPTO_KEY_VALUE}" \
   -n longhorn-system
 ----
-
++
 Verify successful Secret creation:
-
++
 [source,bash]
 ----
 kubectl get secret longhorn-crypto -n longhorn-system
 ----
-
++
 [TIP]
 ====
-In production environments, consider using external secret management solutions that integrate with Kubernetes, such as the External Secrets Operator or sealed-secrets, to avoid storing sensitive data directly in cluster etcd.
+In production environments, consider using external secret management solutions that integrate with Kubernetes, such as the External Secrets Operator or sealed-secrets, to avoid storing sensitive data directly in the cluster's etcd.
 ====
 
-=== Step 3: Configure the encrypted StorageClass
-
-Define a StorageClass that specifies encryption parameters for the Longhorn CSI driver:
-
+. **Configure the encrypted StorageClass**
++
+Define a `StorageClass` that specifies encryption parameters for the Longhorn CSI driver:
++
 [source,yaml]
 ----
 apiVersion: storage.k8s.io/v1
@@ -140,35 +141,35 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
   csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
 ----
-
++
 The encryption-specific parameters configure CSI secret references:
-
++
 * `encrypted: "true"` - Enables LUKS encryption for all volumes provisioned from this StorageClass
 * `csi.storage.k8s.io/provisioner-secret-name` - Specifies the Secret containing the encryption key used during volume provisioning
 * `csi.storage.k8s.io/node-publish-secret-name` - Identifies the Secret used when mounting volumes to pods
 * `csi.storage.k8s.io/node-stage-secret-name` - References the Secret used during volume staging operations
-
++
 Apply the StorageClass definition:
-
++
 [source,bash]
 ----
 kubectl apply -f longhorn-encrypted-storageclass.yaml
 ----
-
++
 Verify StorageClass creation and configuration:
-
++
 [source,bash]
 ----
 kubectl get storageclass longhorn-encrypted
 kubectl get storageclass longhorn-encrypted -o yaml
 ----
 
-=== Step 4: Deploy a test workload
-
+. **Deploy a test workload**
++
 To validate the encryption implementation, deploy a test pod that writes data to an encrypted volume.
-
++
 Create the following manifest (`test-encryption.yaml`):
-
++
 [source,yaml]
 ----
 # Test Longhorn Encryption
@@ -224,45 +225,54 @@ spec:
     persistentVolumeClaim:
       claimName: test-encrypted-pvc
 ----
-
++
 This manifest defines:
-
-* A PersistentVolumeClaim requesting 1Gi of storage from the `longhorn-encrypted` StorageClass
-* A Pod that writes test data to the encrypted volume and remains running for verification
-
++
+. A `PersistentVolumeClaim` requesting 1Gi of storage from the `longhorn-encrypted` StorageClass
+. A Pod that writes test data to the encrypted volume and remains running for verification
++
 Deploy the test workload:
-
++
 [source,bash]
 ----
 kubectl apply -f test-encryption.yaml
 ----
-
++
 Monitor pod startup:
-
++
 [source,bash]
 ----
 kubectl get pod encryption-test-pod -w
 ----
 
-=== Step 5: Verify volume functionality
-
+. **Verify volume functionality**
++
 Once the pod reaches `Running` state, verify that data operations complete successfully:
-
++
+.. View pod logs:
++
 [source,bash]
 ----
-# View pod logs
 kubectl logs encryption-test-pod
+----
 
-# Execute a shell inside the pod
+.. Run a shell inside the pod:
++
+[source,bash]
+----
 kubectl exec -it encryption-test-pod -- sh
+----
 
-# Inside the pod, verify the content:
+.. Inside the pod, verify the content:
++
+[source,bash]
+----
 cat /data/secret.txt
 ls -lh /data/
 ----
-
++
 Expected output:
-
++
 [source,text]
 ----
 SECRET DATA: Credit Card 4111-1111-1111-1111
@@ -270,20 +280,20 @@ SECRET DATA: Password MySuperSecret123!
 SECRET DATA: API Key sk-1234567890abcdef
 Thu Jul 03 10:30:45 UTC 2026
 ----
-
++
 [NOTE]
 ====
 Successful data operations confirm volume provisioning and mounting functionality. However, this verification alone does not validate encryption. The following steps provide cryptographic verification.
 ====
 
-=== Step 6: Cryptographic verification
-
+. **Cryptographic verification**
++
 To conclusively verify that encryption is active, direct inspection of the underlying storage device is required.
-
-==== 6.1. Identify the volume location
-
++
+.. **Identify the volume location**
++
 Determine which node hosts the volume replica:
-
++
 [source,bash]
 ----
 # Get the PVC details
@@ -296,10 +306,10 @@ kubectl get pv | grep test-encrypted
 kubectl get volumes -n longhorn-system | grep test-encrypted
 ----
 
-==== 6.2. Access the node and locate volume files
-
+.. **Access the node and locate volume files**
++
 SSH to the node hosting the volume (identified from the previous output):
-
++
 [source,bash]
 ----
 # Connect to the node
@@ -308,32 +318,33 @@ ssh root@<node-ip>
 # Locate the volume image file
 find /var/lib/longhorn -name "*.img*" -type f | grep -i test
 ----
-
++
 Typical volume path:
++
 [source,text]
 ----
 /var/lib/longhorn/replicas/pvc-abc12345-r-6789/volume-head-001.img
 ----
 
-==== 6.3. Attempt plaintext data extraction
-
-Execute the following command to search for unencrypted data:
-
+.. **Attempt plaintext data extraction**
++
+Run the following command to search for unencrypted data:
++
 [source,bash]
 ----
 # Attempt to find plaintext strings in the volume file
 strings /var/lib/longhorn/replicas/pvc-*/volume-head-*.img | grep -i "credit card"
 ----
-
++
 **Verification results:**
-
++
 * **Encryption active**: No plaintext strings found (data is encrypted)
 * **Encryption inactive**: Plaintext strings detected (data is unencrypted)
 
-==== 6.4. Hexadecimal inspection
-
+.. **Hexadecimal inspection**
++
 Examine the raw byte content of the volume:
-
++
 [source,bash]
 ----
 # Navigate to the replica directory
@@ -342,25 +353,27 @@ cd /var/lib/longhorn/replicas/pvc-XXXXX-r-YYYY/
 # Display raw volume content
 hexdump -C volume-head-*.img | head -100
 ----
-
++
 **Encrypted volume output (random bytes):**
++
 [source,text]
 ----
 00000000  a3 7f 2c d9 8b 4e f1 2a  9c 5d 8e 6b 4f 1d 3c 7a  |..,..N.*.[.kO.<z|
 00000010  d2 9f 4a 8c 3b e7 6d 1e  5f 0c b8 a4 7d 2f 9e 6c  |..J.;.m._...}/.l|
 ----
-
++
 **Unencrypted volume output (readable ASCII):**
++
 [source,text]
 ----
 00000000  53 45 43 52 45 54 20 44  41 54 41 3a 20 43 72 65  |SECRET DATA: Cre|
 00000010  64 69 74 20 43 61 72 64  20 34 31 31 31 2d 31 31  |dit Card 4111-11|
 ----
 
-=== Step 7: LUKS device verification
-
+. **LUKS device verification**
++
 Longhorn implements encryption using the Linux LUKS subsystem. Verify LUKS device mapper targets:
-
++
 [source,bash]
 ----
 # List block devices with encryption type
@@ -369,13 +382,13 @@ lsblk -o NAME,FSTYPE,SIZE,MOUNTPOINT | grep -i crypt
 # List device mapper crypt targets
 dmsetup ls --target crypt
 ----
-
++
 The presence of `crypto_LUKS` filesystem types or device mapper crypt targets confirms active LUKS encryption.
 
-=== Step 8: Data persistence verification
-
+. **Data persistence verification**
++
 Verify that encrypted volumes maintain data integrity across pod lifecycle events:
-
++
 [source,bash]
 ----
 # Delete the pod (volume persists)
@@ -390,7 +403,7 @@ kubectl get pod encryption-test-pod -w
 # Verify data persistence
 kubectl exec -it encryption-test-pod -- cat /data/secret.txt
 ----
-
++
 Data should remain intact, demonstrating proper volume persistence.
 
 == Encryption verification summary
@@ -432,7 +445,7 @@ kubectl delete pvc test-encrypted-pvc
 
 == CAPI integration
 
-When deploying clusters using Cluster API (CAPI) with Metal3, encryption configuration can be embedded in cluster provisioning manifests, enabling encrypted storage from initial cluster bootstrap.
+When deploying clusters using Cluster API (CAPI) with Metal^3^, encryption configuration can be embedded in cluster provisioning manifests, enabling encrypted storage from initial cluster bootstrap.
 
 A complete reference implementation is available in the https://github.com/suse-edge/telco-cloud-examples/tree/main/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption[SUSE Edge telco-cloud-examples repository].
 

--- a/asciidoc/guides/longhorn-encryption.adoc
+++ b/asciidoc/guides/longhorn-encryption.adoc
@@ -1,0 +1,472 @@
+[#guides-longhorn-encryption]
+= Longhorn Volume Encryption
+:revdate: 2026-07-03
+:page-revdate: {revdate}
+:experimental:
+
+ifdef::env-github[]
+:imagesdir: ../images/
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+Longhorn is a distributed block storage system for Kubernetes that provides persistent storage with replication and high availability capabilities. This guide demonstrates how to configure Longhorn with LUKS/AES-256 encryption to ensure data protection at rest.
+
+== Introduction
+
+Data security is a critical requirement for modern cloud-native applications, particularly in environments handling sensitive information. Volume encryption provides a fundamental security layer that protects data stored on physical media from unauthorized access, even in scenarios where physical security has been compromised.
+
+Longhorn implements volume-level encryption using industry-standard cryptographic technologies:
+
+* **LUKS (Linux Unified Key Setup)**: A specification for block device encryption that provides a platform-independent standard on-disk format
+* **AES-256**: Advanced Encryption Standard with 256-bit keys, providing robust cryptographic protection
+
+== Why implement volume encryption
+
+Volume encryption addresses several security and compliance requirements:
+
+. **Data Protection at Rest**: Encrypted data on physical storage media remains protected against unauthorized access, even if disks are physically removed or stolen.
+. **Regulatory Compliance**: Industry regulations such as GDPR, HIPAA, and PCI-DSS mandate encryption for sensitive data, making volume encryption essential for compliance.
+. **Defense in Depth**: Encryption provides an additional security layer that complements Kubernetes RBAC and network policies.
+. **Secure Data Disposal**: Encrypted volumes can be securely decommissioned by simply destroying the encryption keys, ensuring data is rendered permanently inaccessible.
+
+[NOTE]
+====
+Encryption is applied transparently at the volume level. Applications interact with encrypted volumes through standard Kubernetes persistent volume claims without requiring code modifications.
+====
+
+== Architecture overview
+
+Longhorn encryption integrates with the Kubernetes Container Storage Interface (CSI) to provide transparent volume encryption. The encryption process occurs during volume provisioning and is managed through the following components:
+
+* **Kubernetes Secrets**: Encryption keys are stored securely as Kubernetes Secret resources
+* **StorageClass Parameters**: Encryption configuration is specified through CSI-specific parameters
+* **LUKS Device Mapper**: Each encrypted volume is backed by a LUKS-encrypted device mapper target
+* **CSI Driver**: The Longhorn CSI driver manages encryption key retrieval and volume staging
+
+The encryption workflow operates as follows:
+
+. When a PersistentVolumeClaim (PVC) requests storage from an encrypted StorageClass, the Longhorn CSI driver retrieves the encryption key from the designated Secret
+. A LUKS-encrypted device mapper target is created using the encryption key
+. All data written to the volume is encrypted before being committed to the underlying storage
+. When the volume is mounted, the CSI driver stages the volume by unlocking the LUKS device using the stored encryption key
+
+== Prerequisites
+
+Before implementing Longhorn volume encryption, ensure the following prerequisites are met:
+
+* A functional Kubernetes cluster with Longhorn version 1.11.1 or higher installed
+* Cluster administrative access with appropriate RBAC permissions
+* `kubectl` command-line tool configured for cluster access
+* `openssl` utility for cryptographic key generation
+
+== Implementation guide
+
+=== Step 1: Generate the encryption key
+
+Encryption key generation must be performed using cryptographically secure random number generation. Execute the following command to generate a 256-bit encryption key encoded in base64 format:
+
+[source,bash]
+----
+openssl rand -base64 32
+----
+
+Example output:
+[source,text]
+----
+Kq8Xh2vN9pL3mZ1wR4tY6uI0oP5aS7dF8gH9jK1lM2n=
+----
+
+[WARNING]
+====
+**Key Management Critical Requirements**
+
+* **Never commit encryption keys to version control systems**
+* Loss of the encryption key results in **permanent and irreversible data loss**
+====
+
+=== Step 2: Create the encryption key Secret
+
+Once generated, the encryption key must be stored as a Kubernetes Secret in the `longhorn-system` namespace:
+
+[source,bash]
+----
+CRYPTO_KEY_VALUE="Kq8Xh2vN9pL3mZ1wR4tY6uI0oP5aS7dF8gH9jK1lM2n="
+
+kubectl create secret generic longhorn-crypto \
+  --from-literal=CRYPTO_KEY_VALUE="${CRYPTO_KEY_VALUE}" \
+  -n longhorn-system
+----
+
+Verify successful Secret creation:
+
+[source,bash]
+----
+kubectl get secret longhorn-crypto -n longhorn-system
+----
+
+[TIP]
+====
+In production environments, consider using external secret management solutions that integrate with Kubernetes, such as the External Secrets Operator or sealed-secrets, to avoid storing sensitive data directly in cluster etcd.
+====
+
+=== Step 3: Configure the encrypted StorageClass
+
+Define a StorageClass that specifies encryption parameters for the Longhorn CSI driver:
+
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-encrypted
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+parameters:
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "2880"
+  fromBackup: ""
+  fsType: "ext4"
+  dataLocality: "disabled"
+  # Encryption configuration
+  encrypted: "true"
+  csi.storage.k8s.io/provisioner-secret-name: "longhorn-crypto"
+  csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-publish-secret-name: "longhorn-crypto"
+  csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
+  csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+----
+
+The encryption-specific parameters configure CSI secret references:
+
+* `encrypted: "true"` - Enables LUKS encryption for all volumes provisioned from this StorageClass
+* `csi.storage.k8s.io/provisioner-secret-name` - Specifies the Secret containing the encryption key used during volume provisioning
+* `csi.storage.k8s.io/node-publish-secret-name` - Identifies the Secret used when mounting volumes to pods
+* `csi.storage.k8s.io/node-stage-secret-name` - References the Secret used during volume staging operations
+
+Apply the StorageClass definition:
+
+[source,bash]
+----
+kubectl apply -f longhorn-encrypted-storageclass.yaml
+----
+
+Verify StorageClass creation and configuration:
+
+[source,bash]
+----
+kubectl get storageclass longhorn-encrypted
+kubectl get storageclass longhorn-encrypted -o yaml
+----
+
+=== Step 4: Deploy a test workload
+
+To validate the encryption implementation, deploy a test pod that writes data to an encrypted volume.
+
+Create the following manifest (`test-encryption.yaml`):
+
+[source,yaml]
+----
+# Test Longhorn Encryption
+# Deploys a simple pod that writes data to an encrypted volume
+
+---
+# PVC using the encrypted StorageClass
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-encrypted-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-encrypted
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+# Pod that writes sensitive data to the volume
+apiVersion: v1
+kind: Pod
+metadata:
+  name: encryption-test-pod
+  namespace: default
+  labels:
+    app: encryption-test
+spec:
+  containers:
+  - name: writer
+    image: busybox
+    command:
+      - sh
+      - -c
+      - |
+        echo "=== Writing sensitive data to encrypted volume ==="
+        echo "SECRET DATA: Credit Card 4111-1111-1111-1111" > /data/secret.txt
+        echo "SECRET DATA: Password MySuperSecret123!" >> /data/secret.txt
+        echo "SECRET DATA: API Key sk-1234567890abcdef" >> /data/secret.txt
+        date >> /data/secret.txt
+        echo "=== Data written successfully ==="
+        echo "Content of /data/secret.txt:"
+        cat /data/secret.txt
+        echo "=== Sleeping forever (use 'kubectl exec' to verify) ==="
+        sleep infinity
+    volumeMounts:
+    - name: encrypted-storage
+      mountPath: /data
+  volumes:
+  - name: encrypted-storage
+    persistentVolumeClaim:
+      claimName: test-encrypted-pvc
+----
+
+This manifest defines:
+
+* A PersistentVolumeClaim requesting 1Gi of storage from the `longhorn-encrypted` StorageClass
+* A Pod that writes test data to the encrypted volume and remains running for verification
+
+Deploy the test workload:
+
+[source,bash]
+----
+kubectl apply -f test-encryption.yaml
+----
+
+Monitor pod startup:
+
+[source,bash]
+----
+kubectl get pod encryption-test-pod -w
+----
+
+=== Step 5: Verify volume functionality
+
+Once the pod reaches `Running` state, verify that data operations complete successfully:
+
+[source,bash]
+----
+# View pod logs
+kubectl logs encryption-test-pod
+
+# Execute a shell inside the pod
+kubectl exec -it encryption-test-pod -- sh
+
+# Inside the pod, verify the content:
+cat /data/secret.txt
+ls -lh /data/
+----
+
+Expected output:
+
+[source,text]
+----
+SECRET DATA: Credit Card 4111-1111-1111-1111
+SECRET DATA: Password MySuperSecret123!
+SECRET DATA: API Key sk-1234567890abcdef
+Thu Jul 03 10:30:45 UTC 2026
+----
+
+[NOTE]
+====
+Successful data operations confirm volume provisioning and mounting functionality. However, this verification alone does not validate encryption. The following steps provide cryptographic verification.
+====
+
+=== Step 6: Cryptographic verification
+
+To conclusively verify that encryption is active, direct inspection of the underlying storage device is required.
+
+==== 6.1. Identify the volume location
+
+Determine which node hosts the volume replica:
+
+[source,bash]
+----
+# Get the PVC details
+kubectl get pvc test-encrypted-pvc
+
+# Get the associated PersistentVolume
+kubectl get pv | grep test-encrypted
+
+# View Longhorn volume details
+kubectl get volumes -n longhorn-system | grep test-encrypted
+----
+
+==== 6.2. Access the node and locate volume files
+
+SSH to the node hosting the volume (identified from the previous output):
+
+[source,bash]
+----
+# Connect to the node
+ssh root@<node-ip>
+
+# Locate the volume image file
+find /var/lib/longhorn -name "*.img*" -type f | grep -i test
+----
+
+Typical volume path:
+[source,text]
+----
+/var/lib/longhorn/replicas/pvc-abc12345-r-6789/volume-head-001.img
+----
+
+==== 6.3. Attempt plaintext data extraction
+
+Execute the following command to search for unencrypted data:
+
+[source,bash]
+----
+# Attempt to find plaintext strings in the volume file
+strings /var/lib/longhorn/replicas/pvc-*/volume-head-*.img | grep -i "credit card"
+----
+
+**Verification results:**
+
+* **Encryption active**: No plaintext strings found (data is encrypted)
+* **Encryption inactive**: Plaintext strings detected (data is unencrypted)
+
+==== 6.4. Hexadecimal inspection
+
+Examine the raw byte content of the volume:
+
+[source,bash]
+----
+# Navigate to the replica directory
+cd /var/lib/longhorn/replicas/pvc-XXXXX-r-YYYY/
+
+# Display raw volume content
+hexdump -C volume-head-*.img | head -100
+----
+
+**Encrypted volume output (random bytes):**
+[source,text]
+----
+00000000  a3 7f 2c d9 8b 4e f1 2a  9c 5d 8e 6b 4f 1d 3c 7a  |..,..N.*.[.kO.<z|
+00000010  d2 9f 4a 8c 3b e7 6d 1e  5f 0c b8 a4 7d 2f 9e 6c  |..J.;.m._...}/.l|
+----
+
+**Unencrypted volume output (readable ASCII):**
+[source,text]
+----
+00000000  53 45 43 52 45 54 20 44  41 54 41 3a 20 43 72 65  |SECRET DATA: Cre|
+00000010  64 69 74 20 43 61 72 64  20 34 31 31 31 2d 31 31  |dit Card 4111-11|
+----
+
+=== Step 7: LUKS device verification
+
+Longhorn implements encryption using the Linux LUKS subsystem. Verify LUKS device mapper targets:
+
+[source,bash]
+----
+# List block devices with encryption type
+lsblk -o NAME,FSTYPE,SIZE,MOUNTPOINT | grep -i crypt
+
+# List device mapper crypt targets
+dmsetup ls --target crypt
+----
+
+The presence of `crypto_LUKS` filesystem types or device mapper crypt targets confirms active LUKS encryption.
+
+=== Step 8: Data persistence verification
+
+Verify that encrypted volumes maintain data integrity across pod lifecycle events:
+
+[source,bash]
+----
+# Delete the pod (volume persists)
+kubectl delete pod encryption-test-pod
+
+# Recreate the pod
+kubectl apply -f test-encryption.yaml
+
+# Wait for Running state
+kubectl get pod encryption-test-pod -w
+
+# Verify data persistence
+kubectl exec -it encryption-test-pod -- cat /data/secret.txt
+----
+
+Data should remain intact, demonstrating proper volume persistence.
+
+== Encryption verification summary
+
+The following table summarizes encryption verification indicators:
+
+|===
+|Verification Method | Encrypted | Not Encrypted
+
+|`strings` output
+|No plaintext found
+|Plaintext strings visible
+
+|`hexdump` output
+|Random binary data
+|Readable ASCII text
+
+|`lsblk` output
+|`crypto_LUKS` type present
+|No `crypto_LUKS` type
+
+|`dmsetup ls --target crypt`
+|Lists crypt devices
+|No crypt devices listed
+|===
+
+== Test environment cleanup
+
+Remove test resources:
+
+[source,bash]
+----
+# Delete the test pod
+kubectl delete -f test-encryption.yaml
+
+# Delete the PVC and volume
+kubectl delete pvc test-encrypted-pvc
+----
+
+== CAPI integration
+
+When deploying clusters using Cluster API (CAPI) with Metal3, encryption configuration can be embedded in cluster provisioning manifests, enabling encrypted storage from initial cluster bootstrap.
+
+A complete reference implementation is available in the https://github.com/suse-edge/telco-cloud-examples/tree/main/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption[SUSE Edge telco-cloud-examples repository].
+
+This reference implementation includes:
+
+* **BareMetalHost** definitions for multi-node control plane deployment
+* **CAPI cluster manifests** with integrated Longhorn encryption configuration
+* **Automatic Secret provisioning** during cluster initialization
+* **Pre-configured encrypted StorageClass** set as default
+* **MetalLB** configuration for VIP management
+* **Endpoint Copier Operator** for control plane endpoint synchronization
+
+In CAPI-based deployments, the encryption key is typically provided through cluster provisioning variables:
+
+[source,yaml]
+----
+# Example variable reference from CAPI manifest
+# Full manifests available in the repository
+CRYPTO_KEY_VALUE: "YOUR_GENERATED_KEY_HERE"
+----
+
+This variable is consumed during cluster provisioning to automatically create the `longhorn-crypto` Secret in the downstream cluster's `longhorn-system` namespace.
+
+[CAUTION]
+====
+**CAPI encryption deployment considerations:**
+
+* Generate encryption keys using `openssl rand -base64 32` before cluster provisioning
+* Replace placeholder values in manifests with actual encryption keys
+* **Never commit manifests containing real encryption keys to version control**
+* Implement GitOps workflows with secret management solutions
+* Maintain encryption keys in enterprise secret management systems for disaster recovery
+* Use unique encryption keys per cluster to limit blast radius in case of key compromise
+====
+
+
+


### PR DESCRIPTION
This pull request adds comprehensive documentation and operational procedures for automating the cleanup of obsolete Longhorn engine images in Kubernetes clusters. The main focus is on introducing a new Day 2 operations guide, including step-by-step Kubernetes manifests and instructions, and integrating this content into the main documentation structure.

**Longhorn Engine Image Cleanup Documentation and Integration:**

* New content: Adds a detailed AsciiDoc guide (`longhorn-engine-image-cleanup.adoc`) describing the problem, solution architecture, and implementation steps for safely cleaning up unused Longhorn engine images using a Kubernetes CronJob, with YAML manifests and operational procedures.
* Documentation integration: Includes the new cleanup guide in the main Telco Edge Book documentation by adding it to `edge-book/telco.adoc` under Day 2 operations.

**Related documentation updates:**

* Adds the Longhorn encryption guide to the documentation structure for improved discoverability.