### PR TITLE
Migrate Metal3 examples to the supported provider-id format

### DIFF
--- a/docs/en/guides/clusterclass.adoc
+++ b/docs/en/guides/clusterclass.adoc
@@ -213,7 +213,8 @@ spec:
                 Type=oneshot
                 User=root
                 ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                # Note we use _ as a delimiter for sed here because the providerid includes / characters
+                ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -222,7 +223,7 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-      - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://PROVIDERID
     nodeName: "localhost.localdomain"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
@@ -325,7 +326,7 @@ spec:
             TO-BE-PATCHED-AUTOMATICALLY
         kubelet:
           extraArgs:
-          - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://PROVIDERID
         nodeName: "localhost.localdomain"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
@@ -630,7 +631,8 @@ spec:
                     Type=oneshot
                     User=root
                     ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                    ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                    # Note we use _ as a delimiter for sed here because the providerid includes / characters
+                    ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
                     ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                     ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
                     ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"

--- a/docs/en/product/atip-automated-provision.adoc
+++ b/docs/en/product/atip-automated-provision.adoc
@@ -784,7 +784,7 @@ spec:
 
 The `RKE2ControlPlane` object specifies the control-plane configuration to be used and the `Metal3MachineTemplate` object specifies the control-plane image to be used.
 Also, it contains the information about the number of replicas to be used (in this case, one) and the `CNI` plug-in to be used (in this case, `Cilium`).
-The agentConfig block contains the `Ignition` format to be used and the `additionalUserData` to be used to configure the `RKE2` node with information like a systemd named `rke2-preinstall.service` to replace automatically the `BAREMETALHOST_UUID` and `node-name` during the provisioning process using the Ironic information.
+The agentConfig block contains the `Ignition` format to be used and the `additionalUserData` to be used to configure the `RKE2` node with information like a systemd named `rke2-preinstall.service` to replace automatically the `PROVIDERID` and `node-name` during the provisioning process using the Ironic information.
 To enable multus with cilium a file is created in the `rke2` server manifests directory named `rke2-cilium-config.yaml` with the configuration to be used.
 The last block of information contains the Kubernetes version to be used. `$\{RKE2_VERSION\}` is the version of `RKE2` to be used replacing this value (for example, `{version-kubernetes-rke2}`).
 
@@ -832,7 +832,8 @@ spec:
               Type=oneshot
               User=root
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              # Note we use _ as a delimiter for sed here because the providerid includes / characters
+              ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -911,7 +912,7 @@ spec:
               name: root
     kubelet:
       extraArgs:
-      - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://PROVIDERID
     nodeName: "localhost.localdomain"
 ----
 
@@ -1142,7 +1143,7 @@ The `RKE2ControlPlane` object specifies the control-plane configuration to be us
 * The advertisement mode to be used by the Load Balancer (`address` uses the L2 implementation), as well as the address to be used (replacing the `$\{EDGE_VIP_ADDRESS\}` with the `VIP` address).
 * The `serverConfig` with the `CNI` plug-in to be used (in this case, `Cilium`), and the additional `VIP` address(es) and name(s) to be listed under `tlsSan`.
 * The agentConfig block contains the `Ignition` format to be used and the `additionalUserData` to be used to configure the `RKE2` node with information like:
-    ** The systemd service named `rke2-preinstall.service` to replace automatically the `BAREMETALHOST_UUID` and `node-name` during the provisioning process using the Ironic information plus adding the `metal3.io/uuid` label to Node objects with the `BareMetalHost` UUID.
+    ** The systemd service named `rke2-preinstall.service` to replace automatically the `PROVIDERID` and `node-name` during the provisioning process using the Ironic information plus adding the `metal3.io/uuid` label to Node objects with the `BareMetalHost` UUID.
     ** The systemd service named `rke2-traefik-deployment.service` to set the RKE2 `ingress-controller` config. server option in `/etc/rancher/rke2/config.yaml` file to `traefik`.
     ** The `storage` block which contains the Helm charts to be used to install the `MetalLB` and the `endpoint-copier-operator`.
     ** The `metalLB` custom resource file with the `IPaddressPool` and the `L2Advertisement` to be used (replacing `$\{EDGE_VIP_ADDRESS_IPV4\}` with the `VIP` address).
@@ -1199,7 +1200,8 @@ spec:
               Type=oneshot
               User=root
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              # Note we use _ as a delimiter for sed here because the providerid includes / characters
+              ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -1359,7 +1361,7 @@ spec:
               name: root
     kubelet:
       extraArgs:
-      - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://PROVIDERID
     nodeName: "Node-multinode-cluster"
 ----
 
@@ -1469,7 +1471,7 @@ spec:
         format: ignition
         kubelet:
           extraArgs:
-          - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://PROVIDERID
         nodeName: "Node-multinode-cluster-worker"
         additionalUserData:
           config: |
@@ -1489,7 +1491,8 @@ spec:
                   Type=oneshot
                   User=root
                   ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                  ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                  # Note we use _ as a delimiter for sed here because the providerid includes / characters
+                  ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
                   ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                   ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
                   ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -1785,7 +1788,7 @@ To make the process clear, the changes required on that block (`RKE2ControlPlane
 |===
 
 * The following systemd services are used to enable the following:
-    ** `rke2-preinstall.service` to replace automatically the `BAREMETALHOST_UUID` and `node-name` during the provisioning process using the Ironic information.
+    ** `rke2-preinstall.service` to replace automatically the `PROVIDERID` and `node-name` during the provisioning process using the Ironic information.
     ** `cpu-partitioning.service` to enable the isolation cores of the `CPU` (for example, `1-30,33-62`).
     ** `performance-settings.service` to enable the CPU performance tuning.
     ** `sriov-custom-auto-vfs.service` to install the `sriov` Helm chart, wait until custom resources are created and run the `/var/sriov-auto-filler.sh` to replace the values in the config map `sriov-custom-auto-config` and create the `sriovnetworknodepolicy` to be used by the workloads.
@@ -1917,7 +1920,8 @@ spec:
               Type=oneshot
               User=root
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              # Note we use _ as a delimiter for sed here because the providerid includes / characters
+              ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -1987,7 +1991,7 @@ spec:
               WantedBy=multi-user.target
     kubelet:
       extraArgs:
-      - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://PROVIDERID
     nodeName: "localhost.localdomain"
 ----
 
@@ -2092,7 +2096,8 @@ spec:
                 Type=oneshot
                 User=root
                 ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                # Note we use _ as a delimiter for sed here because the providerid includes / characters
+                ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -2140,7 +2145,7 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+        - provider-id=metal3://PROVIDERID
     nodeName: "localhost.localdomain"
 ----
 
@@ -2251,7 +2256,8 @@ spec:
                 Type=oneshot
                 User=root
                 ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                # Note we use _ as a delimiter for sed here because the providerid includes / characters
+                ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
                 ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -2352,7 +2358,7 @@ spec:
                   ${PTP4L_AIC2_CONTENTS}
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+        - provider-id=metal3://PROVIDERID
     nodeName: "localhost.localdomain"
 ----
 
@@ -2495,7 +2501,8 @@ spec:
               Type=oneshot
               User=root
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              # Note we use _ as a delimiter for sed here because the providerid includes / characters
+              ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -2519,7 +2526,7 @@ spec:
               WantedBy=multi-user.target
     kubelet:
       extraArgs:
-      - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://PROVIDERID
     nodeName: "localhost.localdomain"
 ----
 
@@ -2787,7 +2794,8 @@ spec:
               Type=oneshot
               User=root
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              # Note we use _ as a delimiter for sed here because the providerid includes / characters
+              ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -2856,7 +2864,7 @@ spec:
               WantedBy=multi-user.target
     kubelet:
       extraArgs:
-      - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://PROVIDERID
     nodeName: "localhost.localdomain"
 ----
 

--- a/docs/en/product/atip-lifecycle.adoc
+++ b/docs/en/product/atip-lifecycle.adoc
@@ -145,7 +145,8 @@ spec:
               Type=oneshot
               User=root
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              # Note we use _ as a delimiter for sed here because the providerid includes / characters
+              ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -254,7 +255,7 @@ spec:
               name: root
     kubelet:
       extraArgs:
-      - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://PROVIDERID
     nodeName: "localhost.localdomain"
 ----
 

--- a/docs/en/quickstart/metal3.adoc
+++ b/docs/en/quickstart/metal3.adoc
@@ -550,7 +550,7 @@ spec:
     format: ignition
     kubelet:
       extraArgs:
-      - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://PROVIDERID
     additionalUserData:
       config: |
         variant: fcos
@@ -569,7 +569,8 @@ spec:
               Type=oneshot
               User=root
               ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-              ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+              # Note we use _ as a delimiter for sed here because the providerid includes / characters
+              ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
               ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
@@ -740,7 +741,7 @@ spec:
         version: {version-kubernetes-rke2}
         kubelet:
           extraArgs:
-          - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://PROVIDERID
         additionalUserData:
           config: |
             variant: fcos
@@ -759,7 +760,8 @@ spec:
                   Type=oneshot
                   User=root
                   ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                  ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                  # Note we use _ as a delimiter for sed here because the providerid includes / characters
+                  ExecStart=/bin/sh -c "sed -i \"s_PROVIDERID_$(jq -r .providerid /mnt/openstack/latest/meta_data.json)_\" /etc/rancher/rke2/config.yaml"
                   ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
                   ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
                   ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"


### PR DESCRIPTION
Align the Metal3 examples with telco-cloud-examples#106, which migrates away from the deprecated provider-id format:

```
  old (deprecated): metal3://<BMH-UID>
  new (supported):  metal3://<namespace>/<bmh-name>/<m3m-name>
``` 

The legacy format was deprecated in CAPM3 v1.13 (3.7 version) and is will be removed for 3.8 in v1.14, see:

  https://github.com/metal3-io/metal3-docs/blob/main/docs/user-guide/src/capm3/providerid-workflow.md

The `metal3.io/uuid` node label is intentionally left unchanged - it still carries the BareMetalHost UUID and is required by CAPM3 to match the Nodes to Machines.