### PR TITLE
Fix duplicated word in eib.adoc

### DIFF
--- a/asciidoc/quickstart/eib.adoc
+++ b/asciidoc/quickstart/eib.adoc
@@ -237,7 +237,7 @@ See the https://documentation.suse.com/smart/security/html/tls-certificates/inde
 === Adding Operating System Files
 
 The files placed in the `os-files` directory in the image configuration directory are automatically copied into the filesystem of the built image. 
-The exact directory directory will be retained when they are copied. 
+The exact directory will be retained when they are copied. 
 For example, if a file exists in a subdirectory named `os-files/etc`, it is placed in the `/etc` directory of the built image. 
 
 [NOTE]


### PR DESCRIPTION
updated sentence to not repeat the same word twice "directory"