### PR TITLE
Migrate CAPM3 examples from v1beta1 to v1beta2 API

### DIFF
--- a/docs/en/guides/clusterclass.adoc
+++ b/docs/en/guides/clusterclass.adoc
@@ -76,7 +76,7 @@ spec:
     kind: Metal3Cluster
     name: emea-spa-cluster-3
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: emea-spa-cluster-3
@@ -225,7 +225,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-3
@@ -245,10 +245,10 @@ spec:
       image:
         checksum: http://fileserver.local:8080/eibimage-downstream-cluster.raw.sha256
         checksumType: sha256
-        format: raw
+        diskFormat: raw
         url: http://fileserver.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-3
@@ -328,7 +328,7 @@ spec:
           - provider-id=metal3://BAREMETALHOST_UUID
         nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3ClusterTemplate
 metadata:
   name: example-cluster-template
@@ -341,7 +341,7 @@ spec:
         port: 6443
       cloudProviderEnabled: false
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: example-controlplane-machineinfrastructure
@@ -361,7 +361,7 @@ spec:
       image:
         checksum: http://TO-BE-PATCHED-AUTOMATICALLY # This will be replaced by the involved patch when applying the cluster instance
         checksumType: sha256
-        format: raw
+        diskFormat: raw
         url: http://TO-BE-PATCHED-AUTOMATICALLY      # This will be replaced by the involved patch when applying the cluster instance
 ---
 apiVersion: cluster.x-k8s.io/v1beta2
@@ -373,7 +373,7 @@ spec:
   infrastructure:
     templateRef:
       kind: Metal3ClusterTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       name: example-cluster-template
   controlPlane:
     templateRef:
@@ -383,7 +383,7 @@ spec:
     machineInfrastructure:
       templateRef:
         kind: Metal3MachineTemplate
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         name: example-controlplane-machineinfrastructure
   variables:
   - name: metallbHelmChartVersion
@@ -432,7 +432,7 @@ spec:
   - name: setControlPlaneMachineTemplateImageURL
     definitions:
     - selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3MachineTemplate
         matchResources:
           controlPlane: true        # Added to select ControlPlane
@@ -448,7 +448,7 @@ spec:
   - name: setControlPlaneMachineTemplateHostSelectorDeployRegion
     definitions:
     - selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3MachineTemplate
         matchResources:
           controlPlane: true
@@ -460,7 +460,7 @@ spec:
   - name: setControlPlaneMachineTemplateHostSelectorClusterType
     definitions:
     - selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3MachineTemplate
         matchResources:
           controlPlane: true        # Added to select ControlPlane
@@ -472,7 +472,7 @@ spec:
   - name: setControlPlaneMachineTemplateDataTemplateName
     definitions:
     - selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3MachineTemplate
         matchResources:
           controlPlane: true        # Added to select ControlPlane
@@ -484,7 +484,7 @@ spec:
   - name: setControlPlaneEndpoint
     definitions:
     - selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3ClusterTemplate
         matchResources:
           infrastructureCluster: true  # Added to select InfraCluster
@@ -689,7 +689,7 @@ spec:
       - 192.168.122.203
       - https://192.168.122.203.sslip.io
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-3

--- a/docs/en/product/atip-automated-provision.adoc
+++ b/docs/en/product/atip-automated-provision.adoc
@@ -766,11 +766,11 @@ into Rancher (by creating a corresponding `clusters.management.cattle.io` object
 See the https://documentation.suse.com/cloudnative/cluster-api/latest/en/tutorials/first-cluster.html#_mark_namespace_for_auto_import[Cluster API documentation] for more information.
 ====
 
-The `Metal3Cluster` object specifies the control-plane endpoint (replacing the `$\{DOWNSTREAM_CONTROL_PLANE_IPV4\}`) to be configured and the `noCloudProvider` because a bare-metal node is used.
+The `Metal3Cluster` object specifies the control-plane endpoint (replacing the `$\{DOWNSTREAM_CONTROL_PLANE_IPV4\}`) to be configured and the `cloudProviderEnabled` flag set to `false` because a bare-metal node is used.
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -779,7 +779,7 @@ spec:
   controlPlaneEndpoint:
     host: ${DOWNSTREAM_CONTROL_PLANE_IPV4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ----
 
 The `RKE2ControlPlane` object specifies the control-plane configuration to be used and the `Metal3MachineTemplate` object specifies the control-plane image to be used.
@@ -923,7 +923,7 @@ The `Metal3MachineTemplate` object specifies the following information:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -939,7 +939,7 @@ spec:
       image:
         checksum: http://imagecache.local:8080/eibimage-output-telco.raw.sha256
         checksumType: sha256
-        format: raw
+        diskFormat: raw
         url: http://imagecache.local:8080/eibimage-output-telco.raw
 ----
 
@@ -947,7 +947,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -1118,10 +1118,10 @@ into Rancher (by creating a corresponding `clusters.management.cattle.io` object
 See the https://documentation.suse.com/cloudnative/cluster-api/latest/en/tutorials/first-cluster.html#_mark_namespace_for_auto_import[Cluster API documentation] for more information.
 ====
 
-The `Metal3Cluster` object specifies the control-plane endpoint that uses the `VIP` address already reserved (replacing the `$\{EDGE_VIP_ADDRESS_IPV4\}`) to be configured and the `noCloudProvider` because the three bare-metal nodes are used.
+The `Metal3Cluster` object specifies the control-plane endpoint that uses the `VIP` address already reserved (replacing the `$\{EDGE_VIP_ADDRESS_IPV4\}`) to be configured and the `cloudProviderEnabled` flag set to `false` because the three bare-metal nodes are used.
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -1130,7 +1130,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_VIP_ADDRESS_IPV4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ----
 
 The `RKE2ControlPlane` object specifies the control-plane configuration to be used, and the `Metal3MachineTemplate` object specifies the control-plane image to be used.
@@ -1371,7 +1371,7 @@ The `Metal3MachineTemplate` object specifies the following information:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -1387,7 +1387,7 @@ spec:
       image:
         checksum: http://imagecache.local:8080/eibimage-output-telco.raw.sha256
         checksumType: sha256
-        format: raw
+        diskFormat: raw
         url: http://imagecache.local:8080/eibimage-output-telco.raw
 ----
 
@@ -1395,7 +1395,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -1503,7 +1503,7 @@ The `Metal3MachineTemplate` object contain references to `dataTemplate`, `hostSe
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-workers
@@ -1519,7 +1519,7 @@ spec:
       image:
         checksum: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw.sha256
         checksumType: sha256
-        format: raw
+        diskFormat: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ----
 
@@ -1527,7 +1527,7 @@ The `Metal3DataTemplate` object specifies the `metaData` for the downstream clus
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-workers-template

--- a/docs/en/product/atip-lifecycle.adoc
+++ b/docs/en/product/atip-lifecycle.adoc
@@ -266,7 +266,7 @@ spec:
 
 [,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -284,7 +284,7 @@ spec:
       image:
         checksum: http://imagecache.local:8080/${NEW_IMAGE_GENERATED}.sha256
         checksumType: sha256
-        format: raw
+        diskFormat: raw
         url: http://imagecache.local:8080/${NEW_IMAGE_GENERATED}.raw
 ----
 

--- a/docs/en/quickstart/metal3.adoc
+++ b/docs/en/quickstart/metal3.adoc
@@ -519,7 +519,7 @@ spec:
     kind: Metal3Cluster
     name: sample-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: sample-cluster
@@ -528,7 +528,7 @@ spec:
   controlPlaneEndpoint:
     host: 192.168.125.200
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
@@ -628,7 +628,7 @@ spec:
             group:
               name: root
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: sample-cluster-controlplane
@@ -644,10 +644,10 @@ spec:
       image:
         checksum: http://imagecache.local:8080/SLE-Micro-eib-output.raw.sha256
         checksumType: sha256
-        format: raw
+        diskFormat: raw
         url: http://imagecache.local:8080/SLE-Micro-eib-output.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: sample-cluster-controlplane-template
@@ -767,7 +767,7 @@ spec:
                   [Install]
                   WantedBy=multi-user.target
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: sample-cluster-workers
@@ -783,10 +783,10 @@ spec:
       image:
         checksum: http://imagecache.local:8080/SLE-Micro-eib-output.raw.sha256
         checksumType: sha256
-        format: raw
+        diskFormat: raw
         url: http://imagecache.local:8080/SLE-Micro-eib-output.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: sample-cluster-workers-template


### PR DESCRIPTION
Align the Metal3 manifests embedded in the documentation with the CAPM3 v1beta1 -> v1beta2 migration guide:

https://github.com/metal3-io/metal3-docs/blob/main/docs/user-guide/src/capm3/migration_v1beta1_to_v1beta2.md

Note this requires CAPM3 v1.13.0 or newer, where v1beta1 is deprecated as mentioned in the release notes:

https://github.com/metal3-io/cluster-api-provider-metal3/releases/tag/v1.13.0

This aligns with https://github.com/suse-edge/telco-cloud-examples/pull/105

Note that testing this requires https://src.opensuse.org/suse-edge/Factory/pulls/590 and Rancher 2.15