### PR TITLE
Adding revision number

### DIFF
--- a/asciidoc/README.adoc
+++ b/asciidoc/README.adoc
@@ -1,5 +1,6 @@
 = SUSE Edge Documentation
 :revdate: 2024-03-06
+:revnumber: 3.1
 :page-revdate: {revdate}
 
 ifdef::env-github[]

--- a/asciidoc/components/akri.adoc
+++ b/asciidoc/components/akri.adoc
@@ -1,6 +1,7 @@
 [#components-akri]
 = Akri
 :revdate: 2025-01-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/edge-image-builder.adoc
+++ b/asciidoc/components/edge-image-builder.adoc
@@ -1,6 +1,7 @@
 [#components-eib]
 = Edge Image Builder
 :revdate: 2025-08-07
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/elemental.adoc
+++ b/asciidoc/components/elemental.adoc
@@ -1,6 +1,7 @@
 [#components-elemental]
 = Elemental
 :revdate: 2025-01-16
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/endpoint-copier-operator.adoc
+++ b/asciidoc/components/endpoint-copier-operator.adoc
@@ -1,6 +1,7 @@
 [#components-eco]
 = Endpoint Copier Operator
 :revdate: 2025-02-28
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/fleet.adoc
+++ b/asciidoc/components/fleet.adoc
@@ -1,6 +1,7 @@
 [#components-fleet]
 = Fleet
 :revdate: 2025-05-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/k3s.adoc
+++ b/asciidoc/components/k3s.adoc
@@ -1,6 +1,7 @@
 [#components-k3s]
 = K3s
 :revdate: 2025-01-16
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/longhorn.adoc
+++ b/asciidoc/components/longhorn.adoc
@@ -1,6 +1,7 @@
 [#components-longhorn]
 = Longhorn
 :revdate: 2025-05-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/metal3.adoc
+++ b/asciidoc/components/metal3.adoc
@@ -1,6 +1,7 @@
 [#components-metal3]
 = Metal^3^
 :revdate: 2024-11-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/metallb.adoc
+++ b/asciidoc/components/metallb.adoc
@@ -1,6 +1,7 @@
 [#components-metallb]
 = MetalLB
 :revdate: 2025-02-28
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/networking.adoc
+++ b/asciidoc/components/networking.adoc
@@ -1,6 +1,7 @@
 [#components-nmc]
 = Edge Networking
 :revdate: 2025-03-26
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/neuvector.adoc
+++ b/asciidoc/components/neuvector.adoc
@@ -2,6 +2,7 @@
 = NeuVector
 
 :revdate: 2025-01-16
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/rancher-dashboard-extensions.adoc
+++ b/asciidoc/components/rancher-dashboard-extensions.adoc
@@ -1,6 +1,7 @@
 [#components-rancher-dashboard-extensions]
 = Rancher Dashboard Extensions
 :revdate: 2025-05-15
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/rancher.adoc
+++ b/asciidoc/components/rancher.adoc
@@ -1,6 +1,7 @@
 [#components-rancher]
 = Rancher
 :revdate: 2025-06-10
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/rke2.adoc
+++ b/asciidoc/components/rke2.adoc
@@ -1,6 +1,7 @@
 [#components-rke2]
 = RKE2
 :revdate: 2025-05-01
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/components/system-upgrade-controller.adoc
+++ b/asciidoc/components/system-upgrade-controller.adoc
@@ -1,6 +1,7 @@
 [#components-system-upgrade-controller]
 = System Upgrade Controller
 :revdate: 2025-02-24
+:revnumber: 3.1
 :page-revdate: {revdate}
 
 ifdef::env-github[]

--- a/asciidoc/components/upgrade-controller.adoc
+++ b/asciidoc/components/upgrade-controller.adoc
@@ -1,6 +1,7 @@
 [#components-upgrade-controller]
 = Upgrade Controller
 :revdate: 2025-05-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 
 ifdef::env-github[]

--- a/asciidoc/components/virtualization.adoc
+++ b/asciidoc/components/virtualization.adoc
@@ -1,6 +1,7 @@
 [#components-kubevirt]
 = Edge Virtualization
 :revdate: 2025-05-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 
 // for GitHub rendering only, do not modify

--- a/asciidoc/concepts/observability.adoc
+++ b/asciidoc/concepts/observability.adoc
@@ -1,5 +1,6 @@
 = Observability
 :revdate: 2024-03-06
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/concepts/terms.adoc
+++ b/asciidoc/concepts/terms.adoc
@@ -1,6 +1,7 @@
 [glossary]
 = Terminology 
 :revdate: 2024-03-06
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/day2/downstream-cluster-helm.adoc
+++ b/asciidoc/day2/downstream-cluster-helm.adoc
@@ -1,6 +1,7 @@
 [#day2-helm-upgrade]
 == Helm chart upgrade
 :revdate: 2025-07-30
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/day2/downstream-clusters.adoc
+++ b/asciidoc/day2/downstream-clusters.adoc
@@ -1,6 +1,7 @@
 [#day2-downstream-clusters]
 = Downstream clusters
 :revdate: 2025-07-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/day2/mgmt-cluster.adoc
+++ b/asciidoc/day2/mgmt-cluster.adoc
@@ -1,6 +1,7 @@
 [#day2-mgmt-cluster]
 = Management Cluster
 :revdate: 2025-01-14
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/day2/migration.adoc
+++ b/asciidoc/day2/migration.adoc
@@ -1,6 +1,7 @@
 [#day2-migration]
 = Edge 3.1 migration
 :revdate: 2025-05-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/edge-book/edge.adoc
+++ b/asciidoc/edge-book/edge.adoc
@@ -1,5 +1,6 @@
 = SUSE Edge Documentation
 :revdate: 2025-07-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 :docinfo:

--- a/asciidoc/edge-book/releasenotes.adoc
+++ b/asciidoc/edge-book/releasenotes.adoc
@@ -2,6 +2,7 @@
 
 = Abstract
 :revdate: 2025-12-03
+:revnumber: 3.1
 :page-revdate: {revdate}
 ifdef::env-github[]
 :imagesdir: ../images/

--- a/asciidoc/edge-book/version-matrix.adoc
+++ b/asciidoc/edge-book/version-matrix.adoc
@@ -1,6 +1,7 @@
 [#component-version-matrix]
 = Component Versions
 :revdate: 2025-12-03
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/edge-book/versions.adoc
+++ b/asciidoc/edge-book/versions.adoc
@@ -1,5 +1,6 @@
 // ============================================================================
 :revdate: 2025-12-03
+:revnumber: 3.1
 :page-revdate: {revdate}
 // Automatic Version Substitutions
 // 

--- a/asciidoc/edge-book/welcome.adoc
+++ b/asciidoc/edge-book/welcome.adoc
@@ -1,5 +1,6 @@
 = SUSE Edge Documentation
 :revdate: 2025-07-15
+:revnumber: 3.1
 :page-revdate: {revdate}
 
 :experimental:

--- a/asciidoc/guides/air-gapped-eib-deployments.adoc
+++ b/asciidoc/guides/air-gapped-eib-deployments.adoc
@@ -1,5 +1,6 @@
 = Air-gapped deployments with Edge Image Builder
 :revdate: 2025-07-08
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/guides/kiwi-builder-images.adoc
+++ b/asciidoc/guides/kiwi-builder-images.adoc
@@ -1,6 +1,7 @@
 [#guides-kiwi-builder-images]
 = Building Updated SUSE Linux Micro Images with Kiwi
 :revdate: 2025-03-26
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/guides/metallb-k3s.adoc
+++ b/asciidoc/guides/metallb-k3s.adoc
@@ -1,6 +1,7 @@
 [#guides-metallb-k3s]
 = MetalLB on K3s (using L2)
 :revdate: 2025-05-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/guides/metallb-kube-api.adoc
+++ b/asciidoc/guides/metallb-kube-api.adoc
@@ -1,6 +1,7 @@
 [#guides-metallb-kubernetes]
 = MetalLB in front of the Kubernetes API server
 :revdate: 2025-05-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/integrations/create-package-obs.adoc
+++ b/asciidoc/integrations/create-package-obs.adoc
@@ -1,5 +1,6 @@
 = Create a package (RPM or Container image) using OBS (openSUSE Build Service)
 :revdate: 2024-03-06
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/integrations/linkerd.adoc
+++ b/asciidoc/integrations/linkerd.adoc
@@ -1,6 +1,7 @@
 [#integrations-linkerd]
 = Linkerd Service Mesh
 :revdate: 2024-04-22
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/integrations/nats.adoc
+++ b/asciidoc/integrations/nats.adoc
@@ -1,6 +1,7 @@
 [#integrations-nats]
 = NATS
 :revdate: 2025-04-25
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/integrations/nvidia-slemicro.adoc
+++ b/asciidoc/integrations/nvidia-slemicro.adoc
@@ -1,5 +1,6 @@
 = NVIDIA GPUs on SLE Micro
 :revdate: 2025-04-25
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/product/atip-architecture.adoc
+++ b/asciidoc/product/atip-architecture.adoc
@@ -1,6 +1,7 @@
 [#atip-architecture]
 == Concept & Architecture
 :revdate: 2025-07-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/product/atip-automated-provision.adoc
+++ b/asciidoc/product/atip-automated-provision.adoc
@@ -1,6 +1,7 @@
 [#atip-automated-provisioning]
 == Fully automated directed network provisioning
 :revdate: 2025-07-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/product/atip-features.adoc
+++ b/asciidoc/product/atip-features.adoc
@@ -1,6 +1,7 @@
 [#atip-features]
 == Telco features configuration
 :revdate: 2025-07-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/product/atip-lifecycle.adoc
+++ b/asciidoc/product/atip-lifecycle.adoc
@@ -1,6 +1,7 @@
 [#atip-lifecycle]
 == Lifecycle actions
 :revdate: 2025-07-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/product/atip-management-cluster.adoc
+++ b/asciidoc/product/atip-management-cluster.adoc
@@ -1,6 +1,7 @@
 [#atip-management-cluster]
 == Setting up the management cluster
 :revdate: 2025-07-31
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/product/atip-requirements.adoc
+++ b/asciidoc/product/atip-requirements.adoc
@@ -1,6 +1,7 @@
 [#atip-requirements]
 == Requirements & Assumptions
 :revdate: 2025-07-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/product/atip.adoc
+++ b/asciidoc/product/atip.adoc
@@ -1,6 +1,7 @@
 [#atip]
 = SUSE Adaptive Telco Infrastructure Platform (ATIP)
 :revdate: 2025-07-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -1,6 +1,7 @@
 [#quickstart-eib]
 = Standalone clusters with Edge Image Builder
 :revdate: 2025-07-31
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/quickstart/elemental.adoc
+++ b/asciidoc/quickstart/elemental.adoc
@@ -1,6 +1,7 @@
 [#quickstart-elemental]
 = Remote host onboarding with Elemental
 :revdate: 2025-06-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/quickstart/metal3.adoc
+++ b/asciidoc/quickstart/metal3.adoc
@@ -1,6 +1,7 @@
 [#quickstart-metal3]
 = BMC automated deployments with Metal^3^
 :revdate: 2025-07-29
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/tech_writing_best_practices.adoc
+++ b/asciidoc/tech_writing_best_practices.adoc
@@ -1,5 +1,6 @@
 = Technical Writing: Best Practices
 :revdate: 2024-03-06
+:revnumber: 3.1
 :page-revdate: {revdate}
 
 Five basic rules on how to write better technical documentation

--- a/asciidoc/template.adoc
+++ b/asciidoc/template.adoc
@@ -1,5 +1,6 @@
 = Title
 :revdate: 2024-03-06
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/tips/eib.adoc
+++ b/asciidoc/tips/eib.adoc
@@ -1,5 +1,6 @@
 = Edge Image Builder
 :revdate: 2025-03-26
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/tips/elemental.adoc
+++ b/asciidoc/tips/elemental.adoc
@@ -1,5 +1,6 @@
 = Elemental
 :revdate: 2025-01-20
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/troubleshooting/collecting-diagnostics-for-support.adoc
+++ b/asciidoc/troubleshooting/collecting-diagnostics-for-support.adoc
@@ -1,6 +1,7 @@
 [#collecting-diagnostics-for-support]
 == Collecting Diagnostics for Support
 :revdate: 2025-06-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/troubleshooting/general-troubleshooting-principles.adoc
+++ b/asciidoc/troubleshooting/general-troubleshooting-principles.adoc
@@ -1,6 +1,7 @@
 [#general-troubleshooting-principles]
 == General Troubleshooting Principles
 :revdate: 2025-06-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/troubleshooting/troubleshooting-directed-network-provisioning.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-directed-network-provisioning.adoc
@@ -1,6 +1,7 @@
 [#troubleshooting-directed-network-provisioning]
 == Troubleshooting Directed-network provisioning
 :revdate: 2025-06-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/troubleshooting/troubleshooting-edge-image-builder.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-edge-image-builder.adoc
@@ -1,6 +1,7 @@
 [#troubleshooting-edge-image-builder]
 == Troubleshooting Edge Image Builder (EIB)
 :revdate: 2025-06-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/troubleshooting/troubleshooting-edge-networking.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-edge-networking.adoc
@@ -1,6 +1,7 @@
 [#troubleshooting-edge-networking]
 == Troubleshooting Edge Networking (NMC)
 :revdate: 2025-06-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/troubleshooting/troubleshooting-kiwi.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-kiwi.adoc
@@ -1,6 +1,7 @@
 [#troubleshooting-kiwi]
 == Troubleshooting Kiwi
 :revdate: 2025-06-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/troubleshooting/troubleshooting-other-components.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-other-components.adoc
@@ -1,6 +1,7 @@
 [#troubleshooting-other-components]
 == Troubleshooting Other components
 :revdate: 2025-06-19
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 

--- a/asciidoc/troubleshooting/troubleshooting-phone-home-scenarios.adoc
+++ b/asciidoc/troubleshooting/troubleshooting-phone-home-scenarios.adoc
@@ -1,6 +1,7 @@
 [#troubleshooting-phone-home-scenarios]
 == Troubleshooting Phone-Home scenarios
 :revdate: 2025-06-17
+:revnumber: 3.1
 :page-revdate: {revdate}
 :experimental:
 


### PR DESCRIPTION
Asciidoctor only creates a revision history when both revdate and revnumber are set. A revision history is required to set a correct modified date for the file, which in terms is a must for SEO, SearchUnify and AskGeeko.