### PR TITLE
Fix typos and clarify language in atip-features.adoc

### DIFF
--- a/docs/en/product/atip-features.adoc
+++ b/docs/en/product/atip-features.adoc
@@ -113,9 +113,9 @@ This behavior prevents any disruption caused by disk I/O to any time sensitive a
 ** `rcupdate.rcu_expedited=1` speeds up the grace period for RCU operations, making read-side critical sections more responsive
 ** `rcupdate.rcu_normal_after_boot=1` When used with rcu_expedited, it allows RCU to revert to normal (non-expedited) operation after the system boot.
 ** `rcupdate.rcu_task_stall_timeout=0` disables the RCU task stall detector, preventing potential warnings or system halts from long-running RCU tasks.
-** `rcutree.kthread_prio=99` sets the priority of the RCU callback kernel thread to the highest possible (99), ensuring it gets scheduled and handles RCU callbacks promptly, when needed.
+** `rcutree.kthread_prio=99` sets the priority of the RCU callback kernel thread to the highest possible value (99), ensuring it is scheduled immediately to handle callbacks promptly when needed.
 
-* Add `ignition.platform.id=openstack` for Metal3 and Cluster API to successfully provision/deprovision the cluster. This is used by Metal3 Python agent, which originated from Openstack Ironic.
+* Add `ignition.platform.id=openstack` for Metal^3^ and Cluster API to successfully provision/deprovision the cluster. This is used by Metal^3^ Python agent, which originated from OpenStack Ironic.
 
 * Enable https://documentation.suse.com/smart/network/html/network-interface-predictable-naming/index.html[Predictable Network Interface Naming] via `net.ifnames=1`. From SUSE Linux Micro 6.2 onwards, this is enabled by default and explicit configuration is not required. For versions prior to 6.2, this must be explicitly set as a kernel argument. This aligns with the `predictableNicNames` configuration in the Management Cluster's Metal^3^ Helm chart, which is required for Directed Network Provisioning to function correctly. Consistent interface naming is also critical when SR-IOV is utilized.
 
@@ -183,7 +183,7 @@ The following options are important to be customized with your current hardware 
 
 | nohz
 | on
-| When enabled, kernel's periodic timer interrupt (the 'tick') will stop on any CPU core that is idle. This primary benefits the housekeeping CPUs (`0,31,32,63`). This conserves power and reduces unnecessary wake-ups on those general-purpose cores.
+| When enabled, the kernel's periodic timer interrupt (the 'tick') stops on any CPU core that becomes idle. This primarily benefits the housekeeping CPUs (`0,31,32,63`), conserving power and reducing unnecessary wake-ups on those general-purpose cores.
 
 | nohz_full
 | 1-30,33-62
@@ -733,11 +733,11 @@ spec:
 ----
 
 ==== Bond CNI with SR-IOV
-Using the Bond CNI with SR-IOV is fairly straight forward. For more details on how to set up SR-IOV, see <<sriov>>. As described there, you have to create `SriovNetworkNodePolicies` that defines `resourceNames`, as well as number of virtual functions and such. The `resourceNames` are being used by the `SriovNetwork` which is used as interfaces in the pod definition. The bond definition is exactly the same as for the MACVLAN and host device cases.
+Using the Bond CNI with SR-IOV is fairly straightforward. For more details on how to set up SR-IOV, see <<sriov>>. As described there, you have to create `SriovNetworkNodePolicies` that defines `resourceNames`, as well as number of virtual functions and such. The `resourceNames` are being used by the `SriovNetwork` which is used as interfaces in the pod definition. The bond definition is exactly the same as for the MACVLAN and host device cases.
 
 [NOTE]
 ====
-Bond CNI with SR-IOV is only applicable to SRIOV Virtual Functions (VF) using the kernel driver. Userspace driver VFs - such as those used in DPDK workloads - can not be bonded with the Bond CNI.
+Bond CNI with SR-IOV is only applicable to SRIOV Virtual Functions (VF) using the kernel driver. Userspace driver VFs - such as those used in DPDK workloads - cannot be bonded with the Bond CNI.
 ====
 
 [#sriov]


### PR DESCRIPTION
Many typos found  within atip-features.adoc including lower levels of language, with this pull it has been corrected

@hardys 