### PR TITLE
Restyle quickstart architecture diagrams to SUSE palette

### DIFF
--- a/asciidoc/images/quickstart-elemental-architecture.svg
+++ b/asciidoc/images/quickstart-elemental-architecture.svg
@@ -516,7 +516,7 @@
          y="79.375015"
          style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.58611px;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Admin Laptop</tspan></text>
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect867"
        width="37.041668"
        height="10.583333"
@@ -589,7 +589,7 @@
        rx="2.8977962"
        ry="2.6458333" />
     <rect
-       style="fill:#c8dafc;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1387"
        width="42.333332"
        height="16.368952"
@@ -599,7 +599,7 @@
        ry="2.7281582"
        transform="matrix(1,0,-0.2438067,0.96982385,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1387-6"
        width="42.333332"
        height="16.368952"
@@ -609,7 +609,7 @@
        ry="2.7281582"
        transform="matrix(1,0,-0.2438067,0.96982385,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1387-2"
        width="42.333332"
        height="16.368952"
@@ -619,7 +619,7 @@
        ry="2.7281582"
        transform="matrix(1,0,-0.2438067,0.96982385,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1387-9"
        width="42.333332"
        height="16.368952"
@@ -629,7 +629,7 @@
        ry="2.7281582"
        transform="matrix(1,0,-0.2438067,0.96982385,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1387-1"
        width="42.333332"
        height="16.368952"
@@ -639,7 +639,7 @@
        ry="2.7281582"
        transform="matrix(1,0,-0.2438067,0.96982385,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1387-9-7"
        width="42.597912"
        height="21.825262"
@@ -649,7 +649,7 @@
        ry="2.7281582"
        transform="matrix(1,0,-0.2438067,0.96982385,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1387-9-7-0"
        width="42.597912"
        height="21.825262"
@@ -659,7 +659,7 @@
        ry="2.7281582"
        transform="matrix(1,0,-0.2438067,0.96982385,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.67167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1387-9-7-0-3"
        width="42.597912"
        height="21.825262"
@@ -745,7 +745,7 @@
          y="30.103407"
          style="stroke-width:0.264583">GitRepo</tspan></text>
     <rect
-       style="fill:#ffefe9;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#f4faf7;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1518"
        width="140.22917"
        height="37.041672"
@@ -754,7 +754,7 @@
        rx="2.8977959"
        ry="2.6458333" />
     <rect
-       style="fill:#ffefe9;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#f4faf7;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1518-6"
        width="94.456261"
        height="37.041656"
@@ -801,7 +801,7 @@
          y="64.897003"
          style="stroke-width:0.264583">Bundle</tspan></text>
     <rect
-       style="fill:#fe7c3f;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#30ba78;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1549"
        width="42.333344"
        height="10.583344"
@@ -831,7 +831,7 @@
          style="text-align:center;text-anchor:middle;stroke-width:0.264583"
          id="tspan7852">Elemental Operator</tspan></text>
     <rect
-       style="fill:#fe7c3f;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#30ba78;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1549-0"
        width="42.333347"
        height="10.583344"
@@ -873,7 +873,7 @@
          y="85.724998"
          style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.5861px;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Rancher Fleet</tspan></text>
     <rect
-       style="fill:#fe7c3f;stroke:#0c322c;stroke-width:0.66145833;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#30ba78;stroke:#0c322c;stroke-width:0.66145833;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1549-0-8"
        width="42.333332"
        height="15.875"
@@ -912,7 +912,7 @@
        rx="5.2916665"
        ry="5.2916665" />
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#f4faf7;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1623"
        width="238.125"
        height="111.125"
@@ -921,7 +921,7 @@
        rx="2.6458435"
        ry="2.6458385" />
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#f4faf7;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1627"
        width="129.64584"
        height="79.375015"
@@ -930,7 +930,7 @@
        rx="2.6458333"
        ry="2.6458333" />
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1629"
        width="50.270832"
        height="18.520834"
@@ -939,7 +939,7 @@
        rx="2.6458333"
        ry="2.6458333" />
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1631"
        width="44.979168"
        height="15.875"
@@ -948,7 +948,7 @@
        rx="2.6458333"
        ry="2.6458333" />
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1631-2"
        width="44.979168"
        height="15.875"
@@ -1049,7 +1049,7 @@
          id="tspan1708"
          x="42.333332"
          y="161.92503"
-         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.58611px;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Edge Location</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.58611px;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Downstream Location</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:4.58611px;line-height:1.25;font-family:SUSE;-inkscape-font-specification:SUSE;letter-spacing:0px;stroke-width:0.264583"
@@ -1060,9 +1060,9 @@
          id="tspan1712"
          x="62.970833"
          y="177.79996"
-         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.58611px;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Edge Server</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:4.58611px;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Downstream Server</tspan></text>
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1631-2-8"
        width="44.979168"
        height="15.875"
@@ -1087,7 +1087,7 @@
          style="text-align:center;text-anchor:middle;stroke-width:0.264583"
          id="tspan1779">system-agent</tspan></text>
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1631-2-3"
        width="44.979168"
        height="15.875"
@@ -1107,7 +1107,7 @@
          y="225.9241"
          style="stroke-width:0.264583">rancher-system-agent</tspan></text>
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1631-2-3-2"
        width="44.979168"
        height="15.875"
@@ -1321,7 +1321,7 @@
        id="path3673"
        sodipodi:nodetypes="cc" />
     <rect
-       style="fill:none;stroke:#0c322c;stroke-width:0.669779;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#0c322c;stroke-width:0.669779;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1625"
        width="214.3125"
        height="15.875"

--- a/asciidoc/images/quickstart-metal3-architecture.svg
+++ b/asciidoc/images/quickstart-metal3-architecture.svg
@@ -298,10 +298,10 @@
        rx="2.6458232" />
     <path
        id="rect1708"
-       style="fill:none;stroke:#000000;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#f4faf7;stroke:#30ba78;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        d="M 18.520833 169.33333 C 17.055042 169.33333 15.875 170.51337 15.875 171.97917 L 15.875 248.70833 C 15.875 250.17413 17.055042 251.35417 18.520833 251.35417 L 187.85417 251.35417 C 189.31996 251.35417 190.5 250.17413 190.5 248.70833 L 190.5 171.97917 C 190.5 170.51337 189.31996 169.33333 187.85417 169.33333 L 100.54167 169.33333 L 100.54167 171.97917 C 100.54167 174.91075 98.181586 177.27083 95.25 177.27083 L 52.916667 177.27083 C 49.985081 177.27083 47.625 174.91075 47.625 171.97917 L 47.625 169.33333 L 18.520833 169.33333 z " />
     <rect
-       style="fill:none;stroke:#000000;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1712"
        width="42.333332"
        height="23.812506"
@@ -310,7 +310,7 @@
        rx="0"
        ry="0" />
     <rect
-       style="fill:none;stroke:#000000;stroke-width:0.666858;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#f4faf7;stroke:#30ba78;stroke-width:0.666858;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1714"
        width="164.04166"
        height="31.75"
@@ -319,7 +319,7 @@
        ry="2.6458435"
        rx="2.6892076" />
     <rect
-       style="fill:none;stroke:#000000;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1716"
        width="63.5"
        height="15.875"
@@ -328,7 +328,16 @@
        rx="0"
        ry="0" />
     <rect
-       style="fill:#ffefe9;stroke:#000000;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       id="rect1"
+       width="52.916664"
+       height="15.87501"
+       x="47.625004"
+       y="161.39583"
+       rx="5.2916718"
+       ry="5.2916718" />
+    <rect
+       style="fill:#f4faf7;stroke:#30ba78;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1720"
        width="73.025017"
        height="47.625"
@@ -337,7 +346,7 @@
        rx="2.6458228"
        ry="2.9652648" />
     <rect
-       style="fill:#fe7c3f;stroke:#000000;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#30ba78;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1722"
        width="34.395832"
        height="10.583336"
@@ -346,7 +355,7 @@
        rx="2.6458228"
        ry="5.2916679" />
     <rect
-       style="fill:#fe7c3f;stroke:#000000;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#30ba78;stroke:#0c322c;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1722-2"
        width="52.91666"
        height="10.583354"
@@ -355,7 +364,7 @@
        rx="2.6458228"
        ry="5.2916679" />
     <rect
-       style="fill:#fe7c3f;stroke:#000000;stroke-width:0.684095;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#30ba78;stroke:#0c322c;stroke-width:0.684095;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1722-7"
        width="31.202496"
        height="7.9191179"
@@ -364,7 +373,7 @@
        rx="2.8365788"
        ry="3.959559" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.688752;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.688752;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1745"
        width="29.104166"
        height="20.080809"
@@ -385,7 +394,7 @@
          y="90.487511"
          style="stroke-width:0.264583">Machine</tspan></text>
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.688753;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.688753;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1745-0"
        width="29.104166"
        height="20.080807"
@@ -395,7 +404,7 @@
        ry="2.8686869"
        transform="matrix(1,0,-0.38643888,0.92231502,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.688753;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.688753;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1745-6"
        width="29.104166"
        height="20.080807"
@@ -405,7 +414,7 @@
        ry="2.8686869"
        transform="matrix(1,0,-0.38643888,0.92231502,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.688753;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.688753;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect1745-2"
        width="29.104166"
        height="20.080807"
@@ -503,13 +512,13 @@
        xml:space="preserve"
        style="font-size:3.88056px;line-height:1.25;font-family:SUSE;-inkscape-font-specification:SUSE;letter-spacing:0px;stroke-width:0.264583"
        x="18.579634"
-       y="174.77771"
+       y="182.5"
        id="text1826"><tspan
          sodipodi:role="line"
          id="tspan1824"
          x="18.579634"
-         y="174.77771"
-         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Edge Server</tspan></text>
+         y="182.5"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Downstream Server</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:3.88056px;line-height:1.25;font-family:SUSE;-inkscape-font-specification:SUSE;letter-spacing:0px;stroke-width:0.264583"
@@ -520,7 +529,7 @@
          id="tspan1828"
          x="7.9375"
          y="156.10417"
-         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Edge Location</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:SUSE;-inkscape-font-specification:'SUSE Medium';stroke-width:0.264583">Downstream Location</tspan></text>
     <path
        style="fill:none;stroke:#000000;stroke-width:0.449792;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2166)"
        d="M 74.083332,185.20833 V 177.8"
@@ -627,7 +636,7 @@
        id="path2628"
        sodipodi:nodetypes="cc" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.688752;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.688752;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect2747"
        width="66.145836"
        height="11.474746"
@@ -637,7 +646,7 @@
        ry="2.8686869"
        transform="matrix(1,0,-0.38643888,0.92231502,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.720804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.720804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect2749"
        width="60.854164"
        height="11.474751"
@@ -647,7 +656,7 @@
        ry="2.8686869"
        transform="matrix(1,0,-0.38643888,0.92231502,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.720804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.720804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect2749-2"
        width="60.854168"
        height="11.474751"
@@ -657,7 +666,7 @@
        ry="2.8686869"
        transform="matrix(1,0,-0.38643888,0.92231502,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.720804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.720804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect2749-0"
        width="60.854168"
        height="11.474751"
@@ -667,7 +676,7 @@
        ry="2.8686869"
        transform="matrix(1,0,-0.38643888,0.92231502,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.720804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.720804;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect2749-23"
        width="60.854168"
        height="11.474751"
@@ -677,7 +686,7 @@
        ry="2.8686869"
        transform="matrix(1,0,-0.38643888,0.92231502,0,0)" />
     <rect
-       style="fill:#c8dafc;stroke:#000000;stroke-width:0.520648;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
+       style="fill:#e6f7ef;stroke:#30ba78;stroke-width:0.520648;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
        id="rect2749-7"
        width="31.750002"
        height="11.474751"
@@ -1130,14 +1139,5 @@
          d="m 441.82,192.61 q -1.62,-0.74 -4,0.59 l -24.52,13.54 a 17.15,17.15 0 0 0 -7.81,9.09 L 368,303.38 330.69,257.18 c -1.59,-2.29 -4.2,-2.45 -7.81,-0.45 l -24.51,13.54 a 11.18,11.18 0 0 0 -4,3.85 9.09,9.09 0 0 0 -1.62,4.91 v 166.83 c 0,1.59 0.55,2.59 1.63,3 1.08,0.41 2.42,0.19 4,-0.69 l 27.34,-15.1 a 11.53,11.53 0 0 0 4,-3.74 8.52,8.52 0 0 0 1.63,-4.8 v -105 l 23.21,30.12 q 3.25,3.19 7.59,0.8 L 373.82,344 q 4.77,-2.62 7.59,-9.18 l 23.43,-55.9 0.25,97.1 0.17,8.31 a 2.85,2.85 0 0 0 1.69,2.86 4.16,4.16 0 0 0 3.78,-0.55 L 438,370.81 a 11.49,11.49 0 0 0 3.9,-3.81 8.49,8.49 0 0 0 1.52,-4.84 V 195.73 c 0.03,-1.6 -0.51,-2.64 -1.6,-3.12 z"
          id="path2701" />
     </g>
-    <rect
-       style="fill:none;stroke:#000000;stroke-width:0.661458;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;paint-order:stroke markers fill;stop-color:#000000"
-       id="rect1"
-       width="52.916664"
-       height="15.87501"
-       x="47.625004"
-       y="161.39583"
-       rx="5.2916718"
-       ry="5.2916718" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
Restyle the two quickstart architecture diagrams to the SUSE brand palette. **Style only** — geometry, text content and third-party brand logos (Kubernetes, Metal3) are preserved.

## Changes
Applies to `quickstart-metal3-architecture.svg` and `quickstart-elemental-architecture.svg`:
- CAPI / Rancher resource shapes → SUSE light green (`#e6f7ef`)
- Active component boxes (Cluster API provider, Baremetal-operator, Ironic / Elemental Operator, Rancher Manager, Fleet Controller) → SUSE green (`#30ba78`)
- Sub-containers (metal3-io, Rancher Provisioning/Fleet) and the Downstream Location/Server sections → light green tints (`#f4faf7` / `#e6f7ef`) with green strokes
- Renamed "Edge Location/Server" → "Downstream Location/Server"
- Metal3: reordered the BMC box so its `redfish-virtualmedia` label renders on top of the fill

## Notes
- Both diagrams ship as SVG only; DAPS renders the PNG referenced by the docs at build time, so no PNG is committed.
- Kubernetes and Metal3 logos are third-party brand assets and were left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)