### PR TITLE
Clarify ipv6 support status

### DIFF
--- a/docs/en/product/atip-automated-provision.adoc
+++ b/docs/en/product/atip-automated-provision.adoc
@@ -1042,7 +1042,7 @@ Where:
 [NOTE]
 ====
 * If no network configuration for the host has been specified, either at image build time or through the `BareMetalHost` definition, an autoconfiguration mechanism (DHCP, DHCPv6, SLAAC) will be used. For more details or complex configurations, check the xref:advanced-network-configuration[].
-* Single-stack IPv6 clusters are in tech preview status and not yet officially supported.
+* Single-stack IPv6 clusters require a dual-stack management cluster.
 * Architecture must be either `x86_64` or `aarch64`, depending on the architecture of the bare-metal host to be enrolled.
 * All modern servers come with a dual-stack capable BMC, however IPv6 support (and possibly the option of using hostnames for the VirtualMedia capability) should be verified before use in production in a dual-stack environment.
 ====


### PR DESCRIPTION
For 3.6 onwards downstream clusters with single-stack ipv6 are supported but require a dual-stack management cluster.