### PR TITLE
Fixed broken links in 3.5 Edge

### DIFF
--- a/docs/en/day2/migration.adoc
+++ b/docs/en/day2/migration.adoc
@@ -270,7 +270,7 @@ Applies only to CAPI/Metal3 management clusters that require a rancher turtles c
 You must ensure the management cluster is first updated to the latest 3.4 z-stream, which contains the necessary 0.24.3 Rancher Turtles version.
 ====
 
-Starting with Rancher 2.13, Rancher Turtles is installed by default, therefore it is necessary to follow some additional migration steps as described in the https://documentation.suse.com/cloudnative/cluster-api/latest/en/tutorials/migration.html[Rancher Turtles Documentation]
+Starting with Rancher 2.13, Rancher Turtles is installed by default, therefore it is necessary to follow some additional migration steps as described in the https://documentation.suse.com/cloudnative/cluster-api/v0.25/en/tutorials/migration.html[Rancher Turtles Documentation]
 
 Before upgrade it is necessary to remove the installed rancher-turtles chart and rancher-turtles-airgap-resources (if installed),
 when installed via Edge Image Builder this requires removal of the corresponding `HelmChart` resources:

--- a/docs/en/edge-book/releasenotes.adoc
+++ b/docs/en/edge-book/releasenotes.adoc
@@ -246,7 +246,7 @@ Summary: SUSE Edge 3.5.1 is the first z-stream release in the SUSE Edge 3.5 rele
 * Updated to SUSE Security (Neuvector) 5.4.9 https://open-docs.neuvector.com/releasenotes/5x/#549-february-2026[Release Notes]
 * Updated Elemental to 1.8.1
 * Updated Edge Image Builder to 1.3.3 see https://github.com/suse-edge/edge-image-builder/blob/release-1.3/RELEASE_NOTES.md[Upstream Release Notes]
-* Updated SUSE Multi-Linux Manager to 5.1.2 see https://documentation.suse.com/releasenotes/suma/5.1/[Release Notes]
+* Updated SUSE Multi-Linux Manager to 5.1.2 see https://www.suse.com/releasenotes/x86_64/multi-linux-manager/5.1/index.html[Release Notes]
 
 == Bug & Security Fixes
 


### PR DESCRIPTION
13 Aug - broken links -
Section: https://documentation.suse.com/suse-edge/3.5/html/edge/day2-migration.html#id-prepare-for-rancher-turtles-upgrade
Broken link: https://documentation.suse.com/cloudnative/cluster-api/latest/en/tutorials/migration.html
Correct link: https://documentation.suse.com/cloudnative/cluster-api/v0.25/en/tutorials/migration.html

Section: https://documentation.suse.com/suse-edge/3.5/html/edge/id-release-notes.html#id-new-features-2
Broken link: https://documentation.suse.com/releasenotes/suma/5.1/
Correct link: https://www.suse.com/releasenotes/x86_64/multi-linux-manager/5.1/index.html