### PR TITLE
[release-3.6] Fix migration version - should be 3.6.0

### DIFF
--- a/asciidoc/day2/migration.adoc
+++ b/asciidoc/day2/migration.adoc
@@ -14,8 +14,8 @@ ifdef::env-github[]
 endif::[]
 :toc: preamble
 :previous-edge-version: 3.5
-:static-edge-version: 3.6.1
-:static-fleet-examples-tag: release-3.6.1
+:static-edge-version: 3.6.0
+:static-fleet-examples-tag: release-3.6.0
 
 This section explains how to migrate your `management` and `downstream` clusters from `{product} {previous-edge-version}` to `{product} {static-edge-version}`.
 


### PR DESCRIPTION
Partially reverts changes made in #1174 - we should not update the migration docs for z-streams, since the tested/supported path is to upgrade to the .0 release when migrating from a previous y-stream.